### PR TITLE
refactor: refactor error handling and update dependencies

### DIFF
--- a/src-tauri/crates/danmu_stream/Cargo.toml
+++ b/src-tauri/crates/danmu_stream/Cargo.toml
@@ -8,37 +8,41 @@ name = "danmu_stream"
 path = "src/lib.rs"
 
 [[example]]
+name = "bilibili"
+path = "examples/bilibili.rs"
+
+[[example]]
 name = "douyin"
 path = "examples/douyin.rs"
 
 [dependencies]
-tokio = { version = "1.0", features = ["full"] }
-tokio-tungstenite = { version = "0.20", features = ["native-tls"] }
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = { version = "0.27", features = ["native-tls"] }
 futures-util = "0.3"
-prost = "0.12"
+prost = "0.14"
 chrono = "0.4"
 log = "0.4"
-env_logger = "0.10"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
+env_logger = "0.11"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+reqwest = { version = "0.12", features = ["json"] }
 url = "2.4"
-md5 = "0.7"
+md5 = "0.8"
 regex = "1.9"
-deno_core = "0.242.0"
-pct-str = "2.0.0"
-custom_error = "1.9.2"
+deno_core = "0.355"
+pct-str = "2.0"
+thiserror = "2.0"
 flate2 = "1.0"
-scroll = "0.13.0"
-scroll_derive = "0.13.0"
-brotli = "8.0.1"
+scroll = "0.13"
+scroll_derive = "0.13"
+brotli = "8.0"
 http = "1.0"
-rand = "0.9.1"
-urlencoding = "2.1.3"
+rand = "0.9"
+urlencoding = "2.1"
 gzip = "0.1.2"
 hex = "0.4.3"
-async-trait = "0.1.88"
-uuid = "1.17.0"
+async-trait = "0.1"
+uuid = "1"
 
 [build-dependencies]
-tonic-build = "0.10"
+tonic-build = "0.14"

--- a/src-tauri/crates/danmu_stream/src/danmu_stream.rs
+++ b/src-tauri/crates/danmu_stream/src/danmu_stream.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
+use tokio::sync::{mpsc, RwLock};
+
 use crate::{
     provider::{new, DanmuProvider, ProviderType},
     DanmuMessageType, DanmuStreamError,
 };
-use tokio::sync::{mpsc, RwLock};
 
 #[derive(Clone)]
 pub struct DanmuStream {

--- a/src-tauri/crates/danmu_stream/src/http_client.rs
+++ b/src-tauri/crates/danmu_stream/src/http_client.rs
@@ -1,19 +1,8 @@
 use std::time::Duration;
 
-use crate::DanmuStreamError;
 use reqwest::header::HeaderMap;
 
-impl From<reqwest::Error> for DanmuStreamError {
-    fn from(value: reqwest::Error) -> Self {
-        Self::HttpError { err: value }
-    }
-}
-
-impl From<url::ParseError> for DanmuStreamError {
-    fn from(value: url::ParseError) -> Self {
-        Self::ParseError { err: value }
-    }
-}
+use crate::DanmuStreamError;
 
 pub struct ApiClient {
     client: reqwest::Client,

--- a/src-tauri/crates/danmu_stream/src/lib.rs
+++ b/src-tauri/crates/danmu_stream/src/lib.rs
@@ -2,16 +2,24 @@ pub mod danmu_stream;
 mod http_client;
 pub mod provider;
 
-use custom_error::custom_error;
+use thiserror::Error;
 
-custom_error! {pub DanmuStreamError
-    HttpError {err: reqwest::Error} = "HttpError {err}",
-    ParseError {err: url::ParseError} = "ParseError {err}",
-    WebsocketError {err: String } = "WebsocketError {err}",
-    PackError {err: String} = "PackError {err}",
-    UnsupportProto {proto: u16} = "UnsupportProto {proto}",
-    MessageParseError {err: String} = "MessageParseError {err}",
-    InvalidIdentifier {err: String} = "InvalidIdentifier {err}"
+#[derive(Error, Debug)]
+pub enum DanmuStreamError {
+    #[error("HttpError {0:?}")]
+    HttpError(#[from] reqwest::Error),
+    #[error("ParseError {0:?}")]
+    ParseError(#[from] url::ParseError),
+    #[error("WebsocketError {err}")]
+    WebsocketError { err: String },
+    #[error("PackError {err}")]
+    PackError { err: String },
+    #[error("UnsupportProto {proto}")]
+    UnsupportProto { proto: u16 },
+    #[error("MessageParseError {err}")]
+    MessageParseError { err: String },
+    #[error("InvalidIdentifier {err}")]
+    InvalidIdentifier { err: String },
 }
 
 #[derive(Debug)]

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/dannmu_msg.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/dannmu_msg.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 
-use crate::{provider::bilibili::stream::WsStreamCtx, DanmuStreamError};
+use super::stream::WsStreamCtx;
+
+use crate::DanmuStreamError;
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/interact_word.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/interact_word.rs
@@ -1,4 +1,6 @@
-use crate::{provider::bilibili::stream::WsStreamCtx, DanmuStreamError};
+use super::stream::WsStreamCtx;
+
+use crate::DanmuStreamError;
 
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/pack.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/pack.rs
@@ -24,7 +24,7 @@ struct PackHotCount {
 
 type BilibiliPackCtx<'a> = (BilibiliPackHeader, &'a [u8]);
 
-fn pack(buffer: &[u8]) -> Result<BilibiliPackCtx, DanmuStreamError> {
+fn pack(buffer: &[u8]) -> Result<BilibiliPackCtx<'_>, DanmuStreamError> {
     let data = buffer
         .pread_with(0, scroll::BE)
         .map_err(|e: scroll::Error| DanmuStreamError::PackError { err: e.to_string() })?;

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/send_gift.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/send_gift.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 
-use crate::{provider::bilibili::stream::WsStreamCtx, DanmuStreamError};
+use super::stream::WsStreamCtx;
+
+use crate::DanmuStreamError;
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/stream.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/stream.rs
@@ -1,10 +1,9 @@
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::{
-    provider::{bilibili::dannmu_msg::BiliDanmuMessage, DanmuMessageType},
-    DanmuMessage, DanmuStreamError,
-};
+use super::dannmu_msg::BiliDanmuMessage;
+
+use crate::{provider::DanmuMessageType, DanmuMessage, DanmuStreamError};
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct WsStreamCtx {

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/super_chat.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/super_chat.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 
-use crate::{provider::bilibili::stream::WsStreamCtx, DanmuStreamError};
+use super::stream::WsStreamCtx;
+
+use crate::DanmuStreamError;
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]

--- a/src-tauri/crates/danmu_stream/src/provider/douyin/messages.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/douyin/messages.rs
@@ -1,5 +1,6 @@
-use prost::Message;
 use std::collections::HashMap;
+
+use prost::Message;
 
 // message Response {
 //   repeated Message messagesList = 1;

--- a/src-tauri/crates/danmu_stream/src/provider/mod.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/mod.rs
@@ -4,10 +4,10 @@ mod douyin;
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
-use crate::{
-    provider::bilibili::BiliDanmu, provider::douyin::DouyinDanmu, DanmuMessageType,
-    DanmuStreamError,
-};
+use self::bilibili::BiliDanmu;
+use self::douyin::DouyinDanmu;
+
+use crate::{DanmuMessageType, DanmuStreamError};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderType {


### PR DESCRIPTION
Purpose: Remove the `custom_error` dependency in favor of `thiserror`. This standardization aligns our error handling with other crates in our dependency tree (like `tokio-tungstenite`, `pct-str`, and `deno`), reducing the total number of dependencies.