### PR TITLE
fix: segment uri concat

### DIFF
--- a/src-tauri/crates/recorder/src/core/hls_recorder.rs
+++ b/src-tauri/crates/recorder/src/core/hls_recorder.rs
@@ -424,7 +424,12 @@ mod tests {
         ).await.unwrap();
         assert_eq!(stream.index(), "https://hs.hls.huya.com/huyalive/156976698-156976698-674209784144068608-314076852-10057-A-0-1.m3u8?ratio=2000&wsSecret=7abc7dec8809146f31f92046eb044e3b&wsTime=68fa41ba&fm=RFdxOEJjSjNoNkRKdDZUWV8kMF8kMV8kMl8kMw%3D%3D&ctype=tars_mobile&fs=bgct&t=103");
         assert_eq!(stream.ts_url("1.ts"), "https://hs.hls.huya.com/huyalive/1.ts?ratio=2000&wsSecret=7abc7dec8809146f31f92046eb044e3b&wsTime=68fa41ba&fm=RFdxOEJjSjNoNkRKdDZUWV8kMF8kMV8kMl8kMw%3D%3D&ctype=tars_mobile&fs=bgct&t=103");
-        assert_eq!(stream.ts_url("1.ts?expires=1760808243"), "https://hs.hls.huya.com/huyalive/1.ts?expires=1760808243&ratio=2000&wsSecret=7abc7dec8809146f31f92046eb044e3b&wsTime=68fa41ba&fm=RFdxOEJjSjNoNkRKdDZUWV8kMF8kMV8kMl8kMw%3D%3D&ctype=tars_mobile&fs=bgct&t=103");
+        // According to HLS spec (RFC 8216), if segment URI contains query parameters,
+        // use them as-is without merging with m3u8 query parameters
+        assert_eq!(
+            stream.ts_url("1.ts?expires=1760808243"),
+            "https://hs.hls.huya.com/huyalive/1.ts?expires=1760808243"
+        );
         assert_eq!(stream.host, "https://hs.hls.huya.com");
         assert_eq!(
             stream.base,


### PR DESCRIPTION
## Summary by Sourcery

Correct HLS segment URL construction to comply better with RFC 8216 when handling segment URIs and query parameters.

Bug Fixes:
- Resolve incorrect concatenation of HLS segment URIs by respecting absolute URLs, relative paths, and existing query parameters without unintended merging.

Enhancements:
- Improve HlsStream.ts_url logic to distinguish absolute and relative segment URIs and conditionally apply m3u8-level query parameters based on spec behavior.

Tests:
- Update HLS recorder tests to cover segment URLs with their own query parameters and validate the new URL construction behavior.