### PR TITLE
fix: video import with number roomId error

### DIFF
--- a/src/lib/components/ImportVideoDialog.svelte
+++ b/src/lib/components/ImportVideoDialog.svelte
@@ -6,9 +6,10 @@
   import type { ProgressUpdate, ProgressFinished } from "../interface";
 
   export let showDialog = false;
-  export let roomId: number | null = null;
+  export let roomId: string | null = null;
 
   const dispatch = createEventDispatcher();
+  const IMPORTED_VIDEO_ROOM = "bsr:import";
 
   let selectedFilePath: string | null = null;
   let selectedFileName: string = "";
@@ -172,7 +173,7 @@
         await uploadFile(file);
       } else {
         alert(
-          "请选择支持的视频文件格式 (MP4, MKV, AVI, MOV, WMV, FLV, M4V, WebM)"
+          "请选择支持的视频文件格式 (MP4, MKV, AVI, MOV, WMV, FLV, M4V, WebM)",
         );
       }
     }
@@ -185,7 +186,7 @@
     try {
       const formData = new FormData();
       formData.append("file", file);
-      formData.append("roomId", String(roomId || 0));
+      formData.append("roomId", roomId || IMPORTED_VIDEO_ROOM);
 
       const xhr = new XMLHttpRequest();
 
@@ -259,7 +260,7 @@
       }
 
       const formData = new FormData();
-      formData.append("room_id", String(roomId || 0));
+      formData.append("room_id", roomId || IMPORTED_VIDEO_ROOM);
 
       files.forEach((file) => {
         formData.append("files", file);
@@ -276,7 +277,7 @@
           // 根据进度估算当前正在上传的文件
           const estimatedCurrentIndex = Math.min(
             Math.floor((progress / 100) * totalFiles),
-            totalFiles - 1
+            totalFiles - 1,
           );
           currentFileName = fileNames[estimatedCurrentIndex] || fileNames[0];
         }
@@ -360,7 +361,7 @@
           if (match) {
             currentFileIndex = parseInt(match[1]);
           }
-        }
+        },
       );
       const clear_finished_listener = await listen(
         `progress-finished:${eventId}`,
@@ -385,13 +386,13 @@
 
           clear_update_listener();
           clear_finished_listener();
-        }
+        },
       );
 
       await invoke("batch_import_external_videos", {
         eventId: eventId,
         filePaths: selectedFiles,
-        roomId: roomId || 0,
+        roomId: roomId || IMPORTED_VIDEO_ROOM,
       });
     } catch (error) {
       console.error("批量导入失败:", error);
@@ -433,7 +434,7 @@
           if (match) {
             currentFileIndex = parseInt(match[1]);
           }
-        }
+        },
       );
       const clear_finished_listener = await listen(
         `progress-finished:${eventId}`,
@@ -458,14 +459,14 @@
 
           clear_update_listener();
           clear_finished_listener();
-        }
+        },
       );
 
       await invoke("import_external_video", {
         eventId: eventId,
         filePath: selectedFilePath,
         title: videoTitle,
-        roomId: roomId || 0,
+        roomId: roomId || IMPORTED_VIDEO_ROOM,
       });
 
       // 注意：成功处理移到了progressFinishedListener中

--- a/src/page/Clip.svelte
+++ b/src/page/Clip.svelte
@@ -31,8 +31,8 @@
   let loading = false;
   let sortBy = "created_at";
   let sortOrder = "desc";
-  let selectedRoomId: number | null = null;
-  let roomIds: number[] = [];
+  let selectedRoomId = null;
+  let roomIds: string[] = [];
 
   let selectedVideos: Set<number> = new Set();
   let showDeleteConfirm = false;
@@ -169,7 +169,7 @@
     try {
       // 获取所有视频
       const allVideos: VideoItem[] = [];
-      const roomIdsSet = new Set<number>();
+      const roomIdsSet = new Set<string>();
       const tempVideos = await invoke<VideoItem[]>("get_all_videos");
 
       for (const video of tempVideos) {
@@ -182,7 +182,7 @@
       }
 
       videos = allVideos;
-      roomIds = Array.from(roomIdsSet).sort((a, b) => a - b);
+      roomIds = Array.from(roomIdsSet).sort();
 
       applyFilters();
     } catch (error) {
@@ -428,7 +428,7 @@
 
       // 更新筛选后的视频列表
       const index = filteredVideos.findIndex(
-        (v) => v.id === videoToEditNote.id
+        (v) => v.id === videoToEditNote.id,
       );
       if (index !== -1) {
         filteredVideos[index].note = editingNote;


### PR DESCRIPTION
## Summary by Sourcery

Fix video import failure caused by numeric roomId by standardizing room identifiers as strings and introducing a dedicated import room constant

Bug Fixes:
- Prevent import errors by replacing numeric roomId fallback (0) with a string constant for import operations

Enhancements:
- Introduce IMPORTED_VIDEO_ROOM constant and use it as default room ID in FormData for single and batch imports
- Change roomId prop in ImportVideoDialog and selectedRoomId/roomIds in Clip.svelte to string types and adjust room ID collection and sorting accordingly
- Apply minor syntax and formatting fixes such as adding missing commas in alert messages and tidying up listener callback braces