### PR TITLE
fix: douyin encoding with danmu

### DIFF
--- a/src-tauri/crates/recorder/src/core/hls_recorder.rs
+++ b/src-tauri/crates/recorder/src/core/hls_recorder.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::{path::PathBuf, sync::Arc};
 
+use chrono::Utc;
 use m3u8_rs::{MediaPlaylist, Playlist};
 use reqwest::header::HeaderMap;
 use std::time::Duration;
@@ -206,6 +207,11 @@ impl HlsRecorder {
                     "Download failed",
                 )));
             };
+
+            let mut segment = segment.clone();
+            if segment.program_date_time.is_none() {
+                segment.program_date_time.replace(Utc::now().into());
+            }
 
             // check if the stream is changed
             let segment_metadata = crate::ffmpeg::extract_video_metadata(&segment_path)

--- a/src-tauri/src/handlers/recorder.rs
+++ b/src-tauri/src/handlers/recorder.rs
@@ -450,6 +450,7 @@ pub async fn generate_whole_clip(
                 "platform": platform,
                 "room_id": room_id,
                 "parent_id": parent_id,
+                "encode_danmu": encode_danmu,
             })
             .to_string(),
         )

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -160,8 +160,8 @@ pub enum RecorderManagerError {
     SubtitleNotFound { live_id: String },
     #[error("Subtitle generation failed: {error}")]
     SubtitleGenerationFailed { error: String },
-    #[error("Invalid playlist without date time")]
-    InvalidPlaylistWithoutDateTime,
+    #[error("Invalid live id, not timestamp str")]
+    InvalidLiveID,
     #[error("Archive danmu ass generation failed: {error}")]
     ArchiveDanmuAssGenerationFailed { error: String },
 }
@@ -754,11 +754,15 @@ impl RecorderManager {
             .find(|t| t.tag == "X-PROGRAM-DATE-TIME");
 
         let Some(program_date_time) = program_date_time else {
-            return Err(RecorderManagerError::InvalidPlaylistWithoutDateTime);
+            return live_id
+                .parse::<i64>()
+                .map_err(|_| RecorderManagerError::InvalidLiveID);
         };
 
         let Some(value) = &program_date_time.rest else {
-            return Err(RecorderManagerError::InvalidPlaylistWithoutDateTime);
+            return live_id
+                .parse::<i64>()
+                .map_err(|_| RecorderManagerError::InvalidLiveID);
         };
 
         // example: "2025-10-18T17:18:17.004+0800"


### PR DESCRIPTION
## Summary by Sourcery

Improve douyin DANMU encoding by enhancing error handling for missing timestamps, providing fallbacks for program date tags, and exposing the encode_danmu flag in the recorder handler.

New Features:
- Add support to pass encode_danmu flag in generate_whole_clip handler

Enhancements:
- Rename InvalidPlaylistWithoutDateTime error variant to InvalidLiveID with updated parsing logic
- Attempt to parse live_id as timestamp when playlist date tag is missing instead of immediate failure
- Populate missing program_date_time on HLS segments with the current timestamp