### PR TITLE
fix: unify static server handling for headless mode(#244)

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -2,3 +2,6 @@ pub const PREFIX_SUBTITLE: &str = "[subtitle]";
 pub const PREFIX_IMPORTED: &str = "[imported]";
 pub const PREFIX_DANMAKU: &str = "[danmaku]";
 pub const PREFIX_CLIP: &str = "[clip]";
+
+/// Default port for the HTTP API server (headless / Docker mode).
+pub const API_PORT: u16 = 3000;

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -4,4 +4,5 @@ pub const PREFIX_DANMAKU: &str = "[danmaku]";
 pub const PREFIX_CLIP: &str = "[clip]";
 
 /// Default port for the HTTP API server (headless / Docker mode).
+#[allow(dead_code)]
 pub const API_PORT: u16 = 3000;

--- a/src-tauri/src/handlers/config.rs
+++ b/src-tauri/src/handlers/config.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+use crate::constants::API_PORT;
 use crate::danmu2ass::Danmu2AssOptions;
 use crate::state::State;
 use crate::state_type;
@@ -13,7 +14,14 @@ pub async fn get_config(state: state_type!()) -> Result<Config, ()> {
 
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn get_static_port(state: state_type!()) -> Result<u16, ()> {
-    Ok(state.static_server.port)
+    #[cfg(feature = "headless")]
+    {
+        Ok(API_PORT)
+    }
+    #[cfg(not(feature = "headless"))]
+    {
+        Ok(state.static_server.port)
+    }
 }
 
 #[cfg_attr(feature = "gui", tauri::command)]

--- a/src-tauri/src/handlers/config.rs
+++ b/src-tauri/src/handlers/config.rs
@@ -13,14 +13,14 @@ pub async fn get_config(state: state_type!()) -> Result<Config, ()> {
 }
 
 #[cfg_attr(feature = "gui", tauri::command)]
-pub async fn get_static_port(state: state_type!()) -> Result<u16, ()> {
+pub async fn get_static_port(_state: state_type!()) -> Result<u16, ()> {
     #[cfg(feature = "headless")]
     {
         Ok(API_PORT)
     }
     #[cfg(not(feature = "headless"))]
     {
-        Ok(state.static_server.port)
+        Ok(_state.static_server.port)
     }
 }
 

--- a/src-tauri/src/handlers/config.rs
+++ b/src-tauri/src/handlers/config.rs
@@ -1,4 +1,5 @@
 use crate::config::Config;
+#[cfg(feature = "headless")]
 use crate::constants::API_PORT;
 use crate::danmu2ass::Danmu2AssOptions;
 use crate::state::State;

--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -1682,8 +1682,14 @@ pub async fn start_api_server(state: State) {
 
     // In headless/Docker mode, serve cache and output from the same port (3000) so they are
     // reachable when only one port is exposed. These routes must be registered before "/".
-    let output_path = state.config.read().await.output.clone();
-    let cache_path = state.config.read().await.cache.clone();
+    //
+    // Take a single read lock on config and clone the relevant fields to avoid
+    // redundant locking. The lock is scoped to this block so it is released
+    // before we move `state` into the router below.
+    let (output_path, cache_path) = {
+        let config = state.config.read().await;
+        (config.output.clone(), config.cache.clone())
+    };
 
     let mut app = Router::new()
         .nest_service("/output", ServeDir::new(output_path))

--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::{
     config::Config,
+    constants::API_PORT,
     database::{
         message::MessageRow, record::RecordRow, recorder::RecorderRow, task::TaskRow,
         video::VideoRow,
@@ -1679,7 +1680,14 @@ pub async fn start_api_server(state: State) {
         .allow_methods(Any)
         .allow_headers(Any);
 
+    // In headless/Docker mode, serve cache and output from the same port (3000) so they are
+    // reachable when only one port is exposed. These routes must be registered before "/".
+    let output_path = state.config.read().await.output.clone();
+    let cache_path = state.config.read().await.cache.clone();
+
     let mut app = Router::new()
+        .nest_service("/output", ServeDir::new(output_path))
+        .nest_service("/cache", ServeDir::new(cache_path))
         // Serve static files from dist directory
         .nest_service("/", ServeDir::new("./dist"))
         // Account commands
@@ -1861,10 +1869,10 @@ pub async fn start_api_server(state: State) {
         .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))
         .with_state(state);
 
-    let addr = "0.0.0.0:3000";
+    let addr = format!("0.0.0.0:{}", API_PORT);
     log::info!("Starting API server on http://{}", addr);
 
-    let listener = match tokio::net::TcpListener::bind(addr).await {
+    let listener = match tokio::net::TcpListener::bind(&addr).await {
         Ok(listener) => {
             log::info!("API server listening on http://{}", addr);
             listener

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -493,11 +493,9 @@ async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Err
     ));
 
     // In headless/Docker, cache and output are served from the API server (API_PORT), so no
-    // separate static server is needed and only one port need be exposed.
-    let static_server = Arc::new(StaticServer {
-        handle: tokio::spawn(async {}),
-        port: API_PORT,
-    });
+    // separate static server is needed and only one port need be exposed. Use a dedicated
+    // constructor to make this intent explicit.
+    let static_server = Arc::new(StaticServer::headless(API_PORT));
 
     let _ = try_rebuild_archives(&db, config.read().await.cache.clone().into()).await;
     let _ = try_convert_live_covers(&db, config.read().await.cache.clone().into()).await;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -434,7 +434,7 @@ impl MigrationSource<'static> for MigrationList {
 async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Error>> {
     use std::path::PathBuf;
 
-    use crate::{static_server::start_static_server, task::TaskManager};
+    use crate::{constants::API_PORT, static_server::StaticServer, task::TaskManager};
     use progress::progress_manager::ProgressManager;
     use progress::progress_reporter::EventEmitter;
 
@@ -492,7 +492,12 @@ async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Err
         webhook_poster.clone(),
     ));
 
-    let static_server = Arc::new(start_static_server(config.clone()).await?);
+    // In headless/Docker, cache and output are served from the API server (API_PORT), so no
+    // separate static server is needed and only one port need be exposed.
+    let static_server = Arc::new(StaticServer {
+        handle: tokio::spawn(async {}),
+        port: API_PORT,
+    });
 
     let _ = try_rebuild_archives(&db, config.read().await.cache.clone().into()).await;
     let _ = try_convert_live_covers(&db, config.read().await.cache.clone().into()).await;

--- a/src-tauri/src/static_server/mod.rs
+++ b/src-tauri/src/static_server/mod.rs
@@ -12,6 +12,19 @@ pub struct StaticServer {
     pub port: u16,
 }
 
+impl StaticServer {
+    /// Create a StaticServer instance for environments where the actual static
+    /// files are served by the API server (e.g. headless/Docker). The handle is
+    /// a no-op task used only to satisfy the existing interface.
+    #[cfg(feature = "headless")]
+    pub fn headless(port: u16) -> Self {
+        Self {
+            handle: tokio::spawn(async {}),
+            port,
+        }
+    }
+}
+
 pub async fn start_static_server(
     config: Arc<RwLock<Config>>,
 ) -> Result<StaticServer, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary by Sourcery

Serve cache and output directories through the main API server port in headless mode and standardize the API server port configuration.

New Features:
- Expose /output and /cache static routes from the API server alongside the existing dist assets.

Enhancements:
- Introduce a shared API_PORT constant and use it for binding the API server and reporting the static port in headless mode.
- Avoid starting a separate static server in headless/Docker mode by reusing the API server port for static content.