### PR TITLE
fix: panic generating whole live without danmu

### DIFF
--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -1362,7 +1362,7 @@ impl RecorderManager {
 
             futures::future::join_all(danmu_ass_files).await
         } else {
-            Vec::new()
+            vec![None; playlists.len()]
         };
 
         let timestamp = chrono::Local::now().format("%Y%m%d%H%M%S").to_string();


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Return a None-filled vector of the same length as playlists instead of an empty vector when danmu files are absent