### PR TITLE
Docker VAAPI 硬件编码误判修复+添加dcoker-compose示例

### DIFF
--- a/docker_compose.yaml
+++ b/docker_compose.yaml
@@ -1,0 +1,26 @@
+services:
+    Bilibili_ShadowReplay:
+        image: ghcr.io/xinrea/bili-shadowreplay:latest
+        container_name: Bili_ShadowReplay
+        restart: unless-stopped
+        devices:
+            - /dev/dri:/dev/dri
+        networks:
+            - stream_replay
+        ports:
+            - "3000:3000"
+        volumes:
+            - ./data:/app/data
+            - ./cache:/app/cache
+            - ./output:/app/output
+            - ./whisper_model.bin:/app/whisper_model.bin
+        environment:
+            DATA_DIR: /app/data
+            CACHE_DIR: /app/cache
+            OUTPUT_DIR: /app/output
+            WHISPER_MODEL: /app/whisper_model.bin
+
+
+networks:
+    stream_replay:
+        driver: bridge

--- a/docs/getting-started/config/ffmpeg.md
+++ b/docs/getting-started/config/ffmpeg.md
@@ -42,6 +42,10 @@ sudo yum install epel-release
 sudo yum install ffmpeg
 ```
 
+### Docker VAAPI 硬件编码
+
+在 Linux Docker 容器中使用核显 VAAPI 编码时，需要把宿主机的 `/dev/dri` 映射到容器中，并确保容器内 FFmpeg 支持 `h264_vaapi` 编码器。程序会自动检测 `/dev/dri/renderD*` 设备，并在测试和转码时追加 `-vaapi_device` 与 `format=nv12,hwupload` 参数。
+
 ## Windows
 
 Windows 版本安装后，FFmpeg 已经放置在了程序目录下，因此不需要额外安装。

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -16,8 +16,6 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 #[allow(unused_imports)]
 use std::os::windows::process::CommandExt;
 
-const H264_SCALE_PAD_FILTER: &str = "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2";
-
 /// Generate a random filename in hex
 pub async fn random_filename() -> String {
     format!("{:x}", rand::random::<u64>())
@@ -192,7 +190,7 @@ pub async fn concat_videos_with_transition(
             hwaccel::apply_x264_encoder_args(
                 &mut ffmpeg_process,
                 video_encoder,
-                Some(H264_SCALE_PAD_FILTER),
+                Some(hwaccel::H264_SCALE_PAD_FILTER),
             );
             ffmpeg_process.args(["-c:a", "aac"]);
             hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -16,6 +16,8 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 #[allow(unused_imports)]
 use std::os::windows::process::CommandExt;
 
+const H264_SCALE_PAD_FILTER: &str = "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2";
+
 /// Generate a random filename in hex
 pub async fn random_filename() -> String {
     format!("{:x}", rand::random::<u64>())
@@ -187,11 +189,13 @@ pub async fn concat_videos_with_transition(
         ]);
         if should_encode {
             let video_encoder = hwaccel::get_x264_encoder().await;
-            ffmpeg_process.args(["-vf", "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2"]);
-            ffmpeg_process.args(["-c:v", video_encoder]);
+            hwaccel::apply_x264_encoder_args(
+                &mut ffmpeg_process,
+                video_encoder,
+                Some(H264_SCALE_PAD_FILTER),
+            );
             ffmpeg_process.args(["-c:a", "aac"]);
-            ffmpeg_process.args(["-crf", "20"]);
-            ffmpeg_process.args(["-preset", "medium"]);
+            hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
             ffmpeg_process.args(["-threads", "0"]);
         } else {
             ffmpeg_process.args(["-c", "copy"]);
@@ -259,14 +263,23 @@ pub async fn concat_videos_with_transition(
         }
         filter_complex.push_str(&format!("concat=n={}:v=0:a=1[outa]", videos.len()));
 
-        ffmpeg_process.args(["-filter_complex", &filter_complex]);
-        ffmpeg_process.args(["-map", "[outv]"]);
+        let video_encoder = hwaccel::get_x264_encoder().await;
+
+        if hwaccel::is_vaapi_encoder(video_encoder) {
+            let filter_complex = format!(
+                "{filter_complex};[outv]{}[outv_hw]",
+                hwaccel::vaapi_filter_suffix()
+            );
+            ffmpeg_process.args(["-filter_complex", filter_complex.as_str()]);
+            ffmpeg_process.args(["-map", "[outv_hw]"]);
+        } else {
+            ffmpeg_process.args(["-filter_complex", &filter_complex]);
+            ffmpeg_process.args(["-map", "[outv]"]);
+        }
         ffmpeg_process.args(["-map", "[outa]"]);
 
-        let video_encoder = hwaccel::get_x264_encoder().await;
-        ffmpeg_process.args(["-c:v", video_encoder]);
-        ffmpeg_process.args(["-preset", "medium"]);
-        ffmpeg_process.args(["-crf", "20"]);
+        hwaccel::apply_x264_encoder_only(&mut ffmpeg_process, video_encoder);
+        hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
         ffmpeg_process.args(["-c:a", "aac"]);
         ffmpeg_process.args(["-progress", "pipe:2"]);
         ffmpeg_process.args(["-y"]);

--- a/src-tauri/src/ffmpeg/hwaccel.rs
+++ b/src-tauri/src/ffmpeg/hwaccel.rs
@@ -14,6 +14,9 @@ const TARGET_ENCODERS: [&str; 7] = [
     "h264_v4l2m2m",
 ];
 
+pub const H264_SCALE_PAD_FILTER: &str =
+    "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2";
+
 const VAAPI_ENCODER: &str = "h264_vaapi";
 const VAAPI_DEVICE_DIR: &str = "/dev/dri";
 const VAAPI_RENDER_PREFIX: &str = "renderD";
@@ -22,6 +25,7 @@ const VAAPI_FILTER_SUFFIX: &str = "format=nv12,hwupload";
 // 缓存选中的编码器，避免重复检查
 static ENCODER_CACHE: OnceLock<String> = OnceLock::new();
 
+/// 查找 Linux VAAPI render 设备。
 fn vaapi_device_path() -> Option<PathBuf> {
     let entries = std::fs::read_dir(VAAPI_DEVICE_DIR).ok()?;
     let mut devices = entries
@@ -38,6 +42,7 @@ fn vaapi_device_path() -> Option<PathBuf> {
     devices.into_iter().next()
 }
 
+/// 为 VAAPI 滤镜链追加硬件上传步骤。
 fn build_vaapi_filter(filter: &str) -> String {
     if filter.trim().is_empty() {
         VAAPI_FILTER_SUFFIX.to_string()
@@ -46,22 +51,26 @@ fn build_vaapi_filter(filter: &str) -> String {
     }
 }
 
+/// 判断编码器是否为 VAAPI。
 pub fn is_vaapi_encoder(encoder: &str) -> bool {
     encoder == VAAPI_ENCODER
 }
 
+/// 返回 VAAPI 硬件上传滤镜片段。
 pub fn vaapi_filter_suffix() -> &'static str {
     VAAPI_FILTER_SUFFIX
 }
 
+/// 为 FFmpeg 命令追加 VAAPI 设备参数。
 fn apply_vaapi_device(command: &mut tokio::process::Command) {
     if let Some(device_path) = vaapi_device_path() {
-        command.args(["-vaapi_device", device_path.to_str().unwrap()]);
+        command.args(["-vaapi_device", device_path.to_string_lossy().as_ref()]);
     } else {
         log::warn!("VAAPI encoder selected but no /dev/dri/renderD* device was found");
     }
 }
 
+/// 只追加视频编码器参数，不追加视频滤镜。
 pub fn apply_x264_encoder_only(command: &mut tokio::process::Command, encoder: &str) {
     if is_vaapi_encoder(encoder) {
         apply_vaapi_device(command);
@@ -69,6 +78,7 @@ pub fn apply_x264_encoder_only(command: &mut tokio::process::Command, encoder: &
     command.args(["-c:v", encoder]);
 }
 
+/// 按编码器类型追加质量参数。
 pub fn apply_x264_quality_args(command: &mut tokio::process::Command, encoder: &str) {
     if is_vaapi_encoder(encoder) {
         command.args(["-qp", "20"]);
@@ -78,6 +88,7 @@ pub fn apply_x264_quality_args(command: &mut tokio::process::Command, encoder: &
     }
 }
 
+/// 追加视频编码器参数，并在 VAAPI 下补齐硬件上传滤镜。
 pub fn apply_x264_encoder_args(
     command: &mut tokio::process::Command,
     encoder: &str,
@@ -195,14 +206,11 @@ async fn test_encoder_availability(encoder: &str) -> bool {
     // 使用合成输入源 (testsrc2) 测试编码器
     // -frames:v 3 只编码3帧，快速测试
     // -f null 丢弃输出，不需要实际文件
-    command
-        .arg("-hide_banner")
-        .arg("-loglevel")
-        .arg("error");
+    command.arg("-hide_banner").arg("-loglevel").arg("error");
 
     let filter = if is_vaapi_encoder(encoder) {
         if let Some(device_path) = vaapi_device_path() {
-            command.args(["-vaapi_device", device_path.to_str().unwrap()]);
+            command.args(["-vaapi_device", device_path.to_string_lossy().as_ref()]);
             Some(vaapi_filter_suffix())
         } else {
             log::debug!("Encoder {encoder} failed: no /dev/dri/renderD* device was found");

--- a/src-tauri/src/ffmpeg/hwaccel.rs
+++ b/src-tauri/src/ffmpeg/hwaccel.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, process::Stdio, sync::OnceLock};
+use std::{collections::HashSet, path::PathBuf, process::Stdio, sync::OnceLock};
 
 use tokio::io::AsyncReadExt;
 
@@ -14,8 +14,90 @@ const TARGET_ENCODERS: [&str; 7] = [
     "h264_v4l2m2m",
 ];
 
+const VAAPI_ENCODER: &str = "h264_vaapi";
+const VAAPI_DEVICE_DIR: &str = "/dev/dri";
+const VAAPI_RENDER_PREFIX: &str = "renderD";
+const VAAPI_FILTER_SUFFIX: &str = "format=nv12,hwupload";
+
 // 缓存选中的编码器，避免重复检查
 static ENCODER_CACHE: OnceLock<String> = OnceLock::new();
+
+fn vaapi_device_path() -> Option<PathBuf> {
+    let entries = std::fs::read_dir(VAAPI_DEVICE_DIR).ok()?;
+    let mut devices = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(VAAPI_RENDER_PREFIX))
+        })
+        .collect::<Vec<_>>();
+
+    devices.sort();
+    devices.into_iter().next()
+}
+
+fn build_vaapi_filter(filter: &str) -> String {
+    if filter.trim().is_empty() {
+        VAAPI_FILTER_SUFFIX.to_string()
+    } else {
+        format!("{filter},{VAAPI_FILTER_SUFFIX}")
+    }
+}
+
+pub fn is_vaapi_encoder(encoder: &str) -> bool {
+    encoder == VAAPI_ENCODER
+}
+
+pub fn vaapi_filter_suffix() -> &'static str {
+    VAAPI_FILTER_SUFFIX
+}
+
+fn apply_vaapi_device(command: &mut tokio::process::Command) {
+    if let Some(device_path) = vaapi_device_path() {
+        command.args(["-vaapi_device", device_path.to_str().unwrap()]);
+    } else {
+        log::warn!("VAAPI encoder selected but no /dev/dri/renderD* device was found");
+    }
+}
+
+pub fn apply_x264_encoder_only(command: &mut tokio::process::Command, encoder: &str) {
+    if is_vaapi_encoder(encoder) {
+        apply_vaapi_device(command);
+    }
+    command.args(["-c:v", encoder]);
+}
+
+pub fn apply_x264_quality_args(command: &mut tokio::process::Command, encoder: &str) {
+    if is_vaapi_encoder(encoder) {
+        command.args(["-qp", "20"]);
+    } else {
+        command.args(["-crf", "20"]);
+        command.args(["-preset", "medium"]);
+    }
+}
+
+pub fn apply_x264_encoder_args(
+    command: &mut tokio::process::Command,
+    encoder: &str,
+    filter: Option<&str>,
+) {
+    if is_vaapi_encoder(encoder) {
+        apply_vaapi_device(command);
+
+        let filter = filter
+            .map(build_vaapi_filter)
+            .unwrap_or_else(|| VAAPI_FILTER_SUFFIX.to_string());
+        command.args(["-vf", filter.as_str()]);
+        command.args(["-c:v", encoder]);
+    } else {
+        if let Some(filter) = filter {
+            command.args(["-vf", filter]);
+        }
+        command.args(["-c:v", encoder]);
+    }
+}
 
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -111,18 +193,37 @@ async fn test_encoder_availability(encoder: &str) -> bool {
     command.creation_flags(CREATE_NO_WINDOW);
 
     // 使用合成输入源 (testsrc2) 测试编码器
-    // -t 0.1 只编码0.1秒，-frames:v 3 只编码3帧，快速测试
+    // -frames:v 3 只编码3帧，快速测试
     // -f null 丢弃输出，不需要实际文件
-    let child = command
+    command
         .arg("-hide_banner")
         .arg("-loglevel")
-        .arg("error")
+        .arg("error");
+
+    let filter = if is_vaapi_encoder(encoder) {
+        if let Some(device_path) = vaapi_device_path() {
+            command.args(["-vaapi_device", device_path.to_str().unwrap()]);
+            Some(vaapi_filter_suffix())
+        } else {
+            log::debug!("Encoder {encoder} failed: no /dev/dri/renderD* device was found");
+            return false;
+        }
+    } else {
+        None
+    };
+
+    command
         .arg("-f")
         .arg("lavfi")
         .arg("-i")
-        .arg("testsrc2=duration=0.1:size=320x240:rate=1")
-        .arg("-c:v")
-        .arg(encoder)
+        .arg("testsrc2=duration=1:size=320x240:rate=30");
+
+    if let Some(filter) = filter {
+        command.args(["-vf", filter]);
+    }
+    command.args(["-c:v", encoder]);
+
+    let child = command
         .arg("-frames:v")
         .arg("3")
         .arg("-f")

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -33,8 +33,6 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 #[allow(unused_imports)]
 use std::os::windows::process::CommandExt;
 
-const H264_SCALE_PAD_FILTER: &str = "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2";
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Range {
     pub start: f64,
@@ -78,10 +76,9 @@ pub async fn transcode(
         hwaccel::apply_x264_encoder_args(
             &mut ffmpeg_process,
             video_encoder,
-            Some(H264_SCALE_PAD_FILTER),
+            Some(hwaccel::H264_SCALE_PAD_FILTER),
         );
-        ffmpeg_process
-            .args(["-c:a", "aac"]);
+        ffmpeg_process.args(["-c:a", "aac"]);
         hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
         ffmpeg_process.args(["-threads", "0"]);
     }
@@ -459,7 +456,10 @@ pub async fn encode_video_subtitle(
     } else {
         format!("'{}'", subtitle.display())
     };
-    let vf = format!("{H264_SCALE_PAD_FILTER},subtitles={subtitle}:force_style='{srt_style}'");
+    let vf = format!(
+        "{},subtitles={subtitle}:force_style='{srt_style}'",
+        hwaccel::H264_SCALE_PAD_FILTER
+    );
     log::info!("vf: {vf}");
 
     let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
@@ -563,7 +563,7 @@ pub async fn encode_video_danmu(
 
     let video_encoder = hwaccel::get_x264_encoder().await;
 
-    let vf = format!("{H264_SCALE_PAD_FILTER},ass={subtitle}");
+    let vf = format!("{},ass={subtitle}", hwaccel::H264_SCALE_PAD_FILTER);
     ffmpeg_process.args(["-i", file.to_str().unwrap()]);
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
     ffmpeg_process.args(["-c:a", "copy"]);

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -33,6 +33,8 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 #[allow(unused_imports)]
 use std::os::windows::process::CommandExt;
 
+const H264_SCALE_PAD_FILTER: &str = "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Range {
     pub start: f64,
@@ -73,13 +75,15 @@ pub async fn transcode(
         ffmpeg_process.args(["-c:v", "copy"]).args(["-c:a", "copy"]);
     } else {
         let video_encoder = hwaccel::get_x264_encoder().await;
+        hwaccel::apply_x264_encoder_args(
+            &mut ffmpeg_process,
+            video_encoder,
+            Some(H264_SCALE_PAD_FILTER),
+        );
         ffmpeg_process
-            .args(["-vf", "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2"])
-            .args(["-c:v", video_encoder])
-            .args(["-c:a", "aac"])
-            .args(["-crf", "20"])
-            .args(["-preset", "medium"])
-            .args(["-threads", "0"]);
+            .args(["-c:a", "aac"]);
+        hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
+        ffmpeg_process.args(["-threads", "0"]);
     }
 
     let child = ffmpeg_process
@@ -455,7 +459,7 @@ pub async fn encode_video_subtitle(
     } else {
         format!("'{}'", subtitle.display())
     };
-    let vf = format!("scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,subtitles={subtitle}:force_style='{srt_style}'");
+    let vf = format!("{H264_SCALE_PAD_FILTER},subtitles={subtitle}:force_style='{srt_style}'");
     log::info!("vf: {vf}");
 
     let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
@@ -464,13 +468,11 @@ pub async fn encode_video_subtitle(
 
     let video_encoder = hwaccel::get_x264_encoder().await;
 
+    ffmpeg_process.args(["-i", file.to_str().unwrap()]);
+    hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
+    ffmpeg_process.args(["-c:a", "copy"]);
+    hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
     let child = ffmpeg_process
-        .args(["-i", file.to_str().unwrap()])
-        .args(["-vf", vf.as_str()])
-        .args(["-c:v", video_encoder])
-        .args(["-c:a", "copy"])
-        .args(["-crf", "20"])
-        .args(["-preset", "medium"])
         .args([output_path.to_str().unwrap()])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
@@ -561,13 +563,12 @@ pub async fn encode_video_danmu(
 
     let video_encoder = hwaccel::get_x264_encoder().await;
 
+    let vf = format!("{H264_SCALE_PAD_FILTER},ass={subtitle}");
+    ffmpeg_process.args(["-i", file.to_str().unwrap()]);
+    hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
+    ffmpeg_process.args(["-c:a", "copy"]);
+    hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
     let child = ffmpeg_process
-        .args(["-i", file.to_str().unwrap()])
-        .args(["-vf", &format!("scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,ass={subtitle}")])
-        .args(["-c:v", video_encoder])
-        .args(["-c:a", "copy"])
-        .args(["-crf", "20"])
-        .args(["-preset", "medium"])
         .args([output_file_path.to_str().unwrap()])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
@@ -876,14 +877,14 @@ pub async fn clip_from_video_file(
 
     let video_encoder = hwaccel::get_x264_encoder().await;
 
-    let child = ffmpeg_process
+    ffmpeg_process
         .args(["-i", &format!("{}", input_path.display())])
         .args(["-ss", &start_time.to_string()])
-        .args(["-t", &duration.to_string()])
-        .args(["-c:v", video_encoder])
-        .args(["-c:a", "aac"])
-        .args(["-crf", "20"])
-        .args(["-preset", "medium"])
+        .args(["-t", &duration.to_string()]);
+    hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, None);
+    ffmpeg_process.args(["-c:a", "aac"]);
+    hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
+    let child = ffmpeg_process
         .args(["-avoid_negative_ts", "make_zero"])
         .args(["-y", output_path.to_str().unwrap()])
         .args(["-progress", "pipe:2"])

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -1593,8 +1593,8 @@ impl RecorderManager {
 
         let cover_filename = output_filename.with_extension("jpg");
 
-        let output_path = Path::new(&self.config.read().await.output.as_str())
-            .join(&output_filename);
+        let output_path =
+            Path::new(&self.config.read().await.output.as_str()).join(&output_filename);
 
         let playlists_refs: Vec<&Path> = playlists.iter().map(|p| p.path.as_path()).collect();
 


### PR DESCRIPTION
# Docker VAAPI 硬件编码误判修复

## 问题背景

项目通过 `get_x264_encoder()` 自动选择 H.264 硬件编码器，并在 `test_encoder_availability()` 中用 FFmpeg 合成测试流验证编码器是否真实可用。

在 Linux Docker 容器中，即使已经通过 `-v /dev/dri:/dev/dri` 映射宿主机核显设备，原检测命令仍可能把 `h264_vaapi` 误判为不可用，最终回退到 `libx264`，导致实际编码仍由 CPU 承担。

原检测命令缺少 VAAPI 必需的设备与像素格式上传参数，例如：

```bash
ffmpeg -hide_banner -loglevel error \
  -f lavfi -i testsrc2=duration=0.1:size=320x240:rate=1 \
  -c:v h264_vaapi \
  -frames:v 3 \
  -f null -
```

在 Docker VAAPI 环境中，该命令会因为软件帧无法自动转换为 VAAPI 硬件帧而失败。

## 修复内容

### 1. 修复 VAAPI 可用性检测

在 `src-tauri/src/ffmpeg/hwaccel.rs` 中为 `h264_vaapi` 增加专用检测参数：

- 自动查找 `/dev/dri/renderD*` 设备；
- 检测命令追加 `-vaapi_device <renderD*>`；
- 检测命令追加 `-vf format=nv12,hwupload`；
- 测试流调整为更接近实际编码场景的 `duration=1:size=320x240:rate=30`。

修复后的 VAAPI 检测语义等价于：

```bash
ffmpeg -hide_banner -loglevel error \
  -vaapi_device /dev/dri/renderD128 \
  -f lavfi -i testsrc2=duration=1:size=320x240:rate=30 \
  -vf format=nv12,hwupload \
  -c:v h264_vaapi \
  -frames:v 3 \
  -f null -
```

### 2. 确保检测通过后实际转码也使用 VAAPI 参数

仅修复检测命令还不够；如果实际转码命令仍只使用 `-c:v h264_vaapi`，同样可能因为缺少 VAAPI 设备或 `hwupload` 滤镜而失败。

因此新增了统一的 FFmpeg 编码参数构造逻辑，用于在实际转码时：

- 对 VAAPI 自动追加 `-vaapi_device`；
- 对 VAAPI 自动把普通视频滤镜后接 `format=nv12,hwupload`；
- 无普通滤镜时也会追加 `-vf format=nv12,hwupload`；
- 非 VAAPI 编码器保持原有行为。

### 3. 更新所有相关调用点

本次修复覆盖了主要 `get_x264_encoder()` 调用路径：

- `src-tauri/src/ffmpeg/mod.rs`
  - `transcode`
  - `encode_video_subtitle`
  - `encode_video_danmu`
  - `clip_from_video_file`

- `src-tauri/src/ffmpeg/general.rs`
  - 普通视频合并重新编码路径
  - 带转场的 `filter_complex` 合并路径

其中 `filter_complex` 场景不能简单追加 `-vf`，因此对 VAAPI 单独把 `[outv]format=nv12,hwupload[outv_hw]` 接入 filter graph，并映射 `[outv_hw]` 输出，避免 `-vf` 与 `-filter_complex` 冲突。

### 4. 调整编码质量参数

原逻辑对所有编码器统一追加：

```bash
-crf 20 -preset medium
```

这更适合 `libx264`，但不适合所有硬件编码器。修复后：

- VAAPI 使用 `-qp 20`；
- 非 VAAPI 继续使用原来的 `-crf 20 -preset medium`。

这样可以降低 VAAPI 实际转码阶段因不兼容参数失败的风险。

### 5. 补充文档

更新了 `docs/getting-started/config/ffmpeg.md`，新增 Docker VAAPI 硬件编码说明：

- Docker 容器需要映射 `/dev/dri`；
- 容器内 FFmpeg 需要支持 `h264_vaapi`；
- 程序会自动检测 `/dev/dri/renderD*` 并追加 VAAPI 所需参数。

根目录添加了docker_compose.yaml作为示例文件。

## 预期效果

在 Linux Docker 容器中，只要满足以下条件：

1. 宿主机核显驱动可用；
2. 容器启动时映射了 `/dev/dri:/dev/dri`；
3. 容器内 FFmpeg 编译/安装了 `h264_vaapi` 编码器；
4. 当前用户对 `/dev/dri/renderD*` 有访问权限；

程序就应能正确检测到 `h264_vaapi` 可用，并在后续转码、切片、字幕压制、弹幕压制、视频合并等路径中实际使用 VAAPI 核显编码，而不是误回退到 CPU `libx264`。

## 验证情况

已完成的检查：

- `git diff --check` 无空白或 patch 格式问题；
- 代码审查中已覆盖复用、质量、效率风险，重点检查了：
  - VAAPI 检测参数；
  - 实际转码参数是否与检测一致；
  - `-vf` 与 `-filter_complex` 的兼容性；
  - 非 VAAPI 编码器行为是否保持兼容。

已在 Docker 环境中执行实际转码任务进行验证，通过 FFmpeg 日志确认 `h264_vaapi` 被选中并承担编码。

## 验证环境：

- 系统：群晖DSM7.2-Docker
- CPU：Intel N100

## Summary by Sourcery

Improve VAAPI H.264 hardware encoder detection and usage in Docker environments and add a Docker Compose example for easier deployment.

New Features:
- Add centralized helpers to apply encoder selection, VAAPI device settings, and quality parameters when building FFmpeg commands.
- Provide a docker_compose.yaml example for running the application with VAAPI hardware encoding enabled via /dev/dri mapping.

Bug Fixes:
- Correctly detect h264_vaapi availability in Docker by probing /dev/dri/renderD* devices and applying required VAAPI filters during test encoding.
- Ensure actual transcoding, clipping, subtitle and danmaku encoding, and video concatenation pipelines use the same VAAPI-specific parameters as detection to avoid silent fallback to CPU encoding.

Enhancements:
- Unify and reuse the scale-and-pad filter string across video processing paths.
- Adjust quality options to use -qp for VAAPI encoders while retaining -crf/-preset for software encoders for better compatibility and results.

Build:
- Add the tauri runtime dependency to package.json.

Documentation:
- Document Docker VAAPI hardware encoding requirements and automatic parameter handling in the FFmpeg configuration guide.

## Summary by Sourcery

Fix VAAPI H.264 hardware encoder detection and usage in Docker environments and add a Docker Compose example for VAAPI-enabled deployment.

New Features:
- Introduce shared helpers to apply encoder selection, VAAPI device configuration, filters, and quality settings when constructing FFmpeg commands.
- Provide a docker_compose.yaml example for running the application with mapped /dev/dri for VAAPI hardware encoding.

Bug Fixes:
- Correct h264_vaapi availability testing by probing /dev/dri/renderD* devices and applying required VAAPI device and format upload options in the test encoding command.
- Ensure all transcoding, clipping, subtitle and danmaku encoding, and video concatenation paths apply VAAPI-specific parameters consistently to avoid falling back to CPU encoding.

Enhancements:
- Centralize and reuse the standard 1080p scale-and-pad filter across FFmpeg video processing paths.
- Adjust quality options to use -qp for VAAPI encoders while keeping -crf and -preset for non-VAAPI encoders for better compatibility and results.

Documentation:
- Document Docker VAAPI hardware encoding requirements and automatic parameter handling in the FFmpeg configuration guide.

Chores:
- Add a Docker Compose configuration example for easier container deployment with hardware acceleration.