### PR TITLE
fix: support nested segment paths in HLS request handler (CoolVibe)

### DIFF
--- a/src-tauri/crates/danmu_stream/src/provider/kuaishou.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/kuaishou.rs
@@ -10,11 +10,11 @@ use async_trait::async_trait;
 use flate2::read::GzDecoder;
 use futures_util::{SinkExt, StreamExt, TryStreamExt};
 use log::{error, info, warn};
+use prost::Message;
 use rand::{distr::Alphanumeric, Rng};
 use regex::Regex;
 use reqwest::header::{HeaderMap, HeaderValue};
 use serde_json::Value;
-use prost::Message;
 use tokio::{
     sync::{mpsc, RwLock},
     time::sleep,
@@ -63,10 +63,7 @@ pub struct KuaishouDanmu {
 impl DanmuProvider for KuaishouDanmu {
     async fn new(cookie: &str, room_id: &str) -> Result<Self, DanmuStreamError> {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            "User-Agent",
-            HeaderValue::from_static(KUAISHOU_USER_AGENT),
-        );
+        headers.insert("User-Agent", HeaderValue::from_static(KUAISHOU_USER_AGENT));
         if !cookie.trim().is_empty() {
             if let Ok(value) = HeaderValue::from_str(cookie) {
                 headers.insert("Cookie", value);
@@ -161,11 +158,9 @@ impl KuaishouDanmu {
             })?
             .to_string();
 
-        let (conn, _) = connect_async(&ws_url).await.map_err(|e| {
-            DanmuStreamError::WebsocketError {
-                err: e.to_string(),
-            }
-        })?;
+        let (conn, _) = connect_async(&ws_url)
+            .await
+            .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
 
         let (write, read) = conn.split();
         *self.write.write().await = Some(write);
@@ -240,7 +235,7 @@ impl KuaishouDanmu {
 
             if let Some(write) = write.write().await.as_mut() {
                 write
-                .send(WsMessage::binary(msg.encode_to_vec()))
+                    .send(WsMessage::binary(msg.encode_to_vec()))
                     .await
                     .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
             }
@@ -265,11 +260,8 @@ impl KuaishouDanmu {
                 continue;
             }
 
-            let socket_msg = SocketMessage::decode(&*data).map_err(|e| {
-                DanmuStreamError::MessageParseError {
-                    err: e.to_string(),
-                }
-            })?;
+            let socket_msg = SocketMessage::decode(&*data)
+                .map_err(|e| DanmuStreamError::MessageParseError { err: e.to_string() })?;
 
             let payload = match CompressionType::try_from(socket_msg.compression_type).ok() {
                 Some(CompressionType::None) | Some(CompressionType::Unknown) => socket_msg.payload,
@@ -283,11 +275,8 @@ impl KuaishouDanmu {
 
             if PayloadType::try_from(socket_msg.payload_type).ok() == Some(PayloadType::ScFeedPush)
             {
-                let feed = ScWebFeedPush::decode(&*payload).map_err(|e| {
-                    DanmuStreamError::MessageParseError {
-                        err: e.to_string(),
-                    }
-                })?;
+                let feed = ScWebFeedPush::decode(&*payload)
+                    .map_err(|e| DanmuStreamError::MessageParseError { err: e.to_string() })?;
                 for comment in feed.comment_feeds {
                     let user = comment.user.unwrap_or_default();
                     let user_id = user.principal_id.parse::<u64>().unwrap_or(0);
@@ -309,9 +298,7 @@ impl KuaishouDanmu {
                         timestamp: ts,
                     };
                     tx.send(DanmuMessageType::DanmuMessage(danmu))
-                        .map_err(|e| DanmuStreamError::WebsocketError {
-                            err: e.to_string(),
-                        })?;
+                        .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
                 }
             }
         }
@@ -363,7 +350,7 @@ impl KuaishouDanmu {
         }
 
         if !self.cookie.is_empty() {
-        let ws_info = self
+            let ws_info = self
                 .client
                 .get("https://live.kuaishou.com/live_api/liveroom/websocketinfo")
                 .query(&[("caver", "2"), ("liveStreamId", live_stream_id.as_str())])
@@ -408,9 +395,8 @@ fn extract_kww(cookie: &str) -> Option<String> {
 }
 
 fn parse_response_data(text: &str) -> Result<Value, DanmuStreamError> {
-    let root: Value = serde_json::from_str(text).map_err(|e| DanmuStreamError::MessageParseError {
-        err: e.to_string(),
-    })?;
+    let root: Value = serde_json::from_str(text)
+        .map_err(|e| DanmuStreamError::MessageParseError { err: e.to_string() })?;
 
     let data = root.get("data").cloned().unwrap_or(root);
 
@@ -457,9 +443,7 @@ fn gunzip(data: &[u8]) -> Result<Vec<u8>, DanmuStreamError> {
     let mut out = Vec::new();
     decoder
         .read_to_end(&mut out)
-        .map_err(|e| DanmuStreamError::MessageParseError {
-            err: e.to_string(),
-        })?;
+        .map_err(|e| DanmuStreamError::MessageParseError { err: e.to_string() })?;
     Ok(out)
 }
 

--- a/src-tauri/crates/recorder/src/core/stream_info.rs
+++ b/src-tauri/crates/recorder/src/core/stream_info.rs
@@ -80,11 +80,7 @@ impl StreamVariant {
             error: format!("Invalid URL: {}", e),
         })?;
 
-        let host = format!(
-            "{}://{}",
-            parsed.scheme(),
-            parsed.host_str().unwrap_or("")
-        );
+        let host = format!("{}://{}", parsed.scheme(), parsed.host_str().unwrap_or(""));
         let base = parsed.path().to_string();
         let extra = parsed.query().unwrap_or("").to_string();
 

--- a/src-tauri/crates/recorder/src/platforms/bilibili/stream_info.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/stream_info.rs
@@ -25,7 +25,10 @@ impl BiliStreamInfo {
         if url_info.extra.is_empty() {
             format!("{}{}", url_info.host, self.inner.base_url)
         } else {
-            format!("{}{}?{}", url_info.host, self.inner.base_url, url_info.extra)
+            format!(
+                "{}{}?{}",
+                url_info.host, self.inner.base_url, url_info.extra
+            )
         }
     }
 }

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -1338,7 +1338,7 @@ impl RecorderManager {
         let params = uri.split('?').nth(1).unwrap_or("");
         let path_segs: Vec<&str> = path.split('/').collect();
 
-        if path_segs.len() != 4 {
+        if path_segs.len() < 4 {
             log::warn!("Invalid request path: {path}");
             return Err(RecorderManagerError::HLSError {
                 err: "Invalid hls path".into(),
@@ -1398,7 +1398,15 @@ impl RecorderManager {
             None
         };
 
-        if path_segs[3] == "playlist.m3u8" {
+        // Check if this is a playlist request
+        // The remaining path after platform/room_id/live_id could be:
+        // - "playlist.m3u8" (4 segments total)
+        // - "some_dir/playlist.m3u8" (5+ segments)
+        // - "segment.ts" (4 segments total)
+        // - "some_dir/segment.ts" (5+ segments)
+        let remaining_path = path_segs[3..].join("/");
+
+        if remaining_path == "playlist.m3u8" || remaining_path.ends_with("/playlist.m3u8") {
             let playlist = self.load_playlist(platform, room_id, live_id).await?;
             let playlist = self.playlist_range(&playlist, range).await?;
             let mut bytes: Vec<u8> = Vec::new();


### PR DESCRIPTION
修复 https://github.com/Xinrea/bili-shadowreplay/issues/246 中出现的问题

## Summary by Sourcery

Support nested HLS playlist paths while performing minor formatting cleanups.

New Features:
- Allow HLS request handler to resolve playlists when the playlist.m3u8 file is located under nested subdirectories in the segment path.

Bug Fixes:
- Relax HLS path validation to handle paths with more than four segments, fixing failures when serving nested HLS segment or playlist URLs.

Enhancements:
- Simplify URL host extraction and WebSocket/HLS error mapping code formatting for improved readability.