### PR TITLE
Feat manual select merge replay

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -201,8 +201,6 @@ impl Config {
         let format_config = format_config.replace("{room_id}", &params.room_id.to_string());
         let format_config = format_config.replace("{live_id}", &params.live_id);
         let format_config = format_config.replace("{note}", &params.note);
-        let danmu_tag = if params.danmu { "danmaku" } else { "" };
-        let format_config = format_config.replace("{danmu}", danmu_tag);
         let format_config = format_config.replace(
             "{x}",
             &params

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -81,7 +81,7 @@ fn default_openai_api_key() -> String {
 }
 
 fn default_clip_name_format() -> String {
-    "[{room_id}][{live_id}][{title}][{created_at}].mp4".to_string()
+    "[{room_id}][{note}][{live_id}][{title}][{created_at}].mp4".to_string()
 }
 
 fn default_auto_generate_config() -> AutoGenerateConfig {
@@ -201,6 +201,8 @@ impl Config {
         let format_config = format_config.replace("{room_id}", &params.room_id.to_string());
         let format_config = format_config.replace("{live_id}", &params.live_id);
         let format_config = format_config.replace("{note}", &params.note);
+        let danmu_tag = if params.danmu { "danmaku" } else { "" };
+        let format_config = format_config.replace("{danmu}", danmu_tag);
         let format_config = format_config.replace(
             "{x}",
             &params
@@ -221,6 +223,11 @@ impl Config {
         );
         let duration = params.ranges.iter().map(|r| r.duration()).sum::<f64>();
         let format_config = format_config.replace("{length}", &duration.to_string());
+
+        let mut format_config = format_config;
+        while format_config.contains("[]") {
+            format_config = format_config.replace("[]", "");
+        }
 
         let sanitized = sanitize_filename::sanitize(&format_config);
         let output = self.output.clone();

--- a/src-tauri/src/handlers/recorder.rs
+++ b/src-tauri/src/handlers/recorder.rs
@@ -466,6 +466,8 @@ pub async fn generate_whole_clip(
     platform: String,
     room_id: String,
     parent_id: String,
+    selected_live_ids: Option<Vec<String>>,
+    output_name: Option<String>,
 ) -> Result<TaskRow, String> {
     log::info!("Generate whole clip for {platform} {room_id} {parent_id}");
 
@@ -479,6 +481,8 @@ pub async fn generate_whole_clip(
                 "room_id": room_id,
                 "parent_id": parent_id,
                 "encode_danmu": encode_danmu,
+                "selected_live_ids": selected_live_ids,
+                "output_name": output_name,
             })
             .to_string(),
         )
@@ -512,6 +516,8 @@ pub async fn generate_whole_clip(
                         platform,
                         &room_id,
                         parent_id,
+                        selected_live_ids,
+                        output_name,
                     )
                     .await
                 {

--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -1041,6 +1041,8 @@ struct GenerateWholeClipRequest {
     platform: String,
     room_id: String,
     parent_id: String,
+    selected_live_ids: Option<Vec<String>>,
+    output_name: Option<String>,
 }
 
 async fn handler_generate_whole_clip(
@@ -1053,6 +1055,8 @@ async fn handler_generate_whole_clip(
         param.platform,
         param.room_id,
         param.parent_id,
+        param.selected_live_ids,
+        param.output_name,
     )
     .await?;
     Ok(Json(ApiResponse::success(task)))

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -434,6 +434,8 @@ impl RecorderManager {
                             platform.as_str().to_string(),
                             &room_id,
                             live_record.parent_id,
+                            None,
+                            None,
                         )
                         .await
                     {
@@ -1509,6 +1511,8 @@ impl RecorderManager {
         platform: String,
         room_id: &str,
         parent_id: String,
+        selected_live_ids: Option<Vec<String>>,
+        output_name: Option<String>,
     ) -> Result<(), RecorderManagerError> {
         let platform = PlatformType::from_str(&platform).map_err(|_| {
             RecorderManagerError::InvalidPlatformType {
@@ -1516,11 +1520,30 @@ impl RecorderManager {
             }
         })?;
 
-        let playlists = self
+        let mut playlists = self
             .get_related_playlists(&platform, room_id, &parent_id)
             .await;
         if playlists.is_empty() {
             log::error!("No related playlists found: {parent_id}");
+            return Ok(());
+        }
+
+        if let Some(selected_live_ids) = selected_live_ids {
+            let mut by_id = std::collections::HashMap::new();
+            for playlist in playlists {
+                by_id.insert(playlist.live_id.clone(), playlist);
+            }
+            let mut ordered = Vec::new();
+            for live_id in selected_live_ids {
+                if let Some(playlist) = by_id.remove(&live_id) {
+                    ordered.push(playlist);
+                }
+            }
+            playlists = ordered;
+        }
+
+        if playlists.is_empty() {
+            log::error!("No selected playlists found: {parent_id}");
             return Ok(());
         }
 
@@ -1543,16 +1566,35 @@ impl RecorderManager {
             vec![None; playlists.len()]
         };
 
-        let timestamp = chrono::Local::now().format("%Y%m%d%H%M%S").to_string();
+        let output_filename = if let Some(output_name) = output_name {
+            let trimmed = output_name.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                let mut sanitized = sanitize_filename::sanitize(trimmed);
+                if !sanitized.to_lowercase().ends_with(".mp4") {
+                    sanitized.push_str(".mp4");
+                }
+                Some(std::path::PathBuf::from(sanitized))
+            }
+        } else {
+            None
+        };
 
-        let sanitized_filename = sanitize_filename::sanitize(format!(
-            "[full][{platform:?}][{room_id}][{parent_id}][{timestamp}]{title}.mp4"
-        ));
-        let output_filename = Path::new(&sanitized_filename);
+        let output_filename = if let Some(output_filename) = output_filename {
+            output_filename
+        } else {
+            let timestamp = chrono::Local::now().format("%Y%m%d%H%M%S").to_string();
+            let sanitized_filename = sanitize_filename::sanitize(format!(
+                "[full][{platform:?}][{room_id}][{parent_id}][{timestamp}]{title}.mp4"
+            ));
+            std::path::PathBuf::from(sanitized_filename)
+        };
+
         let cover_filename = output_filename.with_extension("jpg");
 
-        let output_path =
-            Path::new(&self.config.read().await.output.as_str()).join(output_filename);
+        let output_path = Path::new(&self.config.read().await.output.as_str())
+            .join(&output_filename);
 
         let playlists_refs: Vec<&Path> = playlists.iter().map(|p| p.path.as_path()).collect();
 

--- a/src/lib/actions/clickOutside.ts
+++ b/src/lib/actions/clickOutside.ts
@@ -1,0 +1,15 @@
+export function clickOutside(node: HTMLElement, callback: () => void) {
+  const handleClick = (event: MouseEvent) => {
+    if (node && !node.contains(event.target as Node) && !event.defaultPrevented) {
+      callback();
+    }
+  };
+
+  document.addEventListener('click', handleClick, true);
+
+  return {
+    destroy() {
+      document.removeEventListener('click', handleClick, true);
+    }
+  };
+}

--- a/src/lib/components/GenerateWholeClipModal.svelte
+++ b/src/lib/components/GenerateWholeClipModal.svelte
@@ -2,8 +2,8 @@
   import { invoke, get_static_url } from "../invoker";
   import type { RecordItem } from "../db";
   import { fade, scale } from "svelte/transition";
-  import { X, FileVideo } from "lucide-svelte";
-  import { createEventDispatcher } from "svelte";
+  import { X, FileVideo, Info } from "lucide-svelte";
+  import { createEventDispatcher, onMount } from "svelte";
 
   export let showModal = false;
   export let archive: RecordItem | null = null;
@@ -15,11 +15,31 @@
   let wholeClipArchives: RecordItem[] = [];
   let isLoading = false;
   let encodeDanmu = false;
+  let selectedLiveIds: string[] = [];
+  let outputName = "";
+  let outputNameEdited = false;
+  let showSelectionHelp = false;
+  let selectionHelpRef: HTMLDivElement | null = null;
 
   // 当modal显示且有archive时，加载相关片段
   $: if (showModal && archive) {
     loadWholeClipArchives(roomId, archive.parent_id);
   }
+
+  onMount(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!showSelectionHelp || !selectionHelpRef) {
+        return;
+      }
+      if (!selectionHelpRef.contains(event.target as Node)) {
+        showSelectionHelp = false;
+      }
+    };
+    document.addEventListener("click", handleOutsideClick);
+    return () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
+  });
 
   async function loadWholeClipArchives(roomId: string, parentId: string) {
     if (isLoading) return;
@@ -48,6 +68,9 @@
       });
 
       wholeClipArchives = sameParentArchives;
+      selectedLiveIds = sameParentArchives.map((item) => item.live_id);
+      outputNameEdited = false;
+      outputName = buildDefaultOutputName();
     } catch (error) {
       console.error("Failed to load whole clip archives:", error);
       wholeClipArchives = [];
@@ -63,6 +86,8 @@
         platform: archive.platform,
         roomId: archive.room_id,
         parentId: archive.parent_id,
+        selectedLiveIds: selectedLiveIds,
+        outputName: outputName.trim() ? outputName.trim() : undefined,
       });
 
       showModal = false;
@@ -77,14 +102,65 @@
     return date.toLocaleString();
   }
 
-  function formatDuration(duration: number) {
-    const hours = Math.floor(duration / 3600)
+  function formatCompactTimestamp(date = new Date()) {
+    const pad = (value: number) => value.toString().padStart(2, "0");
+    return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(
+      date.getDate()
+    )}${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+  }
+
+  function sanitizeOutputName(name: string) {
+    return name.replace(/[\\/:*?"<>|]/g, "");
+  }
+
+  function buildDefaultOutputName() {
+    if (!archive) {
+      return "";
+    }
+    const timestamp = formatCompactTimestamp();
+    const name = `[full][${archive.platform}][${archive.room_id}][${
+      archive.parent_id
+    }][${timestamp}]${archive.title}.mp4`;
+    return sanitizeOutputName(name);
+  }
+
+  function selectAll() {
+    selectedLiveIds = [...wholeClipArchives.map((item) => item.live_id)];
+  }
+
+  function clearSelection() {
+    selectedLiveIds = [];
+  }
+
+  function selectionIndex(liveId: string) {
+    return selectedLiveIds.indexOf(liveId);
+  }
+
+  function toggleArchiveSelection(liveId: string, checked: boolean) {
+    if (checked) {
+      if (!selectedLiveIds.includes(liveId)) {
+        selectedLiveIds = [...selectedLiveIds, liveId];
+      }
+    } else {
+      selectedLiveIds = selectedLiveIds.filter((id) => id !== liveId);
+    }
+  }
+
+  function handleSelectionChange(event: Event, liveId: string) {
+    const target = event.currentTarget as HTMLInputElement;
+    toggleArchiveSelection(liveId, target.checked);
+  }
+
+  function formatDuration(duration: number | string) {
+    const numDuration = typeof duration === 'string' ? parseFloat(duration) : duration;
+    const totalSeconds = Math.max(0, Math.round(Number.isNaN(numDuration) ? 0 : numDuration));
+    const hours = Math.floor(totalSeconds / 3600)
       .toString()
       .padStart(2, "0");
-    const minutes = Math.floor((duration % 3600) / 60)
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
       .toString()
       .padStart(2, "0");
-    const seconds = (duration % 60).toString().padStart(2, "0");
+    const seconds = (totalSeconds % 60).toString().padStart(2, "0");
 
     return `${hours}:${minutes}:${seconds}`;
   }
@@ -101,9 +177,24 @@
     }
   }
 
+  $: selectedArchives = selectedLiveIds
+    .map((id) => wholeClipArchives.find((item) => item.live_id === id))
+    .filter((item): item is RecordItem => Boolean(item));
+
+  $: totalDuration = selectedArchives.reduce(
+    (sum, item) => sum + item.length,
+    0
+  );
+
+  $: totalSize = selectedArchives.reduce((sum, item) => sum + item.size, 0);
+
   function closeModal() {
     showModal = false;
     wholeClipArchives = [];
+    selectedLiveIds = [];
+    outputName = "";
+    outputNameEdited = false;
+    showSelectionHelp = false;
   }
 </script>
 
@@ -119,7 +210,7 @@
     <!-- svelte-ignore a11y-click-events-have-key-events -->
     <!-- svelte-ignore a11y-no-static-element-interactions -->
     <div
-      class="mac-modal w-[800px] bg-white dark:bg-[#323234] rounded-xl shadow-xl overflow-hidden flex flex-col max-h-[80vh]"
+      class="mac-modal w-[900px] bg-white dark:bg-[#323234] rounded-xl shadow-xl overflow-hidden flex flex-col max-h-[90vh]"
       transition:scale={{ duration: 150, start: 0.95 }}
       on:click|stopPropagation
     >
@@ -145,17 +236,10 @@
 
       <!-- Content -->
       <div class="flex-1 flex flex-col min-h-0">
-        <!-- Description -->
-        <div class="px-6 pt-6 pb-4">
-          <p class="text-sm text-gray-600 dark:text-gray-400">
-            以下是属于同一场直播的所有片段，将按时间顺序合成为一个完整的视频文件：
-          </p>
-        </div>
-
-        <!-- Main Content: Left (List) + Right (Summary) -->
+        <!-- Main Content: Left (List) -->
         <div class="flex-1 flex min-h-0">
           <!-- Left: Scrollable List -->
-          <div class="flex-1 overflow-auto custom-scrollbar-light px-6 min-h-0">
+          <div class="flex-1 overflow-auto custom-scrollbar-light px-6 py-6 min-h-0">
             {#if isLoading}
               <div class="flex items-center justify-center py-8">
                 <div
@@ -172,22 +256,75 @@
                 未找到相关片段
               </div>
             {:else}
-              <div class="space-y-3 pb-4">
+              <div class="flex items-center justify-between pb-4">
+                <div class="text-sm text-gray-600 dark:text-gray-400">
+                  默认全选，按勾选顺序合成
+                </div>
+                <div class="flex items-center space-x-3 text-sm">
+                  <button
+                    class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                    on:click={selectAll}
+                  >
+                    全选
+                  </button>
+                  <button
+                    class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
+                    on:click={clearSelection}
+                  >
+                    取消全选
+                  </button>
+                  <div class="relative" bind:this={selectionHelpRef}>
+                    <button
+                      class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
+                      on:click={() =>
+                        (showSelectionHelp = !showSelectionHelp)}
+                      on:mouseenter={() => (showSelectionHelp = true)}
+                      on:mouseleave={() => (showSelectionHelp = false)}
+                      aria-label="选择顺序说明"
+                    >
+                      <Info class="w-4 h-4" />
+                    </button>
+                    {#if showSelectionHelp}
+                      <div
+                        class="absolute right-0 top-6 z-20 w-64 rounded-lg border border-gray-200 bg-white p-3 text-xs text-gray-700 shadow-lg dark:border-gray-700 dark:bg-[#2c2c2e] dark:text-gray-200"
+                      >
+                        取消全选后请按需要勾选片段，勾选的先后顺序即合成顺序。
+                      </div>
+                    {/if}
+                  </div>
+                </div>
+              </div>
+              <div class="space-y-2 pb-4">
                 {#each wholeClipArchives as archiveItem, index (archiveItem.live_id)}
                   <div
-                    class="flex items-center space-x-4 p-4 rounded-lg bg-gray-50 dark:bg-gray-700/30"
+                    class="flex items-center space-x-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/30"
                   >
-                    <div
-                      class="flex-shrink-0 w-8 h-8 rounded-full bg-blue-500 flex items-center justify-center text-white text-sm font-medium"
-                    >
-                      {index + 1}
+                    <input
+                      type="checkbox"
+                      class="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                      checked={selectedLiveIds.includes(archiveItem.live_id)}
+                      on:change={(event) =>
+                        handleSelectionChange(event, archiveItem.live_id)}
+                    />
+                    <div class="flex items-center justify-center w-6">
+                      {#if selectedLiveIds.includes(archiveItem.live_id)}
+                        <div
+                          class="w-6 h-6 rounded-full bg-blue-500 flex items-center justify-center text-white text-xs font-bold shadow-sm"
+                        >
+                          {selectedLiveIds.indexOf(archiveItem.live_id) + 1}
+                        </div>
+                      {:else}
+                        <span class="text-xs text-gray-400 dark:text-gray-500 font-medium">
+                          {index + 1}
+                        </span>
+                      {/if}
                     </div>
 
                     {#if archiveItem.cover}
                       <img
                         src={archiveItem.cover}
                         alt="cover"
-                        class="w-16 h-10 rounded object-cover flex-shrink-0"
+                        class="w-14 h-9 rounded object-cover flex-shrink-0"
                       />
                     {/if}
 
@@ -197,12 +334,13 @@
                       >
                         {archiveItem.title}
                       </div>
-                      <div
-                        class="text-xs text-gray-500 dark:text-gray-400 mt-1"
-                      >
-                        {formatTimestamp(archiveItem.created_at)} · {formatDuration(
-                          archiveItem.length
-                        )} · {formatSize(archiveItem.size)}
+                      <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                        开始时间 {formatTimestamp(archiveItem.created_at)}
+                      </div>
+                      <div class="text-xs text-gray-500 dark:text-gray-400">
+                        时长 {formatDuration(archiveItem.length)} · 大小 {formatSize(
+                          archiveItem.size
+                        )}
                       </div>
                     </div>
                   </div>
@@ -210,69 +348,54 @@
               </div>
             {/if}
           </div>
+        </div>
 
-          <!-- Right: Fixed Summary -->
-          {#if !isLoading && wholeClipArchives.length > 0}
-            <div class="w-80 px-6 pb-6 flex-shrink-0 flex items-center">
-              <div
-                class="p-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 w-full"
-              >
-                <div class="flex items-center space-x-2 mb-2">
+        <!-- Bottom Summary -->
+        {#if !isLoading && wholeClipArchives.length > 0}
+          <div class="px-6 pb-4">
+            <div
+              class="p-3 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 w-full"
+            >
+              <div class="flex items-center justify-between">
+                <div class="flex items-center space-x-2">
                   <FileVideo class="w-4 h-4 text-blue-600 dark:text-blue-400" />
                   <span
                     class="text-sm font-medium text-blue-900 dark:text-blue-100"
-                    >合成信息</span
                   >
+                    合成信息
+                  </span>
                 </div>
-                <div class="text-sm text-blue-800 dark:text-blue-200">
-                  共 {wholeClipArchives.length} 个片段 · 总时长 {formatDuration(
-                    wholeClipArchives.reduce(
-                      (sum, archiveItem) => sum + archiveItem.length,
-                      0
-                    )
-                  )} · 总大小 {formatSize(
-                    wholeClipArchives.reduce(
-                      (sum, archiveItem) => sum + archiveItem.size,
-                      0
-                    )
-                  )}
+                <div class="text-xs text-blue-600 dark:text-blue-300">
+                  已选 {selectedArchives.length} 个片段 · 总时长 {formatDuration(totalDuration)} · 总大小 {formatSize(totalSize)}
                 </div>
-
-                <!-- 压制弹幕选项 -->
-                <div
-                  class="mt-4 pt-4 border-t border-blue-200 dark:border-blue-700"
-                >
-                  <div class="flex items-center justify-between">
-                    <div class="flex-1">
-                      <div
-                        class="text-sm font-medium text-blue-900 dark:text-blue-100"
-                      >
-                        压制弹幕
-                      </div>
-                      <div
-                        class="text-xs text-blue-700 dark:text-blue-300 mt-1"
-                      >
-                        将弹幕直接压制到视频中，生成包含弹幕的最终视频文件
-                      </div>
-                    </div>
-                    <label
-                      class="relative inline-flex items-center cursor-pointer"
-                    >
-                      <input
-                        type="checkbox"
-                        bind:checked={encodeDanmu}
-                        class="sr-only peer"
-                      />
-                      <div
-                        class="w-11 h-6 bg-blue-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-blue-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-blue-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-blue-600 peer-checked:bg-blue-600"
-                      ></div>
-                    </label>
-                  </div>
+              </div>
+              <div class="flex items-center gap-4 mt-3">
+                <div class="flex-1">
+                  <input
+                    type="text"
+                    class="w-full px-3 py-1.5 text-sm rounded-lg border border-blue-200 dark:border-blue-700 bg-white dark:bg-[#2c2c2e] text-gray-900 dark:text-gray-100"
+                    bind:value={outputName}
+                    on:input={() => (outputNameEdited = true)}
+                    placeholder="输出文件名"
+                  />
+                </div>
+                <div class="flex items-center space-x-2">
+                  <span class="text-xs text-blue-600 dark:text-blue-300">压制弹幕</span>
+                  <label class="relative inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      bind:checked={encodeDanmu}
+                      class="sr-only peer"
+                    />
+                    <div
+                      class="w-11 h-6 bg-blue-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-blue-700 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-blue-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-blue-600 peer-checked:bg-blue-600"
+                    ></div>
+                  </label>
                 </div>
               </div>
             </div>
-          {/if}
-        </div>
+          </div>
+        {/if}
       </div>
 
       <!-- Footer -->
@@ -287,7 +410,7 @@
         </button>
         <button
           class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={isLoading || wholeClipArchives.length === 0}
+          disabled={isLoading || selectedArchives.length === 0}
           on:click={generateWholeClip}
         >
           开始合成

--- a/src/lib/components/GenerateWholeClipModal.svelte
+++ b/src/lib/components/GenerateWholeClipModal.svelte
@@ -4,6 +4,7 @@
   import { fade, scale } from "svelte/transition";
   import { X, FileVideo, Info } from "lucide-svelte";
   import { createEventDispatcher, onMount } from "svelte";
+  import { clickOutside } from "../actions/clickOutside";
 
   export let showModal = false;
   export let archive: RecordItem | null = null;
@@ -17,29 +18,12 @@
   let encodeDanmu = false;
   let selectedLiveIds: string[] = [];
   let outputName = "";
-  let outputNameEdited = false;
   let showSelectionHelp = false;
-  let selectionHelpRef: HTMLDivElement | null = null;
 
   // 当modal显示且有archive时，加载相关片段
   $: if (showModal && archive) {
     loadWholeClipArchives(roomId, archive.parent_id);
   }
-
-  onMount(() => {
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (!showSelectionHelp || !selectionHelpRef) {
-        return;
-      }
-      if (!selectionHelpRef.contains(event.target as Node)) {
-        showSelectionHelp = false;
-      }
-    };
-    document.addEventListener("click", handleOutsideClick);
-    return () => {
-      document.removeEventListener("click", handleOutsideClick);
-    };
-  });
 
   async function loadWholeClipArchives(roomId: string, parentId: string) {
     if (isLoading) return;
@@ -69,7 +53,6 @@
 
       wholeClipArchives = sameParentArchives;
       selectedLiveIds = sameParentArchives.map((item) => item.live_id);
-      outputNameEdited = false;
       outputName = buildDefaultOutputName();
     } catch (error) {
       console.error("Failed to load whole clip archives:", error);
@@ -193,7 +176,6 @@
     wholeClipArchives = [];
     selectedLiveIds = [];
     outputName = "";
-    outputNameEdited = false;
     showSelectionHelp = false;
   }
 </script>
@@ -273,7 +255,7 @@
                   >
                     取消全选
                   </button>
-                  <div class="relative" bind:this={selectionHelpRef}>
+                  <div class="relative" use:clickOutside={() => (showSelectionHelp = false)}>
                     <button
                       class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
                       on:click={() =>
@@ -375,7 +357,6 @@
                     type="text"
                     class="w-full px-3 py-1.5 text-sm rounded-lg border border-blue-200 dark:border-blue-700 bg-white dark:bg-[#2c2c2e] text-gray-900 dark:text-gray-100"
                     bind:value={outputName}
-                    on:input={() => (outputNameEdited = true)}
                     placeholder="输出文件名"
                   />
                 </div>

--- a/src/page/Setting.svelte
+++ b/src/page/Setting.svelte
@@ -46,6 +46,8 @@
   };
 
   let showModal = false;
+  let show_clip_name_help = false;
+  let clip_name_help_ref: HTMLDivElement | null = null;
   let endpoint = localStorage.getItem("endpoint") || "";
   let endpointValue = endpoint;
 
@@ -161,7 +163,19 @@
   }
 
   onMount(async () => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!show_clip_name_help || !clip_name_help_ref) {
+        return;
+      }
+      if (!clip_name_help_ref.contains(event.target as Node)) {
+        show_clip_name_help = false;
+      }
+    };
+    document.addEventListener("click", handleOutsideClick);
     await get_config();
+    return () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
   });
 </script>
 
@@ -739,17 +753,51 @@
                     >
                       文件名格式
                     </h3>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">
-                      可用标签：{"{title}"}
-                      {"{platform}"}
-                      {"{room_id}"}
-                      {"{live_id}"}
-                      {"{x}"}
-                      {"{y}"}
-                      {"{created_at}"}
-                      {"{length}"}
-                      {"{note}"}
-                    </p>
+                    <div class="flex items-center space-x-2">
+                      <p class="text-sm text-gray-500 dark:text-gray-400">
+                        可用标签：{"{title}"}
+                        {"{platform}"}
+                        {"{room_id}"}
+                        {"{live_id}"}
+                        {"{x}"}
+                        {"{y}"}
+                        {"{created_at}"}
+                        {"{length}"}
+                        {"{note}"}
+                      </p>
+                      <div
+                        class="relative"
+                        bind:this={clip_name_help_ref}
+                        on:mouseenter={() => (show_clip_name_help = true)}
+                        on:mouseleave={() => (show_clip_name_help = false)}
+                      >
+                        <button
+                          type="button"
+                          class="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                          on:click={() =>
+                            (show_clip_name_help = !show_clip_name_help)}
+                        >
+                          详情
+                        </button>
+                        {#if show_clip_name_help}
+                          <div
+                            class="absolute left-0 top-6 z-20 w-96 rounded-lg border border-gray-200 bg-white p-3 text-xs text-gray-700 shadow-lg dark:border-gray-700 dark:bg-[#2c2c2e] dark:text-gray-200"
+                          >
+                            <div class="space-y-1">
+                              <div>{"{title}"}: 直播标题</div>
+                              <div>{"{platform}"}: 平台标识</div>
+                              <div>{"{room_id}"}: 房间号</div>
+                              <div>{"{live_id}"}: 录播 ID</div>
+                              <div>{"{x}"}: 切片起始秒</div>
+                              <div>{"{y}"}: 切片结束秒</div>
+                              <div>{"{created_at}"}: 创建时间</div>
+                              <div>{"{length}"}: 切片时长（秒）</div>
+                              <div>{"{note}"}: 备注</div>
+                            </div>
+                          </div>
+                        {/if}
+                      </div>
+                    </div>
                   </div>
                   <div class="flex items-center space-x-2">
                     <input

--- a/src/page/Setting.svelte
+++ b/src/page/Setting.svelte
@@ -2,6 +2,7 @@
   import { invoke } from "../lib/invoker";
   import { open } from "@tauri-apps/plugin-dialog";
   import { TAURI_ENV } from "../lib/invoker";
+  import { clickOutside } from "../lib/actions/clickOutside";
 
   import type { Config } from "../lib/interface";
   import {
@@ -47,7 +48,6 @@
 
   let showModal = false;
   let show_clip_name_help = false;
-  let clip_name_help_ref: HTMLDivElement | null = null;
   let endpoint = localStorage.getItem("endpoint") || "";
   let endpointValue = endpoint;
 
@@ -163,19 +163,7 @@
   }
 
   onMount(async () => {
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (!show_clip_name_help || !clip_name_help_ref) {
-        return;
-      }
-      if (!clip_name_help_ref.contains(event.target as Node)) {
-        show_clip_name_help = false;
-      }
-    };
-    document.addEventListener("click", handleOutsideClick);
     await get_config();
-    return () => {
-      document.removeEventListener("click", handleOutsideClick);
-    };
   });
 </script>
 
@@ -767,7 +755,7 @@
                       </p>
                       <div
                         class="relative"
-                        bind:this={clip_name_help_ref}
+                        use:clickOutside={() => (show_clip_name_help = false)}
                         on:mouseenter={() => (show_clip_name_help = true)}
                         on:mouseleave={() => (show_clip_name_help = false)}
                       >


### PR DESCRIPTION
## Problem 
1.Resolves #267: Users want to manually rename merged clips.
2.Addresses community feedback: Need improved support for merging full live clips.

## Improvements
- feat: Support custom selection, ordering and merging of whole live clips
- feat: Allow custom output filenames for merged clips
- feat: Add {note} field to default clip filename format (configurable in Settings)
- ui/ux: Add help popover for filename format placeholder in Settings page
## Details & Demo
For a complete walkthrough with screenshots and examples, please refer to this document: 
【腾讯文档】Feat manual select merge replay https://docs.qq.com/doc/DZXd2RG1PWkxIVUt0

1. Default Filename Settings (New {note} field + help popover)
3. Full Live Replay Merging (Custom selection/sorting + custom filename)

## Future Improvements
1.Add a "add replay" feature to the full live replay merging workflow, to handle cases where multiple recordings belong to the same stream but are split in the database and cannot be merged normally.
2.Explore adding replay previews in the full live replay view. Currently, recordings only show start time and duration, making it hard for users to identify content. A simple preview would help creators select segments more easily.

## Summary by Sourcery

Add manual selection, ordering, and naming support for generating full replay clips, and extend filename templating for regular clips.

New Features:
- Allow users to select and order specific live recording segments when generating a full replay clip.
- Support custom output filenames when generating full replay clips from multiple segments.
- Extend clip filename templates with a {note} (and implicit {danmu}) field and default format including {note} for generated clips.
- Expose help popovers in the UI explaining filename template placeholders and full-replay selection behavior.

Enhancements:
- Improve whole-clip generation UI with selection controls, ordering indicators, aggregate duration/size summary, and a more compact layout.
- Make whole-clip generation robust to non-numeric or string durations in archives by normalizing and clamping durations before formatting.