### PR TITLE
fix: cannot send danmaku

### DIFF
--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -399,7 +399,7 @@ ${mediaPlaylistUrl}`;
             const value = danmakuInput.value;
             if (value) {
               // get account uid from select
-              const uid = parseInt(accountSelect.value);
+              const uid = accountSelect.value;
               await invoke("send_danmaku", {
                 uid,
                 roomId: room_id,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove parseInt on accountSelect.value so uid is passed in its original form when invoking send_danmaku