### PR TITLE
feat: introduce static server for file access

### DIFF
--- a/src-tauri/src/handlers/config.rs
+++ b/src-tauri/src/handlers/config.rs
@@ -12,6 +12,11 @@ pub async fn get_config(state: state_type!()) -> Result<Config, ()> {
 }
 
 #[cfg_attr(feature = "gui", tauri::command)]
+pub async fn get_static_port(state: state_type!()) -> Result<u16, ()> {
+    Ok(state.static_server.port)
+}
+
+#[cfg_attr(feature = "gui", tauri::command)]
 #[allow(dead_code)]
 pub async fn set_cache_path(state: state_type!(), cache_path: String) -> Result<(), String> {
     let old_cache_path = state.config.read().await.cache.clone();

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4,6 +4,7 @@ use tokio::sync::RwLock;
 use crate::config::Config;
 use crate::database::Database;
 use crate::recorder_manager::RecorderManager;
+use crate::static_server::StaticServer;
 use crate::task::TaskManager;
 use crate::webhook::poster::WebhookPoster;
 
@@ -17,6 +18,7 @@ pub struct State {
     pub webhook_poster: WebhookPoster,
     pub recorder_manager: Arc<RecorderManager>,
     pub task_manager: Arc<TaskManager>,
+    pub static_server: Arc<StaticServer>,
     #[cfg(not(feature = "headless"))]
     pub app_handle: tauri::AppHandle,
     #[cfg(feature = "headless")]

--- a/src-tauri/src/static_server/mod.rs
+++ b/src-tauri/src/static_server/mod.rs
@@ -1,0 +1,57 @@
+use crate::config::Config;
+use axum::Router;
+use std::{net::SocketAddr, sync::Arc};
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use tower_http::cors::{Any, CorsLayer};
+use tower_http::services::ServeDir;
+
+pub struct StaticServer {
+    #[allow(dead_code)]
+    pub handle: JoinHandle<()>,
+    pub port: u16,
+}
+
+pub async fn start_static_server(
+    config: Arc<RwLock<Config>>,
+) -> Result<StaticServer, Box<dyn std::error::Error>> {
+    let bind_addr = SocketAddr::from(([0, 0, 0, 0], 0));
+    log::info!("Starting static server binding to {}", bind_addr);
+
+    let listener = match tokio::net::TcpListener::bind(bind_addr).await {
+        Ok(listener) => {
+            match listener.local_addr() {
+                Ok(addr) => log::info!("Static server listening on http://{}", addr),
+                Err(e) => log::warn!("Unable to determine listening address: {}", e),
+            }
+            listener
+        }
+        Err(e) => {
+            log::error!("Failed to bind static server: {}", e);
+            log::error!("Please check if the port is already in use or try a different port");
+            return Err(e.into());
+        }
+    };
+
+    let port = listener.local_addr().unwrap().port();
+
+    let output_path = config.read().await.output.clone();
+    let cache_path = config.read().await.cache.clone();
+
+    let handle = tokio::spawn(async move {
+        let cors = CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods(Any)
+            .allow_headers(Any);
+        let router = Router::new()
+            .layer(cors)
+            .nest_service("/output", ServeDir::new(output_path))
+            .nest_service("/cache", ServeDir::new(cache_path));
+
+        if let Err(e) = axum::serve(listener, router).await {
+            log::error!("Server error: {}", e);
+        }
+    });
+
+    Ok(StaticServer { handle, port })
+}

--- a/src/AppClip.svelte
+++ b/src/AppClip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke, convertFileSrc, get_cover } from "./lib/invoker";
+  import { invoke, get_static_url } from "./lib/invoker";
   import { onMount } from "svelte";
   import VideoPreview from "./lib/components/VideoPreview.svelte";
   import type { Config, VideoItem } from "./lib/interface";
@@ -36,7 +36,7 @@
                 id: v.id,
                 value: v.id,
                 name: v.file,
-                file: await convertFileSrc(v.file),
+                file: await get_static_url("output", v.file),
                 cover: v.cover,
               };
             })
@@ -59,7 +59,7 @@
   async function handleVideoChange(newVideo: VideoItem) {
     if (newVideo) {
       if (newVideo.cover && newVideo.cover.trim() !== "") {
-        newVideo.cover = await get_cover("output", newVideo.cover);
+        newVideo.cover = await get_static_url("output", newVideo.cover);
       } else {
         newVideo.cover = "";
       }
@@ -76,7 +76,7 @@
             id: v.id,
             value: v.id,
             name: v.file,
-            file: await convertFileSrc(v.file),
+            file: await get_static_url("output", v.file),
             cover: v.cover,
           };
         })

--- a/src/AppLive.svelte
+++ b/src/AppLive.svelte
@@ -3,10 +3,9 @@
     invoke,
     set_title,
     TAURI_ENV,
-    convertFileSrc,
     listen,
     log,
-    get_cover,
+    get_static_url,
   } from "./lib/invoker";
   import Player from "./lib/components/Player.svelte";
   import type { RecordItem } from "./lib/db";
@@ -15,8 +14,6 @@
     type VideoItem,
     type Config,
     type Marker,
-    type ProgressUpdate,
-    type ProgressFinished,
     type DanmuEntry,
     clipRange,
     generateEventId,
@@ -264,7 +261,7 @@
           id: v.id,
           value: v.id,
           name: v.file,
-          file: await convertFileSrc(v.file),
+          file: await get_static_url("output", v.file),
           cover: v.cover,
         };
       })
@@ -281,7 +278,7 @@
       return v.value == id;
     });
     if (target_video) {
-      target_video.cover = await get_cover("output", target_video.cover);
+      target_video.cover = await get_static_url("output", target_video.cover);
     }
     selected_video = target_video;
   }
@@ -342,7 +339,7 @@
       fix_encoding,
     })) as VideoItem;
     await get_video_list();
-    new_video.cover = await get_cover("output", new_video.cover);
+    new_video.cover = await get_static_url("output", new_video.cover);
     video_selected = new_video.id;
     selected_video = videos.find((v) => {
       return v.value == new_video.id;

--- a/src/lib/components/GenerateWholeClipModal.svelte
+++ b/src/lib/components/GenerateWholeClipModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke, get_cover } from "../invoker";
+  import { invoke, get_static_url } from "../invoker";
   import type { RecordItem } from "../db";
   import { fade, scale } from "svelte/transition";
   import { X, FileVideo } from "lucide-svelte";
@@ -34,7 +34,7 @@
 
       // 处理封面
       for (const archive of sameParentArchives) {
-        archive.cover = await get_cover(
+        archive.cover = await get_static_url(
           "cache",
           `${archive.platform}/${archive.room_id}/${archive.live_id}/cover.jpg`
         );

--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -34,7 +34,7 @@
     listen,
     log,
     close_window,
-    get_cover,
+    get_static_url,
   } from "../invoker";
   import { onDestroy, onMount } from "svelte";
   import { listen as tauriListen } from "@tauri-apps/api/event";

--- a/src/page/Account.svelte
+++ b/src/page/Account.svelte
@@ -10,6 +10,8 @@
     accounts: [],
   };
 
+  let avatar_cache: Map<string, string> = new Map();
+
   async function update_accounts() {
     let new_account_info = (await invoke("get_accounts")) as AccountInfo;
     for (const account of new_account_info.accounts) {
@@ -17,9 +19,15 @@
         account.avatar = platform_avatar(account.platform);
         continue;
       }
+      if (avatar_cache.has(account.avatar)) {
+        account.avatar = avatar_cache.get(account.avatar);
+        continue;
+      }
       const avatar_response = await get(account.avatar);
       const avatar_blob = await avatar_response.blob();
-      account.avatar = URL.createObjectURL(avatar_blob);
+      const avatar_url = URL.createObjectURL(avatar_blob);
+      avatar_cache.set(account.avatar, avatar_url);
+      account.avatar = avatar_url;
     }
     account_info = new_account_info;
   }

--- a/src/page/Archive.svelte
+++ b/src/page/Archive.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke, get_cover } from "../lib/invoker";
+  import { invoke, get_static_url } from "../lib/invoker";
   import type { RecordItem } from "../lib/db";
   import { onMount } from "svelte";
   import {
@@ -95,7 +95,7 @@
 
           // 处理封面
           for (const archive of roomArchives) {
-            archive.cover = await get_cover(
+            archive.cover = await get_static_url(
               "cache",
               `${archive.platform}/${archive.room_id}/${archive.live_id}/cover.jpg`
             );

--- a/src/page/Clip.svelte
+++ b/src/page/Clip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { invoke, TAURI_ENV, convertFileSrc, get_cover } from "../lib/invoker";
+  import { invoke, TAURI_ENV, get_static_url } from "../lib/invoker";
   import type { VideoItem } from "../lib/interface";
   import ImportVideoDialog from "../lib/components/ImportVideoDialog.svelte";
   import { onMount, onDestroy, tick } from "svelte";
@@ -173,7 +173,7 @@
       const tempVideos = await invoke<VideoItem[]>("get_all_videos");
 
       for (const video of tempVideos) {
-        video.cover = await get_cover("output", video.cover);
+        video.cover = await get_static_url("output", video.cover);
       }
 
       for (const video of tempVideos) {
@@ -298,7 +298,7 @@
     }
   }
 
-  function getRoomUrl(platform: string | undefined, roomId: number) {
+  function getRoomUrl(platform: string | undefined, roomId: string) {
     if (!platform) return null;
     switch (platform.toLowerCase()) {
       case "bilibili":
@@ -393,7 +393,7 @@
 
   async function exportVideo(video: VideoItem) {
     // download video
-    const video_url = await convertFileSrc(video.file);
+    const video_url = await get_static_url("output", video.file);
     const video_name = video.title;
     const a = document.createElement("a");
     a.href = video_url;
@@ -428,7 +428,7 @@
 
       // 更新筛选后的视频列表
       const index = filteredVideos.findIndex(
-        (v) => v.id === videoToEditNote.id,
+        (v) => v.id === videoToEditNote.id
       );
       if (index !== -1) {
         filteredVideos[index].note = editingNote;

--- a/src/page/Summary.svelte
+++ b/src/page/Summary.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { get_cover, invoke } from "../lib/invoker";
+  import { get_static_url, invoke } from "../lib/invoker";
   import type { RecorderList, DiskInfo } from "../lib/interface";
   import type { RecordItem } from "../lib/db";
   const INTERVAL = 5000;
@@ -90,7 +90,7 @@
     })) as RecordItem[];
 
     for (const record of newRecords) {
-      record.cover = await get_cover(
+      record.cover = await get_static_url(
         "cache",
         `${record.platform}/${record.room_id}/${record.live_id}/cover.jpg`
       );


### PR DESCRIPTION
## Summary by Sourcery

Add a standalone static server for file access in both backend and frontend, remove legacy file conversion logic, and update client code to retrieve assets over HTTP with caching

Enhancements:
- Introduce a dedicated HTTP static server in the Tauri backend to serve the output and cache directories
- Expose a new `get_static_port` command and API endpoint to retrieve the static server port
- Replace the old `convertFileSrc` and `get_cover` logic with a unified `get_static_url` helper in the client
- Update Svelte components to fetch static assets via HTTP and add in-memory caching for avatars and images