### PR TITLE
fix: outdated bilibili stream (close #44)

### DIFF
--- a/src-tauri/src/recorder/bilibili/client.rs
+++ b/src-tauri/src/recorder/bilibili/client.rs
@@ -2,16 +2,17 @@ use super::errors::BiliClientError;
 use super::profile;
 use super::profile::Profile;
 use super::response;
-use base64::Engine;
-use pct_str::PctString;
-use pct_str::URIReserved;
-use regex::Regex;
-use reqwest::Client;
 use super::response::Format;
 use super::response::GeneralResponse;
 use super::response::PostVideoMetaResponse;
 use super::response::PreuploadResponse;
 use super::response::VideoSubmitData;
+use crate::database::account::AccountRow;
+use base64::Engine;
+use pct_str::PctString;
+use pct_str::URIReserved;
+use regex::Regex;
+use reqwest::Client;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
@@ -23,7 +24,6 @@ use std::time::SystemTime;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tokio::time::Instant;
-use crate::database::account::AccountRow;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RoomInfo {
@@ -322,7 +322,9 @@ impl BiliClient {
         let response = self.client.get(url).send().await?;
         let bytes = response.bytes().await?;
         let base64 = base64::engine::general_purpose::STANDARD.encode(bytes);
-        let mime_type = mime_guess::from_path(url).first_or_octet_stream().to_string();
+        let mime_type = mime_guess::from_path(url)
+            .first_or_octet_stream()
+            .to_string();
         Ok(format!("data:{};base64,{}", mime_type, base64))
     }
 

--- a/src-tauri/src/recorder/errors.rs
+++ b/src-tauri/src/recorder/errors.rs
@@ -1,6 +1,6 @@
-use custom_error::custom_error;
 use super::bilibili::client::BiliStream;
 use super::douyin::client::DouyinClientError;
+use custom_error::custom_error;
 
 custom_error! {pub RecorderError
     IndexNotFound {url: String} = "Index not found: {url}",
@@ -9,6 +9,7 @@ custom_error! {pub RecorderError
     M3u8ParseFailed {content: String } = "Parse m3u8 content failed: {content}",
     NoStreamAvailable = "No available stream provided",
     FreezedStream {stream: BiliStream} = "Stream is freezed: {stream}",
+    StreamExpired {stream: BiliStream} = "Stream is nearly expired: {stream}",
     NoRoomInfo = "No room info provided",
     InvalidStream {stream: BiliStream} = "Invalid stream: {stream}",
     SlowStream {stream: BiliStream} = "Stream is too slow: {stream}",


### PR DESCRIPTION
之前当直播流获取内容出现错误时，会尝试重新获取直播间状态，当检测到直播间关闭则会放弃继续尝试；
而如果直播间快速关播开播，原直播流虽然无新内容会触发Error::FreezedStream，但是由于流未过期， check_status 不会更新直播流，导致 recorder 无法切换到新的直播流。

更改后，将流过期的判断放在 update_entries 中，如果遇到任何错误，便会尝试重新获取新的流地址。