### PR TITLE
fix: AppLive page icon overlap

### DIFF
--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -372,6 +372,7 @@ ${mediaPlaylistUrl}`;
     video.crossOrigin = "anonymous";
     video.disableRemotePlayback = true;
     video.setAttribute("x-webkit-airplay", "deny");
+    video.setAttribute("webkit-playsinline", "true");
     const ui = video["ui"];
     const controls = ui.getControls();
     const player = controls.getPlayer();
@@ -460,6 +461,9 @@ ${mediaPlaylistUrl}`;
 
     document.getElementsByClassName("shaka-overflow-menu-button")[0].remove();
     document.getElementsByClassName("shaka-fullscreen-button")[0].remove();
+    document
+      .querySelectorAll(".shaka-remote-button")
+      .forEach((el) => el.remove());
     // add self-defined element in shaka-bottom-controls.shaka-no-propagation (second seekbar)
     const shakaBottomControls = document.querySelector(
       ".shaka-bottom-controls.shaka-no-propagation"
@@ -1397,7 +1401,13 @@ ${mediaPlaylistUrl}`;
     style="width: 100%; height: 100vh;"
   >
     <!-- svelte-ignore a11y-media-has-caption -->
-    <video autoplay data-shaka-player id="video" disablepictureinpicture
+    <video
+      autoplay
+      data-shaka-player
+      id="video"
+      disablepictureinpicture
+      disableRemotePlayback
+      playsinline
     ></video>
   </div>
 </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,6 +10,18 @@ body {
   cursor: default;
 }
 
+/* Hide Safari AirPlay button on video elements */
+video::-webkit-media-controls-wireless-playback-picker-button {
+  display: none !important;
+  -webkit-appearance: none !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+video::-webkit-media-controls-start-playback-button {
+  display: none !important;
+}
+
 .icon-white {
   color: white;
 }


### PR DESCRIPTION
## Summary by Sourcery

Prevent Safari-specific video overlay controls from interfering with the AppLive player UI by disabling remote playback and inline start buttons on the video element.

Bug Fixes:
- Hide Safari AirPlay and wireless playback picker controls on video elements to avoid overlaying AppLive page icons.

Enhancements:
- Set video element attributes and properties to disable remote playback and enforce inline playback behavior across supported browsers.