### PR TITLE
fix: AppLive page icon overlap

### DIFF
--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -370,6 +370,8 @@ ${mediaPlaylistUrl}`;
 
     video = document.getElementById("video") as HTMLVideoElement;
     video.crossOrigin = "anonymous";
+    video.disableRemotePlayback = true;
+    video.setAttribute("x-webkit-airplay", "deny");
     const ui = video["ui"];
     const controls = ui.getControls();
     const player = controls.getPlayer();
@@ -1483,6 +1485,10 @@ ${mediaPlaylistUrl}`;
   video {
     width: 100%;
     height: 100%;
+  }
+
+  video::-webkit-media-controls-wireless-playback-picker-button {
+    display: none !important;
   }
 
   p {


### PR DESCRIPTION
## Summary by Sourcery

Disable and hide browser wireless playback controls on the video player to prevent overlapping icons on the AppLive page.

Enhancements:
- Disable remote playback and AirPlay on the HTML5 video element in the player component.
- Hide the WebKit wireless playback picker button via CSS to remove the overlapping control icon.