### PR TITLE
fix: request qn=25000 for bilibili default stream selection

### DIFF
--- a/src-tauri/crates/recorder/src/platforms/bilibili.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili.rs
@@ -194,7 +194,7 @@ impl BiliRecorder {
                     Protocol::HttpHls,
                     Format::TS,
                     &[Codec::Avc, Codec::Hevc],
-                    Qn::Q4K,
+                    Qn::Q25000,
                 )
                 .await;
 

--- a/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
@@ -110,26 +110,30 @@ impl fmt::Display for Protocol {
     }
 }
 
-// 30000	杜比
-// 20000	4K
-// 15000    2K
-// 10000	原画
-// 400	蓝光
-// 250	超清
-// 150	高清
-// 80	流畅
+// Bilibili display labels can vary while sharing the same qn bucket.
+//
+// qn=30000 -> 杜比
+// qn=25000 -> 原画真彩 / 2K 原画 / 2K 原画 高帧率
+// qn=20000 -> 4K
+// qn=15000 -> 2K
+// qn=10000 -> 原画 / 1080P 高码率 / 1080P 高码率 高帧率
+// qn=400   -> 蓝光 / 1080P 蓝光
+// qn=250   -> 超清 / 720P 超清
+// qn=150   -> 高清
+// qn=80    -> 流畅
 
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum Qn {
     Dolby = 30000,
-    Q4K = 20000,
-    Q2K = 15000,
-    Q1080PH = 10000,
-    Q1080P = 400,
-    Q720P = 250,
-    Hd = 150,
-    Smooth = 80,
+    Q25000 = 25000,
+    Q20000 = 20000,
+    Q15000 = 15000,
+    Q10000 = 10000,
+    Q400 = 400,
+    Q250 = 250,
+    Q150 = 150,
+    Q80 = 80,
 }
 
 impl fmt::Display for Qn {

--- a/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
@@ -125,7 +125,7 @@ impl fmt::Display for Protocol {
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub enum Qn {
-    Dolby = 30000,
+    Q30000 = 30000,
     Q25000 = 25000,
     Q20000 = 20000,
     Q15000 = 15000,


### PR DESCRIPTION
## Summary

Fix bilibili default stream selection to request `qn=25000` instead of `qn=20000`.

## Problem

Some logged-in Bilibili live rooms expose high-quality streams in the `25000` bucket.
Requesting `qn=20000` can still fall back to `current_qn=10000`.

Example room:
- https://live.bilibili.com/27183290

Observed behavior:
- request `qn=10000/15000/20000` -> `current_qn=10000`
- request `qn=25000/30000` -> `current_qn=25000`

## Fix

- change the default request qn in `src-tauri/crates/recorder/src/platforms/bilibili.rs`
- update qn bucket comments and enum naming in `src-tauri/crates/recorder/src/platforms/bilibili/api.rs`

## Verification

- built the desktop app successfully
- `cargo check -p recorder --manifest-path src-tauri/Cargo.toml` passed

#263

## Summary by Sourcery

Update Bilibili live recorder to request a higher-quality default stream and align quality level mappings with current Bilibili qn buckets.

Enhancements:
- Adjust the default Bilibili stream quality selection to use qn=25000 for higher-quality streams when available.
- Refresh Bilibili qn bucket documentation and rename quality-level enum variants to match explicit qn values and current labeling behavior.