### PR TITLE
feat: special audio file for waveform

### DIFF
--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -32,10 +32,11 @@ use crate::{
         utils::{console_log, get_disk_info, list_folder, sanitize_filename_advanced, DiskInfo},
         video::{
             batch_import_external_videos, cancel, clip_range, clip_video, delete_video,
-            encode_video_subtitle, generate_video_subtitle, generic_ffmpeg_command, get_all_videos,
-            get_file_size, get_import_progress, get_video, get_video_cover, get_video_subtitle,
-            get_video_typelist, get_videos, import_external_video, update_video_cover,
-            update_video_note, update_video_subtitle, upload_procedure,
+            encode_video_subtitle, generate_audio_sample, generate_video_subtitle,
+            generic_ffmpeg_command, get_all_videos, get_file_size, get_import_progress, get_video,
+            get_video_cover, get_video_subtitle, get_video_typelist, get_videos,
+            import_external_video, update_video_cover, update_video_note, update_video_subtitle,
+            upload_procedure,
         },
         AccountInfo,
     },
@@ -754,6 +755,20 @@ async fn handler_get_video(
 ) -> Result<Json<ApiResponse<VideoRow>>, ApiError> {
     let video = get_video(state.0, param.id).await?;
     Ok(Json(ApiResponse::success(video)))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GenerateAudioSampleRequest {
+    video_id: i64,
+}
+
+async fn handler_generate_audio_sample(
+    state: axum::extract::State<State>,
+    Json(param): Json<GenerateAudioSampleRequest>,
+) -> Result<Json<ApiResponse<()>>, ApiError> {
+    generate_audio_sample(state.0, param.video_id).await?;
+    Ok(Json(ApiResponse::success(())))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1816,6 +1831,10 @@ pub async fn start_api_server(state: State) {
         // Video commands
         .route("/api/clip_range", post(handler_clip_range))
         .route("/api/get_video", post(handler_get_video))
+        .route(
+            "/api/generate_audio_sample",
+            post(handler_generate_audio_sample),
+        )
         .route("/api/get_videos", post(handler_get_videos))
         .route("/api/get_video_cover", post(handler_get_video_cover))
         .route("/api/get_all_videos", post(handler_get_all_videos))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -691,6 +691,7 @@ fn setup_invoke_handlers(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<
         crate::handlers::video::clip_video,
         crate::handlers::video::get_file_size,
         crate::handlers::video::get_import_progress,
+        crate::handlers::video::generate_audio_sample,
         crate::handlers::task::get_tasks,
         crate::handlers::task::delete_task,
         crate::handlers::utils::show_in_folder,

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -1437,6 +1437,7 @@ impl RecorderManager {
         }
 
         let _ = crate::ffmpeg::generate_thumbnail(Path::new(&output_path), 0.0).await;
+        let _ = crate::ffmpeg::extract_audio_sample(Path::new(&output_path)).await;
 
         let video = self
             .db

--- a/src-tauri/src/static_server/mod.rs
+++ b/src-tauri/src/static_server/mod.rs
@@ -44,9 +44,9 @@ pub async fn start_static_server(
             .allow_methods(Any)
             .allow_headers(Any);
         let router = Router::new()
-            .layer(cors)
             .nest_service("/output", ServeDir::new(output_path))
-            .nest_service("/cache", ServeDir::new(cache_path));
+            .nest_service("/cache", ServeDir::new(cache_path))
+            .layer(cors);
 
         if let Err(e) = axum::serve(listener, router).await {
             log::error!("Server error: {}", e);

--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -153,14 +153,14 @@
     isWaveformLoading = true;
 
     try {
-      createWaveSurfer();
+      await createWaveSurfer();
     } catch (error) {
       console.error("Failed to initialize WaveSurfer.js:", error);
       isWaveformLoading = false;
     }
   }
 
-  function createWaveSurfer() {
+  async function createWaveSurfer() {
     // 使用更稳定的容器查找方式
     const container = document.querySelector(
       "[data-waveform-container]"
@@ -203,9 +203,13 @@
         plugins: [],
       });
 
-      console.log("WaveSurfer created, loading file:", video.file);
       // 加载音频
-      wavesurfer.load(video.file);
+      await invoke("generate_audio_sample", {
+        videoId: video.id,
+      });
+      let opus_file = video.file.replace(".mp4", ".opus");
+      console.log("WaveSurfer created, loading file:", opus_file);
+      wavesurfer.load(opus_file);
 
       // 监听加载完成
       wavesurfer.on("ready", () => {
@@ -1738,7 +1742,9 @@
             on:wheel|preventDefault={handleWheel}
           >
             {#if isWaveformLoading}
-              <div class="flex items-center space-x-2 text-gray-400 w-full">
+              <div
+                class="flex items-center justify-center gap-2 text-gray-400 w-full h-full text-center"
+              >
                 <svg
                   class="animate-spin h-4 w-4"
                   xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary by Sourcery

Enable extraction and serving of Opus audio samples from video files for waveform display by introducing a new FFmpeg-based extraction function, Tauri command and API endpoint, integrating it into existing video flows, and updating the frontend to load generated Opus files.

New Features:
- Add extract_audio_sample function to generate 16kHz mono Opus audio files from videos for waveform display
- Expose generate_audio_sample as a Tauri command and HTTP API endpoint to trigger audio sample extraction
- Integrate automatic audio sample generation in video clipping and recording workflows
- Update VideoPreview component to await audio sample generation and load Opus files for waveform visualization

Enhancements:
- Remove generated Opus files when deleting videos
- Adjust CORS middleware order in static server configuration