### PR TITLE
fix: shortcut key conflicts with input

### DIFF
--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -817,7 +817,7 @@
       (!!tagName && ["INPUT", "TEXTAREA", "SELECT"].includes(tagName)) ||
       !!target?.isContentEditable ||
       !!target?.closest(
-        "input, textarea, select, [contenteditable='true'], [contenteditable=''], [contenteditable], [data-hotkey-block]"
+        "input, textarea, select, [contenteditable='true'], [data-hotkey-block]"
       );
 
     switch (event.key) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ignore hotkey processing when the active element is an input, textarea, select, contenteditable element, or marked with data-hotkey-block