### PR TITLE
fix: cover uploading error

### DIFF
--- a/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
@@ -862,8 +862,9 @@ pub async fn upload_cover(
     cover: &str,
 ) -> Result<String, RecorderError> {
     let url = format!(
-        "https://member.bilibili.com/x/vu/web/cover/up?ts={}",
-        chrono::Local::now().timestamp(),
+        "https://member.bilibili.com/x/vu/web/cover/up?ts={}&csrf={}",
+        chrono::Local::now().timestamp_millis(),
+        account.csrf
     );
     let mut headers = generate_user_agent_header();
     if let Ok(cookies) = account.cookies.parse() {

--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -700,7 +700,6 @@ struct UploadProcedureRequest {
     uid: String,
     room_id: String,
     video_id: i64,
-    cover: String,
     profile: Profile,
 }
 
@@ -714,7 +713,6 @@ async fn handler_upload_procedure(
         param.uid,
         param.room_id,
         param.video_id,
-        param.cover,
         param.profile,
     )
     .await?;

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -496,7 +496,6 @@ const post_video_to_bilibili = tool(
     //   profile: profile,
     // })
     const event_id = generateEventId();
-    const cover = await invoke("get_video_cover", { id: video_id });
     let profile = default_profile();
     profile.title = title;
     profile.desc = desc;
@@ -507,7 +506,6 @@ const post_video_to_bilibili = tool(
       eventId: event_id,
       roomId: room_id,
       videoId: video_id,
-      cover,
       profile,
     });
     return result;

--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -374,7 +374,6 @@
       eventId: event_id,
       roomId: roomId,
       videoId: video.id,
-      cover: video.cover,
       profile: profile,
     }).then(async () => {
       uid_selected = 0;


### PR DESCRIPTION
## Summary by Sourcery

Correct cover uploading by reading the generated JPEG cover file, base64 encoding it, and including the account CSRF token and precise timestamp in the upload URL, while removing the obsolete cover parameter throughout the backend and frontend.

Bug Fixes:
- Fix cover uploading failure by generating correct base64 payload from the local JPEG file

Enhancements:
- Include account.csrf and timestamp_millis in the Bilibili cover upload URL
- Add error logging when reading the cover file

Chores:
- Remove deprecated cover parameter from upload_procedure handlers and client invocations across backend and frontend