### PR TITLE
chore: add unit tests

### DIFF
--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/pack.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/pack.rs
@@ -159,3 +159,80 @@ fn brotli_decode(body: &[u8]) -> Result<(BilibiliPackHeader, Vec<u8>), DanmuStre
 
     Ok((header, buf))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_packet_structure() {
+        let packet = encode("hello", 7);
+        // Total length = 16 (header) + 5 (data) = 21
+        assert_eq!(packet.len(), 21);
+        // First 4 bytes = packet length in big-endian
+        let len = u32::from_be_bytes([packet[0], packet[1], packet[2], packet[3]]);
+        assert_eq!(len, 21);
+        // Header length at bytes 4-5
+        let header_len = u16::from_be_bytes([packet[4], packet[5]]);
+        assert_eq!(header_len, 16);
+        // Version at bytes 6-7
+        let ver = u16::from_be_bytes([packet[6], packet[7]]);
+        assert_eq!(ver, 1);
+        // Op code at bytes 8-11
+        let op = u32::from_be_bytes([packet[8], packet[9], packet[10], packet[11]]);
+        assert_eq!(op, 7);
+        // Data payload
+        assert_eq!(&packet[16..], b"hello");
+    }
+
+    #[test]
+    fn test_encode_empty_string() {
+        let packet = encode("", 2);
+        assert_eq!(packet.len(), 16);
+        let len = u32::from_be_bytes([packet[0], packet[1], packet[2], packet[3]]);
+        assert_eq!(len, 16);
+    }
+
+    #[test]
+    fn test_encode_unicode() {
+        let packet = encode("你好", 7);
+        let data_len = "你好".as_bytes().len(); // 6 bytes for UTF-8
+        assert_eq!(packet.len(), 16 + data_len);
+        assert_eq!(&packet[16..], "你好".as_bytes());
+    }
+
+    #[test]
+    fn test_write_int() {
+        let buf = vec![0u8; 8];
+        let result = write_int(&buf, 2, 0x12345678);
+        assert_eq!(result[2], 0x12);
+        assert_eq!(result[3], 0x34);
+        assert_eq!(result[4], 0x56);
+        assert_eq!(result[5], 0x78);
+        // Other bytes unchanged
+        assert_eq!(result[0], 0);
+        assert_eq!(result[1], 0);
+    }
+
+    #[test]
+    fn test_build_pack_invalid_buffer() {
+        // Buffer too short for header
+        let result = build_pack(&[0u8; 4]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encode_roundtrip_structure() {
+        // Encode a JSON auth message (op=7 is auth)
+        let auth_json = r#"{"uid":0,"roomid":12345}"#;
+        let packet = encode(auth_json, 7);
+
+        // Verify we can parse the header back
+        let (header, body) = pack(&packet).unwrap();
+        assert_eq!(header.pack_len as usize, packet.len());
+        assert_eq!(header.ver, 1);
+        // Body should be the original JSON
+        let body_str = std::str::from_utf8(body).unwrap();
+        assert_eq!(body_str, auth_json);
+    }
+}

--- a/src-tauri/crates/recorder/src/core/mod.rs
+++ b/src-tauri/crates/recorder/src/core/mod.rs
@@ -124,3 +124,132 @@ impl HlsStream {
         self.expire > 0 && (self.expire < chrono::Utc::now().timestamp() + SAFE_EXPIRE)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_stream(host: &str, base: &str, extra: &str, expire: i64) -> HlsStream {
+        HlsStream::new(
+            "test_live".to_string(),
+            host.to_string(),
+            base.to_string(),
+            extra.to_string(),
+            Format::TS,
+            Codec::Avc,
+            expire,
+        )
+    }
+
+    #[test]
+    fn test_hls_stream_index_with_extra() {
+        let s = make_stream(
+            "https://cdn.example.com",
+            "/live/stream.m3u8?",
+            "expire=999&token=abc",
+            0,
+        );
+        assert_eq!(
+            s.index(),
+            "https://cdn.example.com/live/stream.m3u8?expire=999&token=abc"
+        );
+    }
+
+    #[test]
+    fn test_hls_stream_index_without_extra() {
+        let s = make_stream("https://cdn.example.com", "/live/stream.m3u8", "", 0);
+        assert_eq!(s.index(), "https://cdn.example.com/live/stream.m3u8");
+    }
+
+    #[test]
+    fn test_ts_url_absolute() {
+        let s = make_stream(
+            "https://cdn.example.com",
+            "/live/stream.m3u8?",
+            "token=abc",
+            0,
+        );
+        let url = s.ts_url("https://other.com/seg001.ts");
+        assert_eq!(url, "https://other.com/seg001.ts");
+    }
+
+    #[test]
+    fn test_ts_url_relative_no_query() {
+        let s = make_stream(
+            "https://cdn.example.com",
+            "/live/stream.m3u8?",
+            "token=abc",
+            0,
+        );
+        let url = s.ts_url("seg001.ts");
+        assert_eq!(url, "https://cdn.example.com/live/seg001.ts?token=abc");
+    }
+
+    #[test]
+    fn test_ts_url_relative_with_query() {
+        let s = make_stream(
+            "https://cdn.example.com",
+            "/live/stream.m3u8?",
+            "token=abc",
+            0,
+        );
+        let url = s.ts_url("seg001.ts?own_token=xyz");
+        assert_eq!(url, "https://cdn.example.com/live/seg001.ts?own_token=xyz");
+    }
+
+    #[test]
+    fn test_ts_url_relative_no_extra() {
+        let s = make_stream("https://cdn.example.com", "/live/stream.m3u8", "", 0);
+        let url = s.ts_url("seg001.ts");
+        assert_eq!(url, "https://cdn.example.com/live/seg001.ts");
+    }
+
+    #[test]
+    fn test_is_expired_zero_expire() {
+        let s = make_stream("https://cdn.example.com", "/live/stream.m3u8", "", 0);
+        assert!(!s.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_past() {
+        let s = make_stream("https://cdn.example.com", "/live/stream.m3u8", "", 1000);
+        assert!(s.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_far_future() {
+        let far_future = chrono::Utc::now().timestamp() + 100000;
+        let s = make_stream(
+            "https://cdn.example.com",
+            "/live/stream.m3u8",
+            "",
+            far_future,
+        );
+        assert!(!s.is_expired());
+    }
+
+    #[test]
+    fn test_format_display() {
+        assert_eq!(format!("{}", Format::Flv), "Flv");
+        assert_eq!(format!("{}", Format::TS), "TS");
+        assert_eq!(format!("{}", Format::FMP4), "FMP4");
+    }
+
+    #[test]
+    fn test_codec_display() {
+        assert_eq!(format!("{}", Codec::Avc), "Avc");
+        assert_eq!(format!("{}", Codec::Hevc), "Hevc");
+    }
+
+    #[test]
+    fn test_format_equality() {
+        assert_eq!(Format::Flv, Format::Flv);
+        assert_ne!(Format::Flv, Format::TS);
+    }
+
+    #[test]
+    fn test_codec_equality() {
+        assert_eq!(Codec::Avc, Codec::Avc);
+        assert_ne!(Codec::Avc, Codec::Hevc);
+    }
+}

--- a/src-tauri/crates/recorder/src/core/stream_info.rs
+++ b/src-tauri/crates/recorder/src/core/stream_info.rs
@@ -209,3 +209,163 @@ fn extract_host(url: &str) -> Result<String, RecorderError> {
             error: format!("Invalid URL: {}", e),
         })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_quality_ordering() {
+        assert!(Quality::Origin < Quality::BluRay4K);
+        assert!(Quality::BluRay4K < Quality::BluRay);
+        assert!(Quality::BluRay < Quality::UltraHD);
+        assert!(Quality::UltraHD < Quality::HD);
+        assert!(Quality::HD < Quality::SD);
+        assert!(Quality::SD < Quality::Smooth);
+    }
+
+    #[test]
+    fn test_stream_variant_to_flv_url_ok() {
+        let sv = StreamVariant {
+            url: "rtmp://live.example.com/stream".to_string(),
+            format: Format::FLV,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: Some(5000),
+        };
+        assert_eq!(sv.to_flv_url().unwrap(), "rtmp://live.example.com/stream");
+    }
+
+    #[test]
+    fn test_stream_variant_to_flv_url_rtmp() {
+        let sv = StreamVariant {
+            url: "rtmp://live.example.com/stream".to_string(),
+            format: Format::RTMP,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: None,
+        };
+        assert!(sv.to_flv_url().is_ok());
+    }
+
+    #[test]
+    fn test_stream_variant_to_flv_url_hls_fails() {
+        let sv = StreamVariant {
+            url: "https://cdn.example.com/live/stream.m3u8".to_string(),
+            format: Format::HLS,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: None,
+        };
+        assert!(sv.to_flv_url().is_err());
+    }
+
+    #[test]
+    fn test_stream_variant_to_hls_stream() {
+        let sv = StreamVariant {
+            url: "https://cdn.example.com/live/stream.m3u8?expire=9999999999&token=abc".to_string(),
+            format: Format::HLS,
+            codec: Codec::AVC,
+            quality: Quality::BluRay,
+            bitrate: Some(3000),
+        };
+        let stream = sv.to_hls_stream("live_123".to_string(), None).unwrap();
+        let index = stream.index();
+        assert!(index.contains("cdn.example.com"));
+        assert!(index.contains("stream.m3u8"));
+    }
+
+    #[test]
+    fn test_stream_variant_to_hls_stream_not_hls() {
+        let sv = StreamVariant {
+            url: "rtmp://live.example.com/stream".to_string(),
+            format: Format::FLV,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: None,
+        };
+        assert!(sv.to_hls_stream("live_123".to_string(), None).is_err());
+    }
+
+    #[test]
+    fn test_stream_variant_to_hls_stream_with_cdn_node() {
+        let sv = StreamVariant {
+            url: "https://cdn1.example.com/live/stream.m3u8?token=abc".to_string(),
+            format: Format::HLS,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: None,
+        };
+        let cdn = CdnNode {
+            host: "cdn2.example.com".to_string(),
+            priority: 1,
+        };
+        let stream = sv
+            .to_hls_stream("live_123".to_string(), Some(&cdn))
+            .unwrap();
+        let index = stream.index();
+        assert!(index.contains("cdn2.example.com"));
+    }
+
+    #[test]
+    fn test_stream_variant_to_recorder_type_hls() {
+        let sv = StreamVariant {
+            url: "https://cdn.example.com/live/stream.m3u8?token=abc".to_string(),
+            format: Format::HLS,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: None,
+        };
+        let rt = sv.to_recorder_type("live_123".to_string(), None).unwrap();
+        assert!(matches!(rt, RecorderType::Hls(_)));
+    }
+
+    #[test]
+    fn test_stream_variant_to_recorder_type_flv() {
+        let sv = StreamVariant {
+            url: "rtmp://live.example.com/stream".to_string(),
+            format: Format::FLV,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: None,
+        };
+        let rt = sv.to_recorder_type("live_123".to_string(), None).unwrap();
+        assert!(matches!(rt, RecorderType::Flv(_)));
+    }
+
+    #[test]
+    fn test_platform_type_as_str() {
+        assert_eq!(PlatformType::Bilibili.as_str(), "bilibili");
+        assert_eq!(PlatformType::Douyin.as_str(), "douyin");
+        assert_eq!(PlatformType::Kuaishou.as_str(), "kuaishou");
+        assert_eq!(PlatformType::Huya.as_str(), "huya");
+        assert_eq!(PlatformType::TikTok.as_str(), "tiktok");
+    }
+
+    #[test]
+    fn test_extract_host() {
+        assert_eq!(
+            extract_host("https://cdn.example.com/path").unwrap(),
+            "cdn.example.com"
+        );
+        assert!(extract_host("not-a-url").is_err());
+    }
+
+    #[test]
+    fn test_quality_equality() {
+        assert_eq!(Quality::Origin, Quality::Origin);
+        assert_ne!(Quality::Origin, Quality::HD);
+    }
+
+    #[test]
+    fn test_format_equality() {
+        assert_eq!(Format::HLS, Format::HLS);
+        assert_ne!(Format::HLS, Format::FLV);
+    }
+
+    #[test]
+    fn test_codec_equality() {
+        assert_eq!(Codec::AVC, Codec::AVC);
+        assert_ne!(Codec::AVC, Codec::HEVC);
+    }
+}

--- a/src-tauri/crates/recorder/src/entry.rs
+++ b/src-tauri/crates/recorder/src/entry.rs
@@ -8,7 +8,7 @@ use tokio::{
 
 const ENTRY_FILE_NAME: &str = "entries.log";
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TsEntry {
     pub url: String,
     pub sequence: u64,
@@ -246,5 +246,139 @@ pub struct Range {
 impl Range {
     pub fn is_in(&self, v: f32) -> bool {
         v >= self.x && v <= self.y
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ts_entry_from_valid() {
+        let line = "https://example.com/seg.ts|42|5.0|1024|1700000000|false";
+        let entry = TsEntry::from(line).unwrap();
+        assert_eq!(entry.url, "https://example.com/seg.ts");
+        assert_eq!(entry.sequence, 42);
+        assert!((entry.length - 5.0).abs() < f64::EPSILON);
+        assert_eq!(entry.size, 1024);
+        assert_eq!(entry.ts, 1700000000);
+        assert!(!entry.is_header);
+    }
+
+    #[test]
+    fn test_ts_entry_from_header() {
+        let line = "https://example.com/init.mp4|0|0.0|512|1700000000|true";
+        let entry = TsEntry::from(line).unwrap();
+        assert!(entry.is_header);
+    }
+
+    #[test]
+    fn test_ts_entry_from_invalid_field_count() {
+        let line = "a|b|c";
+        let result = TsEntry::from(line);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("expected 6 fields"));
+    }
+
+    #[test]
+    fn test_ts_entry_from_invalid_number() {
+        let line = "url|notanumber|5.0|1024|1700000000|false";
+        let result = TsEntry::from(line);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Failed to parse sequence"));
+    }
+
+    #[test]
+    fn test_ts_seconds_milliseconds() {
+        let entry = TsEntry {
+            url: "test".to_string(),
+            sequence: 1,
+            length: 5.0,
+            size: 100,
+            ts: 1700000000000, // ms timestamp
+            is_header: false,
+        };
+        assert_eq!(entry.ts_seconds(), 1700000000);
+    }
+
+    #[test]
+    fn test_ts_seconds_already_seconds() {
+        let entry = TsEntry {
+            url: "test".to_string(),
+            sequence: 1,
+            length: 5.0,
+            size: 100,
+            ts: 1700000000, // already in seconds
+            is_header: false,
+        };
+        assert_eq!(entry.ts_seconds(), 1700000000);
+    }
+
+    #[test]
+    fn test_to_segment_normal() {
+        let entry = TsEntry {
+            url: "segment_001.ts".to_string(),
+            sequence: 1,
+            length: 5.1234,
+            size: 100,
+            ts: 1700000000,
+            is_header: false,
+        };
+        let seg = entry.to_segment();
+        assert!(seg.contains("#EXTINF:5.1234,"));
+        assert!(seg.contains("segment_001.ts"));
+    }
+
+    #[test]
+    fn test_to_segment_header_returns_empty() {
+        let entry = TsEntry {
+            url: "init.mp4".to_string(),
+            sequence: 0,
+            length: 0.0,
+            size: 100,
+            ts: 1700000000,
+            is_header: true,
+        };
+        assert_eq!(entry.to_segment(), "");
+    }
+
+    #[test]
+    fn test_date_time_format() {
+        let entry = TsEntry {
+            url: "test".to_string(),
+            sequence: 1,
+            length: 5.0,
+            size: 100,
+            ts: 1700000000,
+            is_header: false,
+        };
+        let dt = entry.date_time();
+        assert!(dt.starts_with("#EXT-X-PROGRAM-DATE-TIME:"));
+        assert!(dt.contains("2023"));
+    }
+
+    #[test]
+    fn test_range_is_in() {
+        let r = Range { x: 1.0, y: 5.0 };
+        assert!(r.is_in(3.0));
+        assert!(r.is_in(1.0));
+        assert!(r.is_in(5.0));
+        assert!(!r.is_in(0.9));
+        assert!(!r.is_in(5.1));
+    }
+
+    #[test]
+    fn test_ts_entry_display() {
+        let entry = TsEntry {
+            url: "seg.ts".to_string(),
+            sequence: 1,
+            length: 5.0,
+            size: 1024,
+            ts: 1700000000,
+            is_header: false,
+        };
+        let display = format!("{}", entry);
+        assert!(display.contains("seg.ts"));
+        assert!(display.contains("1024"));
     }
 }

--- a/src-tauri/crates/recorder/src/errors.rs
+++ b/src-tauri/crates/recorder/src/errors.rs
@@ -81,3 +81,102 @@ pub enum RecorderError {
     #[error("Not live")]
     NotLive,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_display_messages() {
+        let e = RecorderError::IndexNotFound {
+            url: "https://example.com".to_string(),
+        };
+        assert_eq!(format!("{}", e), "Index not found: https://example.com");
+
+        let e = RecorderError::EmptyCache;
+        assert_eq!(format!("{}", e), "Cache is empty");
+
+        let e = RecorderError::NoStreamAvailable;
+        assert_eq!(format!("{}", e), "No available stream provided");
+
+        let e = RecorderError::NoRoomInfo;
+        assert_eq!(format!("{}", e), "No room info provided");
+
+        let e = RecorderError::EmptyHeader;
+        assert_eq!(format!("{}", e), "Header url is empty");
+
+        let e = RecorderError::InvalidTimestamp;
+        assert_eq!(format!("{}", e), "Header timestamp is invalid");
+
+        let e = RecorderError::InvalidCookies;
+        assert_eq!(format!("{}", e), "Invalid cookies");
+
+        let e = RecorderError::InvalidValue;
+        assert_eq!(format!("{}", e), "Invalid value");
+
+        let e = RecorderError::InvalidResponse;
+        assert_eq!(format!("{}", e), "Invalid response");
+
+        let e = RecorderError::UploadCancelled;
+        assert_eq!(format!("{}", e), "Upload cancelled");
+
+        let e = RecorderError::SecurityControlError;
+        assert_eq!(format!("{}", e), "Security control error");
+
+        let e = RecorderError::UpdateTimeout;
+        assert_eq!(format!("{}", e), "Update timeout");
+
+        let e = RecorderError::UnsupportedStream;
+        assert_eq!(format!("{}", e), "Unsupported stream");
+
+        let e = RecorderError::EmptyRecord;
+        assert_eq!(format!("{}", e), "Empty record");
+
+        let e = RecorderError::NotLive;
+        assert_eq!(format!("{}", e), "Not live");
+    }
+
+    #[test]
+    fn test_error_display_with_fields() {
+        let e = RecorderError::ArchiveInUse {
+            live_id: "abc123".to_string(),
+        };
+        assert!(format!("{}", e).contains("abc123"));
+
+        let e = RecorderError::M3u8ParseFailed {
+            content: "bad content".to_string(),
+        };
+        assert!(format!("{}", e).contains("bad content"));
+
+        let e = RecorderError::StreamExpired { expire: 1700000000 };
+        assert!(format!("{}", e).contains("1700000000"));
+
+        let e = RecorderError::ApiError {
+            error: "rate limited".to_string(),
+        };
+        assert!(format!("{}", e).contains("rate limited"));
+
+        let e = RecorderError::FfmpegError("codec error".to_string());
+        assert!(format!("{}", e).contains("codec error"));
+
+        let e = RecorderError::SubtitleNotFound {
+            live_id: "live1".to_string(),
+        };
+        assert!(format!("{}", e).contains("live1"));
+
+        let e = RecorderError::UploadError {
+            err: "timeout".to_string(),
+        };
+        assert!(format!("{}", e).contains("timeout"));
+
+        let e = RecorderError::JsRuntimeError("eval failed".to_string());
+        assert!(format!("{}", e).contains("eval failed"));
+    }
+
+    #[test]
+    fn test_error_from_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let e: RecorderError = io_err.into();
+        assert!(format!("{}", e).contains("file not found"));
+    }
+}

--- a/src-tauri/crates/recorder/src/lib.rs
+++ b/src-tauri/crates/recorder/src/lib.rs
@@ -237,3 +237,107 @@ impl Display for CachePath {
         write!(f, "{}", self.full_path().display())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_path_relative_without_filename() {
+        let cp = CachePath::new(
+            PathBuf::from("/cache"),
+            PlatformType::BiliBili,
+            "12345",
+            "live_001",
+        );
+        assert_eq!(cp.relative_path(), PathBuf::from("bilibili/12345/live_001"));
+    }
+
+    #[test]
+    fn test_cache_path_relative_with_filename() {
+        let cp = CachePath::new(
+            PathBuf::from("/cache"),
+            PlatformType::BiliBili,
+            "12345",
+            "live_001",
+        )
+        .with_filename("video.ts");
+        assert_eq!(
+            cp.relative_path(),
+            PathBuf::from("bilibili/12345/live_001/video.ts")
+        );
+    }
+
+    #[test]
+    fn test_cache_path_full_path() {
+        let cp = CachePath::new(
+            PathBuf::from("/cache"),
+            PlatformType::Douyin,
+            "room1",
+            "live1",
+        );
+        assert_eq!(cp.full_path(), PathBuf::from("/cache/douyin/room1/live1"));
+    }
+
+    #[test]
+    fn test_cache_path_full_path_with_filename() {
+        let cp = CachePath::new(
+            PathBuf::from("/cache"),
+            PlatformType::Huya,
+            "room1",
+            "live1",
+        )
+        .with_filename("seg.ts");
+        assert_eq!(
+            cp.full_path(),
+            PathBuf::from("/cache/huya/room1/live1/seg.ts")
+        );
+    }
+
+    #[test]
+    fn test_cache_path_with_filename_sanitizes() {
+        let cp = CachePath::new(
+            PathBuf::from("/cache"),
+            PlatformType::BiliBili,
+            "12345",
+            "live_001",
+        )
+        .with_filename("bad/file:name?.ts");
+        let rel = cp.relative_path();
+        let filename = rel.file_name().unwrap().to_str().unwrap();
+        // sanitize_filename should remove invalid chars
+        assert!(!filename.contains('/'));
+        assert!(!filename.contains(':'));
+        assert!(!filename.contains('?'));
+    }
+
+    #[test]
+    fn test_cache_path_display() {
+        let cp = CachePath::new(
+            PathBuf::from("/cache"),
+            PlatformType::TikTok,
+            "room",
+            "live",
+        );
+        let display = format!("{}", cp);
+        assert!(display.contains("tiktok"));
+        assert!(display.contains("room"));
+        assert!(display.contains("live"));
+    }
+
+    #[test]
+    fn test_room_info_default() {
+        let ri = RoomInfo::default();
+        assert_eq!(ri.platform, "");
+        assert_eq!(ri.room_id, "");
+        assert!(!ri.status);
+    }
+
+    #[test]
+    fn test_user_info_default() {
+        let ui = UserInfo::default();
+        assert_eq!(ui.user_id, "");
+        assert_eq!(ui.user_name, "");
+        assert_eq!(ui.user_avatar, "");
+    }
+}

--- a/src-tauri/crates/recorder/src/platforms/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/mod.rs
@@ -54,3 +54,89 @@ impl Hash for PlatformType {
         std::mem::discriminant(self).hash(state);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_platform_type_as_str() {
+        assert_eq!(PlatformType::BiliBili.as_str(), "bilibili");
+        assert_eq!(PlatformType::Douyin.as_str(), "douyin");
+        assert_eq!(PlatformType::Huya.as_str(), "huya");
+        assert_eq!(PlatformType::Youtube.as_str(), "youtube");
+        assert_eq!(PlatformType::Kuaishou.as_str(), "kuaishou");
+        assert_eq!(PlatformType::Xiaohongshu.as_str(), "xiaohongshu");
+        assert_eq!(PlatformType::TikTok.as_str(), "tiktok");
+        assert_eq!(PlatformType::Weibo.as_str(), "weibo");
+    }
+
+    #[test]
+    fn test_platform_type_from_str() {
+        assert_eq!(
+            PlatformType::from_str("bilibili"),
+            Ok(PlatformType::BiliBili)
+        );
+        assert_eq!(PlatformType::from_str("douyin"), Ok(PlatformType::Douyin));
+        assert_eq!(PlatformType::from_str("huya"), Ok(PlatformType::Huya));
+        assert_eq!(PlatformType::from_str("youtube"), Ok(PlatformType::Youtube));
+        assert_eq!(
+            PlatformType::from_str("kuaishou"),
+            Ok(PlatformType::Kuaishou)
+        );
+        assert_eq!(
+            PlatformType::from_str("xiaohongshu"),
+            Ok(PlatformType::Xiaohongshu)
+        );
+        assert_eq!(PlatformType::from_str("tiktok"), Ok(PlatformType::TikTok));
+        assert_eq!(PlatformType::from_str("weibo"), Ok(PlatformType::Weibo));
+    }
+
+    #[test]
+    fn test_platform_type_from_str_invalid() {
+        assert!(PlatformType::from_str("invalid").is_err());
+        assert!(PlatformType::from_str("").is_err());
+        assert!(PlatformType::from_str("BiliBili").is_err()); // case sensitive
+    }
+
+    #[test]
+    fn test_platform_type_roundtrip() {
+        let platforms = [
+            PlatformType::BiliBili,
+            PlatformType::Douyin,
+            PlatformType::Huya,
+            PlatformType::Youtube,
+            PlatformType::Kuaishou,
+            PlatformType::Xiaohongshu,
+            PlatformType::TikTok,
+            PlatformType::Weibo,
+        ];
+        for p in platforms {
+            assert_eq!(PlatformType::from_str(p.as_str()), Ok(p));
+        }
+    }
+
+    #[test]
+    fn test_platform_type_hash() {
+        let mut set = HashSet::new();
+        set.insert(PlatformType::BiliBili);
+        set.insert(PlatformType::Douyin);
+        set.insert(PlatformType::BiliBili); // duplicate
+        assert_eq!(set.len(), 2);
+    }
+
+    #[test]
+    fn test_platform_type_equality() {
+        assert_eq!(PlatformType::BiliBili, PlatformType::BiliBili);
+        assert_ne!(PlatformType::BiliBili, PlatformType::Douyin);
+    }
+
+    #[test]
+    fn test_platform_type_clone() {
+        let p = PlatformType::Huya;
+        let p2 = p;
+        assert_eq!(p, p2);
+    }
+}

--- a/src-tauri/src/danmu2ass.rs
+++ b/src-tauri/src/danmu2ass.rs
@@ -241,3 +241,117 @@ fn normal_danmaku() -> impl FnMut(f64, f64, f64, bool) -> Option<DanmakuPosition
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_time_zero() {
+        assert_eq!(format_time(0.0), "0:00:00.00");
+    }
+
+    #[test]
+    fn test_format_time_seconds() {
+        assert_eq!(format_time(5.5), "0:00:05.50");
+    }
+
+    #[test]
+    fn test_format_time_minutes() {
+        assert_eq!(format_time(65.25), "0:01:05.25");
+    }
+
+    #[test]
+    fn test_format_time_hours() {
+        assert_eq!(format_time(3661.99), "1:01:01.99");
+    }
+
+    #[test]
+    fn test_escape_text_backslash() {
+        assert_eq!(escape_text("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn test_escape_text_braces() {
+        assert_eq!(escape_text("{test}"), "｛test｝");
+    }
+
+    #[test]
+    fn test_escape_text_carriage_return() {
+        // \r is removed, \n becomes \N (ASS line break)
+        assert_eq!(escape_text("line\r\n"), "line\\N");
+    }
+
+    #[test]
+    fn test_escape_text_plain() {
+        assert_eq!(escape_text("hello world"), "hello world");
+    }
+
+    #[test]
+    fn test_danmu2ass_options_default() {
+        let opts = Danmu2AssOptions::default();
+        assert_eq!(opts.font_size, 36.0);
+        assert_eq!(opts.opacity, 0.8);
+    }
+
+    #[test]
+    fn test_danmu_to_ass_empty() {
+        let result = danmu_to_ass(vec![], Danmu2AssOptions::default());
+        assert!(result.contains("[Script Info]"));
+        assert!(result.contains("[V4+ Styles]"));
+        assert!(result.contains("[Events]"));
+    }
+
+    #[test]
+    fn test_danmu_to_ass_with_entries() {
+        let danmus = vec![
+            DanmuEntry {
+                ts: 1000,
+                content: "hello".to_string(),
+            },
+            DanmuEntry {
+                ts: 5000,
+                content: "world".to_string(),
+            },
+        ];
+        let result = danmu_to_ass(danmus, Danmu2AssOptions::default());
+        assert!(result.contains("[Events]"));
+        assert!(result.contains("hello"));
+        assert!(result.contains("world"));
+    }
+
+    #[test]
+    fn test_danmu_to_ass_opacity() {
+        // opacity 1.0 -> alpha 0x00
+        let result = danmu_to_ass(
+            vec![],
+            Danmu2AssOptions {
+                font_size: 36.0,
+                opacity: 1.0,
+            },
+        );
+        assert!(result.contains("&H00FFFFFF"));
+
+        // opacity 0.0 -> alpha 0xFF
+        let result = danmu_to_ass(
+            vec![],
+            Danmu2AssOptions {
+                font_size: 36.0,
+                opacity: 0.0,
+            },
+        );
+        assert!(result.contains("&HFFFFFFFF"));
+    }
+
+    #[test]
+    fn test_danmu_to_ass_font_size() {
+        let result = danmu_to_ass(
+            vec![],
+            Danmu2AssOptions {
+                font_size: 48.0,
+                opacity: 0.8,
+            },
+        );
+        assert!(result.contains(",48,"));
+    }
+}

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -76,6 +76,46 @@ pub async fn handle_ffmpeg_process(
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_concat_path_plain() {
+        let path = Path::new("/tmp/video.mp4");
+        assert_eq!(escape_concat_path(path), "/tmp/video.mp4");
+    }
+
+    #[test]
+    fn test_escape_concat_path_single_quote() {
+        let path = Path::new("/tmp/it's a video.mp4");
+        assert_eq!(escape_concat_path(path), "/tmp/it'\\''s a video.mp4");
+    }
+
+    #[test]
+    fn test_escape_concat_path_square_brackets() {
+        let path = Path::new("/tmp/video [1].mp4");
+        assert_eq!(escape_concat_path(path), "/tmp/video [1].mp4");
+    }
+
+    #[test]
+    fn test_escape_concat_path_spaces() {
+        let path = Path::new("/tmp/my video file.mp4");
+        assert_eq!(escape_concat_path(path), "/tmp/my video file.mp4");
+    }
+
+    #[tokio::test]
+    async fn test_random_filename() {
+        let name1 = random_filename().await;
+        let name2 = random_filename().await;
+        assert!(!name1.is_empty());
+        assert!(!name2.is_empty());
+        // Should be hex strings
+        assert!(name1.chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(name2.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+}
+
 pub async fn concat_videos(
     reporter: Option<&impl ProgressReporterTrait>,
     videos: &[PathBuf],

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -1479,4 +1479,84 @@ mod tests {
         assert!(chunk_dir.to_string_lossy().contains("_chunks"));
         assert!(chunk_dir.to_string_lossy().contains("test"));
     }
+
+    #[test]
+    fn test_range_is_in_inside() {
+        let r = Range {
+            start: 1.0,
+            end: 5.0,
+        };
+        assert!(r.is_in(3.0));
+    }
+
+    #[test]
+    fn test_range_is_in_at_boundaries() {
+        let r = Range {
+            start: 1.0,
+            end: 5.0,
+        };
+        assert!(r.is_in(1.0));
+        assert!(r.is_in(5.0));
+    }
+
+    #[test]
+    fn test_range_is_in_outside() {
+        let r = Range {
+            start: 1.0,
+            end: 5.0,
+        };
+        assert!(!r.is_in(0.9));
+        assert!(!r.is_in(5.1));
+    }
+
+    #[test]
+    fn test_video_metadata_equality() {
+        let m1 = VideoMetadata {
+            duration: 10.0,
+            width: 1920,
+            height: 1080,
+            video_codec: "h264".to_string(),
+            audio_codec: "aac".to_string(),
+        };
+        let m2 = m1.clone();
+        assert_eq!(m1, m2);
+    }
+
+    #[test]
+    fn test_video_metadata_different_resolution() {
+        let m1 = VideoMetadata {
+            duration: 10.0,
+            width: 1920,
+            height: 1080,
+            video_codec: "h264".to_string(),
+            audio_codec: "aac".to_string(),
+        };
+        let m2 = VideoMetadata {
+            duration: 10.0,
+            width: 1280,
+            height: 720,
+            video_codec: "h264".to_string(),
+            audio_codec: "aac".to_string(),
+        };
+        assert_ne!(m1, m2);
+    }
+
+    #[test]
+    fn test_video_metadata_different_codec() {
+        let m1 = VideoMetadata {
+            duration: 10.0,
+            width: 1920,
+            height: 1080,
+            video_codec: "h264".to_string(),
+            audio_codec: "aac".to_string(),
+        };
+        let m2 = VideoMetadata {
+            duration: 10.0,
+            width: 1920,
+            height: 1080,
+            video_codec: "hevc".to_string(),
+            audio_codec: "aac".to_string(),
+        };
+        assert_ne!(m1, m2);
+    }
 }

--- a/src-tauri/src/handlers/account.rs
+++ b/src-tauri/src/handlers/account.rs
@@ -266,4 +266,33 @@ mod tests {
         let uid = get_item_from_cookies("unknown", cookies).unwrap_err();
         assert_eq!(uid, "Invalid cookies: missing unknown");
     }
+
+    #[test]
+    fn test_get_item_from_cookies_empty() {
+        let result = get_item_from_cookies("key", "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_item_from_cookies_no_value() {
+        let cookies = "key1=; key2=value2";
+        let result = get_item_from_cookies("key1", cookies).unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_get_item_from_cookies_special_chars() {
+        let cookies = "token=abc%3Ddef; session=xyz123";
+        let result = get_item_from_cookies("token", cookies).unwrap();
+        assert_eq!(result, "abc%3Ddef");
+    }
+
+    #[test]
+    fn test_get_item_from_cookies_whitespace_handling() {
+        let cookies = "  key1=val1  ;  key2=val2  ";
+        let result = get_item_from_cookies("key1", cookies).unwrap();
+        assert_eq!(result, "val1");
+        let result = get_item_from_cookies("key2", cookies).unwrap();
+        assert_eq!(result, "val2");
+    }
 }

--- a/src-tauri/src/jianying/mod.rs
+++ b/src-tauri/src/jianying/mod.rs
@@ -157,3 +157,54 @@ fn escape_xml(s: &str) -> String {
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_escape_xml_ampersand() {
+        assert_eq!(escape_xml("a&b"), "a&amp;b");
+    }
+
+    #[test]
+    fn test_escape_xml_angle_brackets() {
+        assert_eq!(escape_xml("<tag>"), "&lt;tag&gt;");
+    }
+
+    #[test]
+    fn test_escape_xml_quotes() {
+        assert_eq!(escape_xml(r#"say "hello""#), "say &quot;hello&quot;");
+        assert_eq!(escape_xml("it's"), "it&apos;s");
+    }
+
+    #[test]
+    fn test_escape_xml_no_special_chars() {
+        assert_eq!(escape_xml("plain text 123"), "plain text 123");
+    }
+
+    #[test]
+    fn test_escape_xml_all_special() {
+        assert_eq!(escape_xml(r#"<a href="x">&'y'"#), "&lt;a href=&quot;x&quot;&gt;&amp;&apos;y&apos;");
+    }
+
+    #[test]
+    fn test_escape_xml_empty() {
+        assert_eq!(escape_xml(""), "");
+    }
+
+    #[test]
+    fn test_video_clip_struct() {
+        let clip = VideoClip {
+            file_path: PathBuf::from("/tmp/test.mp4"),
+            start_time: 10.0,
+            duration: 5.0,
+            width: 1920,
+            height: 1080,
+        };
+        assert_eq!(clip.start_time, 10.0);
+        assert_eq!(clip.duration, 5.0);
+        assert_eq!(clip.width, 1920);
+        assert_eq!(clip.height, 1080);
+    }
+}

--- a/src-tauri/src/subtitle_generator/mod.rs
+++ b/src-tauri/src/subtitle_generator/mod.rs
@@ -115,3 +115,253 @@ pub trait SubtitleGenerator {
         language_hint: &str,
     ) -> Result<GenerateResult, String>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subtitle_generator_type_as_str() {
+        assert_eq!(SubtitleGeneratorType::Whisper.as_str(), "whisper");
+        assert_eq!(
+            SubtitleGeneratorType::WhisperOnline.as_str(),
+            "whisper_online"
+        );
+        assert_eq!(SubtitleGeneratorType::PowerLive.as_str(), "powerlive");
+    }
+
+    #[test]
+    fn test_subtitle_generator_type_from_str() {
+        assert_eq!(
+            SubtitleGeneratorType::from_str("whisper"),
+            Some(SubtitleGeneratorType::Whisper)
+        );
+        assert_eq!(
+            SubtitleGeneratorType::from_str("whisper_online"),
+            Some(SubtitleGeneratorType::WhisperOnline)
+        );
+        assert_eq!(
+            SubtitleGeneratorType::from_str("powerlive"),
+            Some(SubtitleGeneratorType::PowerLive)
+        );
+        assert_eq!(SubtitleGeneratorType::from_str("unknown"), None);
+        assert_eq!(SubtitleGeneratorType::from_str(""), None);
+    }
+
+    #[test]
+    fn test_subtitle_generator_type_roundtrip() {
+        for t in [
+            SubtitleGeneratorType::Whisper,
+            SubtitleGeneratorType::WhisperOnline,
+            SubtitleGeneratorType::PowerLive,
+        ] {
+            assert_eq!(SubtitleGeneratorType::from_str(t.as_str()), Some(t));
+        }
+    }
+
+    #[test]
+    fn test_add_offset_no_overflow() {
+        let time = srtparse::Time {
+            hours: 0,
+            minutes: 1,
+            seconds: 30,
+            milliseconds: 500,
+        };
+        let result = add_offset(&time, 10);
+        assert_eq!(result.hours, 0);
+        assert_eq!(result.minutes, 1);
+        assert_eq!(result.seconds, 40);
+        assert_eq!(result.milliseconds, 500);
+    }
+
+    #[test]
+    fn test_add_offset_seconds_overflow() {
+        let time = srtparse::Time {
+            hours: 0,
+            minutes: 0,
+            seconds: 50,
+            milliseconds: 0,
+        };
+        let result = add_offset(&time, 15);
+        assert_eq!(result.hours, 0);
+        assert_eq!(result.minutes, 1);
+        assert_eq!(result.seconds, 5);
+        assert_eq!(result.milliseconds, 0);
+    }
+
+    #[test]
+    fn test_add_offset_minutes_overflow() {
+        let time = srtparse::Time {
+            hours: 0,
+            minutes: 59,
+            seconds: 50,
+            milliseconds: 0,
+        };
+        let result = add_offset(&time, 15);
+        assert_eq!(result.hours, 1);
+        assert_eq!(result.minutes, 0);
+        assert_eq!(result.seconds, 5);
+        assert_eq!(result.milliseconds, 0);
+    }
+
+    #[test]
+    fn test_add_offset_large() {
+        let time = srtparse::Time {
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+            milliseconds: 100,
+        };
+        let result = add_offset(&time, 3661); // 1h 1m 1s
+        assert_eq!(result.hours, 1);
+        assert_eq!(result.minutes, 1);
+        assert_eq!(result.seconds, 1);
+        assert_eq!(result.milliseconds, 100);
+    }
+
+    #[test]
+    fn test_add_offset_zero() {
+        let time = srtparse::Time {
+            hours: 2,
+            minutes: 30,
+            seconds: 45,
+            milliseconds: 999,
+        };
+        let result = add_offset(&time, 0);
+        assert_eq!(result.hours, 2);
+        assert_eq!(result.minutes, 30);
+        assert_eq!(result.seconds, 45);
+        assert_eq!(result.milliseconds, 999);
+    }
+
+    #[test]
+    fn test_item_to_srt_format() {
+        let item = srtparse::Item {
+            pos: 1,
+            start_time: srtparse::Time {
+                hours: 0,
+                minutes: 1,
+                seconds: 2,
+                milliseconds: 300,
+            },
+            end_time: srtparse::Time {
+                hours: 0,
+                minutes: 1,
+                seconds: 5,
+                milliseconds: 600,
+            },
+            text: "Hello world".to_string(),
+        };
+        let result = item_to_srt(&item);
+        assert_eq!(result, "1\n00:01:02,300 --> 00:01:05,600\nHello world\n\n");
+    }
+
+    #[test]
+    fn test_item_to_srt_zero_padding() {
+        let item = srtparse::Item {
+            pos: 42,
+            start_time: srtparse::Time {
+                hours: 1,
+                minutes: 2,
+                seconds: 3,
+                milliseconds: 4,
+            },
+            end_time: srtparse::Time {
+                hours: 10,
+                minutes: 20,
+                seconds: 30,
+                milliseconds: 40,
+            },
+            text: "Test".to_string(),
+        };
+        let result = item_to_srt(&item);
+        assert!(result.contains("01:02:03,004"));
+        assert!(result.contains("10:20:30,040"));
+    }
+
+    #[test]
+    fn test_generate_result_concat() {
+        let mut result1 = GenerateResult {
+            generator_type: SubtitleGeneratorType::Whisper,
+            subtitle_id: "1".to_string(),
+            subtitle_content: vec![srtparse::Item {
+                pos: 1,
+                start_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 0,
+                    milliseconds: 0,
+                },
+                end_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 5,
+                    milliseconds: 0,
+                },
+                text: "First".to_string(),
+            }],
+        };
+        let result2 = GenerateResult {
+            generator_type: SubtitleGeneratorType::Whisper,
+            subtitle_id: "2".to_string(),
+            subtitle_content: vec![srtparse::Item {
+                pos: 1,
+                start_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 0,
+                    milliseconds: 0,
+                },
+                end_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 3,
+                    milliseconds: 0,
+                },
+                text: "Second".to_string(),
+            }],
+        };
+
+        result1.concat(&result2, 10);
+        assert_eq!(result1.subtitle_content.len(), 2);
+        assert_eq!(result1.subtitle_content[1].pos, 2);
+        assert_eq!(result1.subtitle_content[1].start_time.seconds, 10);
+        assert_eq!(result1.subtitle_content[1].end_time.seconds, 13);
+        assert_eq!(result1.subtitle_content[1].text, "Second");
+    }
+
+    #[test]
+    fn test_generate_result_concat_empty_base() {
+        let mut result1 = GenerateResult {
+            generator_type: SubtitleGeneratorType::Whisper,
+            subtitle_id: "1".to_string(),
+            subtitle_content: vec![],
+        };
+        let result2 = GenerateResult {
+            generator_type: SubtitleGeneratorType::Whisper,
+            subtitle_id: "2".to_string(),
+            subtitle_content: vec![srtparse::Item {
+                pos: 1,
+                start_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 5,
+                    milliseconds: 0,
+                },
+                end_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 10,
+                    milliseconds: 0,
+                },
+                text: "Only".to_string(),
+            }],
+        };
+
+        result1.concat(&result2, 60);
+        assert_eq!(result1.subtitle_content.len(), 1);
+        assert_eq!(result1.subtitle_content[0].pos, 1);
+        assert_eq!(result1.subtitle_content[0].start_time.minutes, 1);
+        assert_eq!(result1.subtitle_content[0].start_time.seconds, 5);
+    }
+}

--- a/src-tauri/src/webhook/events.rs
+++ b/src-tauri/src/webhook/events.rs
@@ -46,3 +46,79 @@ pub fn new_webhook_event(event_type: &str, payload: Payload) -> WebhookEvent {
         timestamp: chrono::Utc::now().timestamp(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_type_constants() {
+        assert_eq!(CLIP_GENERATED, "clip.generated");
+        assert_eq!(CLIP_DELETED, "clip.deleted");
+        assert_eq!(RECORD_STARTED, "record.started");
+        assert_eq!(RECORD_ENDED, "record.ended");
+        assert_eq!(LIVE_STARTED, "live.started");
+        assert_eq!(LIVE_ENDED, "live.ended");
+        assert_eq!(ARCHIVE_DELETED, "archive.deleted");
+        assert_eq!(RECORDER_REMOVED, "recorder.removed");
+        assert_eq!(RECORDER_ADDED, "recorder.added");
+    }
+
+    #[test]
+    fn test_new_webhook_event() {
+        let payload = Payload::Room(RecorderInfo {
+            room_info: recorder::RoomInfo::default(),
+            user_info: recorder::UserInfo::default(),
+            platform_live_id: "plid".to_string(),
+            live_id: "lid".to_string(),
+            recording: true,
+            enabled: true,
+        });
+        let event = new_webhook_event(LIVE_STARTED, payload);
+        assert_eq!(event.event, "live.started");
+        assert!(!event.id.is_empty());
+        assert!(event.timestamp > 0);
+    }
+
+    #[test]
+    fn test_webhook_event_unique_ids() {
+        let payload1 = Payload::Room(RecorderInfo {
+            room_info: recorder::RoomInfo::default(),
+            user_info: recorder::UserInfo::default(),
+            platform_live_id: "".to_string(),
+            live_id: "".to_string(),
+            recording: false,
+            enabled: false,
+        });
+        let payload2 = Payload::Room(RecorderInfo {
+            room_info: recorder::RoomInfo::default(),
+            user_info: recorder::UserInfo::default(),
+            platform_live_id: "".to_string(),
+            live_id: "".to_string(),
+            recording: false,
+            enabled: false,
+        });
+        let e1 = new_webhook_event(LIVE_STARTED, payload1);
+        let e2 = new_webhook_event(LIVE_STARTED, payload2);
+        assert_ne!(e1.id, e2.id);
+    }
+
+    #[test]
+    fn test_webhook_event_serialization() {
+        let payload = Payload::Room(RecorderInfo {
+            room_info: recorder::RoomInfo::default(),
+            user_info: recorder::UserInfo::default(),
+            platform_live_id: "".to_string(),
+            live_id: "".to_string(),
+            recording: false,
+            enabled: false,
+        });
+        let event = new_webhook_event(RECORD_STARTED, payload);
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("record.started"));
+        // Deserialize back
+        let deserialized: WebhookEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.event, "record.started");
+        assert_eq!(deserialized.id, event.id);
+    }
+}

--- a/src-tauri/src/webhook/poster.rs
+++ b/src-tauri/src/webhook/poster.rs
@@ -253,4 +253,72 @@ mod tests {
         let poster = create_webhook_poster("https://httpbin.org/post", Some(headers));
         assert!(poster.is_ok());
     }
+
+    #[test]
+    fn test_webhook_config_default() {
+        let config = WebhookConfig::default();
+        assert_eq!(config.url, "");
+        assert_eq!(config.timeout, Duration::from_secs(30));
+        assert_eq!(config.retry_attempts, 3);
+        assert_eq!(config.retry_delay, Duration::from_secs(1));
+        assert!(config.headers.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_webhook_poster_update_config() {
+        let config = WebhookConfig {
+            url: "https://old.example.com".to_string(),
+            ..Default::default()
+        };
+        let poster = WebhookPoster::new(config).unwrap();
+        let new_config = WebhookConfig {
+            url: "https://new.example.com".to_string(),
+            ..Default::default()
+        };
+        poster.update_config(new_config).await.unwrap();
+        let current = poster.config.read().await;
+        assert_eq!(current.url, "https://new.example.com");
+    }
+
+    #[tokio::test]
+    async fn test_webhook_post_event_empty_url_skips() {
+        let config = WebhookConfig {
+            url: "".to_string(),
+            ..Default::default()
+        };
+        let poster = WebhookPoster::new(config).unwrap();
+        let event = crate::webhook::events::WebhookEvent {
+            id: "test".to_string(),
+            event: "test.event".to_string(),
+            payload: crate::webhook::events::Payload::Room(recorder::RecorderInfo {
+                room_info: recorder::RoomInfo::default(),
+                user_info: recorder::UserInfo::default(),
+                platform_live_id: "".to_string(),
+                live_id: "".to_string(),
+                recording: false,
+                enabled: false,
+            }),
+            timestamp: 0,
+        };
+        // post_event with empty URL should return Ok
+        let result = poster.post_event(&event).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_webhook_poster_no_headers() {
+        let poster = create_webhook_poster("https://example.com/hook", None);
+        assert!(poster.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_webhook_post_json_empty_url() {
+        let config = WebhookConfig {
+            url: "".to_string(),
+            ..Default::default()
+        };
+        let poster = WebhookPoster::new(config).unwrap();
+        let result = poster.post_json("{}").await;
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add comprehensive unit test coverage across subtitle generation, recording, danmaku/ASS conversion, ffmpeg helpers, Bilibili danmaku packing, webhook events/poster, Jianying XML escaping, and account cookie parsing utilities.

Tests:
- Add tests for subtitle generator type conversions, time offset calculations, SRT formatting, and result concatenation.
- Add tests for recorder core types including stream variants, HLS stream URL handling, platform/quality/format/codec enums, cache paths, entries, errors, and platform type hashing/parsing.
- Add tests for danmaku-to-ASS conversion helpers, including time/text formatting and style options.
- Add tests for ffmpeg-related helpers such as path escaping, random filename generation, range checks, and video metadata equality.
- Add tests for Bilibili danmaku packet encoding and parsing.
- Add tests for webhook event construction, configuration defaults, posting behavior, and JSON serialization.
- Add tests for Jianying XML escaping and video clip struct behavior.
- Add additional tests for account cookie parsing edge cases.