### PR TITLE
fix: clip ffmpeg error

### DIFF
--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -28,6 +28,19 @@ pub async fn random_filename() -> String {
 /// - Square brackets [] do NOT need escaping when inside single quotes
 fn escape_concat_path(path: &Path) -> String {
     let path_str = path.to_string_lossy();
+
+    // On Windows, canonicalize returns UNC paths like \\?\D:\path
+    // FFmpeg doesn't handle these well, so we need to strip the UNC prefix
+    #[cfg(target_os = "windows")]
+    let path_str = {
+        let s = path_str.as_ref();
+        if s.starts_with(r"\\?\") {
+            std::borrow::Cow::Borrowed(&s[4..])
+        } else {
+            path_str
+        }
+    };
+
     // Only escape backslashes and single quotes
     // Do NOT escape square brackets - they work fine in single-quoted paths
     path_str.replace('\\', "\\\\").replace('\'', "'\\''")
@@ -264,4 +277,120 @@ pub async fn concat_videos_with_transition(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod concat_videos_tests {
+    use super::{concat_videos, ffmpeg_path, random_filename};
+    use std::path::Path;
+
+    #[cfg(target_os = "windows")]
+    use super::CREATE_NO_WINDOW;
+
+    /// Helper function to create a minimal valid MP4 file for testing
+    async fn create_test_video(path: &Path, duration_secs: u32) -> Result<(), String> {
+        // Create parent directory if it doesn't exist
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| format!("Failed to create parent dir: {}", e))?;
+        }
+
+        // Use FFmpeg to generate a test video with color and audio
+        let mut cmd = tokio::process::Command::new(ffmpeg_path());
+        #[cfg(target_os = "windows")]
+        cmd.creation_flags(CREATE_NO_WINDOW);
+
+        cmd.args([
+            "-f",
+            "lavfi",
+            "-i",
+            &format!("color=c=blue:s=1280x720:d={}", duration_secs),
+            "-f",
+            "lavfi",
+            "-i",
+            &format!("anullsrc=r=44100:cl=stereo:d={}", duration_secs),
+            "-c:v",
+            "libx264",
+            "-preset",
+            "ultrafast",
+            "-c:a",
+            "aac",
+            "-y",
+            path.to_str().unwrap(),
+        ]);
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| format!("Failed to run ffmpeg: {}", e))?;
+
+        if !output.status.success() {
+            return Err(format!(
+                "FFmpeg failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_concat_videos_with_chinese_and_brackets() {
+        // Create a temporary directory for testing
+        let temp_dir = std::env::temp_dir().join(format!("bili_test_{}", random_filename().await));
+        tokio::fs::create_dir_all(&temp_dir).await.unwrap();
+
+        // Create test videos with problematic filenames (Chinese characters and brackets)
+        let video1_path =
+            temp_dir.join("[22637261][1773410394380][电台久违的嚼嚼嚼][2026-03-14_11-11-41].0.mp4");
+        let video2_path =
+            temp_dir.join("[22637261][1773410394380][电台久违的嚼嚼嚼][2026-03-14_11-11-41].1.mp4");
+        let output_path =
+            temp_dir.join("[22637261][1773410394380][电台久违的嚼嚼嚼][2026-03-14_11-11-41].mp4");
+
+        // Create test videos
+        create_test_video(&video1_path, 2).await.unwrap();
+        create_test_video(&video2_path, 2).await.unwrap();
+
+        // Test concatenation
+        let videos = vec![video1_path.clone(), video2_path.clone()];
+        let result = concat_videos(
+            None::<&crate::progress::progress_reporter::ProgressReporter>,
+            &videos,
+            &output_path,
+        )
+        .await;
+
+        // Clean up
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+
+        // Assert
+        assert!(result.is_ok(), "Concat should succeed: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_concat_videos_with_spaces_and_special_chars() {
+        let temp_dir = std::env::temp_dir().join(format!("bili_test_{}", random_filename().await));
+        tokio::fs::create_dir_all(&temp_dir).await.unwrap();
+
+        let video1_path = temp_dir.join("video with spaces [1].mp4");
+        let video2_path = temp_dir.join("video's file [2].mp4");
+        let output_path = temp_dir.join("output [final].mp4");
+
+        create_test_video(&video1_path, 2).await.unwrap();
+        create_test_video(&video2_path, 2).await.unwrap();
+
+        let videos = vec![video1_path, video2_path];
+        let result = concat_videos(
+            None::<&crate::progress::progress_reporter::ProgressReporter>,
+            &videos,
+            &output_path,
+        )
+        .await;
+
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+
+        assert!(result.is_ok(), "Concat should succeed: {:?}", result);
+    }
 }


### PR DESCRIPTION
03:11:28 [INFO] Open player window: 22637261 1773410394380

03:11:28 [INFO] [frontend] "AppLive loaded" "22637261" "bilibili" "1773410394380"

03:11:40 [INFO] [frontend] "listen to event:" "progress-update:fbltg4myuu"

03:11:40 [INFO] [frontend] "listen to event:" "progress-finished:fbltg4myuu"

03:11:41 [INFO] Create task: fbltg4myuu clip\_range

03:11:41 [INFO] [fbltg4myuu]Clip room\_id: 22637261, ts: 1773410394380, ranges: [Range { start: 293.92, end: 358.55 }]

03:11:41 [INFO] Transcode: D:\\bili-shadowreplay\\clips\\[22637261][1773410394380][电台久违的嚼嚼嚼][2026-03-14\_11-11-41].0.mp4 copy: true

03:11:41 [INFO] Trim video task start: D:\\bili-shadowreplay\\clips\\[22637261][1773410394380][电台久违的嚼嚼嚼][2026-03-14\_11-11-41].0.mp4

03:11:41 [INFO] Trim video task end: D:\\bili-shadowreplay\\clips\\[22637261][1773410394380][电台久违的嚼嚼嚼][2026-03-14\_11-11-41].0.tmp.mp4

03:11:41 [INFO] [FFmpeg] Command { std: "ffmpeg.exe" "-f" "concat" "-safe" "0" "-i" "D:\\\\bili-shadowreplay\\\\clips\\\\filelist\_aa10cc79c716fda2.txt" "-c" "copy" "D:\\\\bili-shadowreplay\\\\clips\\\\[22637261][1773410394380][电台久违的嚼嚼嚼][2026-03-14\_11-11-41].mp4" "-progress" "pipe:2" "-y", kill\_on\_drop: false }

03:12:00 [WARN] NewEvents emitted without explicit RedrawEventsCleared

03:12:00 [WARN] RedrawEventsCleared emitted without explicit MainEventsCleared

 ![{6219781B-BFEA-8EA6-2240-4F8FA2EF003A}.jpg](.vibe-images/424a9d7d-2d79-4fcd-b403-34af6814f8c6.jpg)

请检查可能的原因，你需要：

1. 查明原因，编写测试样例复现
2. 修复，让测试样例通过

你可以生成测试用的 hls 流相关文件用于测试样例的测试

## Summary by Sourcery

Fix FFmpeg concat failures on Windows and add regression tests for file paths with special characters.

Bug Fixes:
- Normalize Windows paths by stripping UNC prefixes before passing them to FFmpeg to prevent concat command failures with certain clip file paths.

Tests:
- Add async integration tests that generate sample videos and verify FFmpeg concatenation works with filenames containing Chinese characters, brackets, spaces, and quotes.