### PR TITLE
修复：关闭Web页面后，切片任务卡在processing无法继续进行

### DIFF
--- a/docs/development/backend/recorder-manager.md
+++ b/docs/development/backend/recorder-manager.md
@@ -96,7 +96,12 @@ enum RecordingStatus {
 }
 ```
 
-## 主要方法
+## 切片任务取消
+
+实时回放页面的 `clip_range` 命令会先在数据库创建任务记录，再交给 `TaskManager` 执行实际的 `RecorderManager::clip_range` 流程。前端关闭页面或用户取消时调用 `cancel` 命令，后端通过 `TaskManager::cancel_task` 中止运行中的任务并把数据库状态更新为 `cancelled`，避免任务停留在 `processing`。
+
+切片、转码、合并和弹幕压制中的 FFmpeg 子进程必须随 Rust future 取消而退出。使用 `tokio::process::Child::kill_on_drop(true)` 包装 FFmpeg 进程，确保 TaskManager abort 时不会留下后台 FFmpeg 进程继续运行。
+
 
 ### 创建录制任务
 

--- a/docs/development/backend/recorder-manager.md
+++ b/docs/development/backend/recorder-manager.md
@@ -98,7 +98,7 @@ enum RecordingStatus {
 
 ## 切片任务取消
 
-实时回放页面的 `clip_range` 命令会先在数据库创建任务记录，再交给 `TaskManager` 执行实际的 `RecorderManager::clip_range` 流程。前端关闭页面或用户取消时调用 `cancel` 命令，后端通过 `TaskManager::cancel_task` 中止运行中的任务；只有任务实际取消，或数据库记录仍处于 `pending` / `processing` 时，才会把数据库状态更新为 `cancelled`，避免覆盖已经完成的任务。
+实时回放页面的 `clip_range` 命令会先在数据库创建任务记录，再交给 `TaskManager` 执行实际的 `RecorderManager::clip_range` 流程。这样切片任务不会绑定在 Web 页面的 HTTP 请求生命周期上，页面关闭后仍可继续在后台运行。用户显式取消任务时，后端通过 `TaskManager::cancel_task` 中止运行中的任务；只有任务实际取消，或数据库记录仍处于 `pending` / `processing` 时，才会把数据库状态更新为 `cancelled`，避免覆盖已经完成的任务。
 
 切片、转码、合并和弹幕压制中的 FFmpeg 子进程必须随 Rust future 取消而退出。统一使用 `ffmpeg::ffmpeg_command()` 创建 FFmpeg 命令并设置 `kill_on_drop(true)`，确保 TaskManager abort 时不会留下后台 FFmpeg 进程继续运行。
 

--- a/docs/development/backend/recorder-manager.md
+++ b/docs/development/backend/recorder-manager.md
@@ -98,9 +98,9 @@ enum RecordingStatus {
 
 ## 切片任务取消
 
-实时回放页面的 `clip_range` 命令会先在数据库创建任务记录，再交给 `TaskManager` 执行实际的 `RecorderManager::clip_range` 流程。前端关闭页面或用户取消时调用 `cancel` 命令，后端通过 `TaskManager::cancel_task` 中止运行中的任务并把数据库状态更新为 `cancelled`，避免任务停留在 `processing`。
+实时回放页面的 `clip_range` 命令会先在数据库创建任务记录，再交给 `TaskManager` 执行实际的 `RecorderManager::clip_range` 流程。前端关闭页面或用户取消时调用 `cancel` 命令，后端通过 `TaskManager::cancel_task` 中止运行中的任务；只有任务实际取消，或数据库记录仍处于 `pending` / `processing` 时，才会把数据库状态更新为 `cancelled`，避免覆盖已经完成的任务。
 
-切片、转码、合并和弹幕压制中的 FFmpeg 子进程必须随 Rust future 取消而退出。使用 `tokio::process::Child::kill_on_drop(true)` 包装 FFmpeg 进程，确保 TaskManager abort 时不会留下后台 FFmpeg 进程继续运行。
+切片、转码、合并和弹幕压制中的 FFmpeg 子进程必须随 Rust future 取消而退出。统一使用 `ffmpeg::ffmpeg_command()` 创建 FFmpeg 命令并设置 `kill_on_drop(true)`，确保 TaskManager abort 时不会留下后台 FFmpeg 进程继续运行。
 
 
 ### 创建录制任务

--- a/docs/development/frontend/invoker.md
+++ b/docs/development/frontend/invoker.md
@@ -139,7 +139,7 @@ export async function getClips(recordingId: string) {
 
 ### 切片任务生命周期
 
-实时回放页使用 `clip_range` 生成切片时会保存当前 `eventId`，监听 `progress-update:<eventId>` 和 `progress-finished:<eventId>` 更新按钮状态。页面卸载不会取消后端切片任务；切片任务进入 `TaskManager` 后会继续在后台运行。若页面关闭/刷新时仍有切片任务运行，前端会通过 `beforeunload` 提示用户可前往任务页面管理后台任务。只有用户显式触发取消时，才会调用 `cancel` 命令将任务状态写为 `cancelled`，并中止关联的 FFmpeg 处理。
+实时回放页使用 `clip_range` 生成切片时会保存当前 `eventId`，监听 `progress-update:<eventId>` 和 `progress-finished:<eventId>` 更新按钮状态。页面卸载不会取消后端切片任务；切片任务进入 `TaskManager` 后会继续在后台运行。若页面关闭/刷新时仍有切片任务运行，前端会通过 `beforeunload` 触发浏览器原生离开确认，并在页面内提示用户可前往任务页面管理后台任务；浏览器不允许自定义原生离开确认文案。只有用户显式触发取消时，才会调用 `cancel` 命令将任务状态写为 `cancelled`，并中止关联的 FFmpeg 处理。切片完成、失败或取消请求返回后，前端会清理进度监听器并恢复生成按钮状态。
 
 
 ### 后端错误返回

--- a/docs/development/frontend/invoker.md
+++ b/docs/development/frontend/invoker.md
@@ -139,7 +139,7 @@ export async function getClips(recordingId: string) {
 
 ### 切片任务生命周期
 
-实时回放页使用 `clip_range` 生成切片时会保存当前 `eventId`，监听 `progress-update:<eventId>` 和 `progress-finished:<eventId>` 更新按钮状态。页面卸载时如果切片仍在运行，会调用 `cancel` 命令取消后端任务；取消命令会将任务状态写为 `cancelled`，并中止关联的 FFmpeg 处理。
+实时回放页使用 `clip_range` 生成切片时会保存当前 `eventId`，监听 `progress-update:<eventId>` 和 `progress-finished:<eventId>` 更新按钮状态。页面卸载不会取消后端切片任务；切片任务进入 `TaskManager` 后会继续在后台运行。若页面关闭/刷新时仍有切片任务运行，前端会通过 `beforeunload` 提示用户可前往任务页面管理后台任务。只有用户显式触发取消时，才会调用 `cancel` 命令将任务状态写为 `cancelled`，并中止关联的 FFmpeg 处理。
 
 
 ### 后端错误返回

--- a/docs/development/frontend/invoker.md
+++ b/docs/development/frontend/invoker.md
@@ -137,7 +137,10 @@ export async function getClips(recordingId: string) {
 }
 ```
 
-## 错误处理
+### 切片任务生命周期
+
+实时回放页使用 `clip_range` 生成切片时会保存当前 `eventId`，监听 `progress-update:<eventId>` 和 `progress-finished:<eventId>` 更新按钮状态。页面卸载时如果切片仍在运行，会调用 `cancel` 命令取消后端任务；取消命令会将任务状态写为 `cancelled`，并中止关联的 FFmpeg 处理。
+
 
 ### 后端错误返回
 

--- a/src-tauri/src/database/task.rs
+++ b/src-tauri/src/database/task.rs
@@ -58,6 +58,15 @@ impl Database {
         Ok(tasks)
     }
 
+    pub async fn get_task(&self, id: &str) -> Result<TaskRow, DatabaseError> {
+        let lock = self.db.read().await.clone().unwrap();
+        let task = sqlx::query_as::<_, TaskRow>("SELECT * FROM tasks WHERE id = $1")
+            .bind(id)
+            .fetch_one(&lock)
+            .await?;
+        Ok(task)
+    }
+
     pub async fn update_task(
         &self,
         id: &str,

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -51,6 +51,7 @@ pub async fn handle_ffmpeg_process(
     ffmpeg_process: &mut tokio::process::Command,
 ) -> Result<(), String> {
     log::info!("[FFmpeg] {:?}", ffmpeg_process);
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -8,7 +8,7 @@ use tokio::io::{AsyncWriteExt, BufReader};
 
 use crate::{ffmpeg::hwaccel, progress::progress_reporter::ProgressReporterTrait};
 
-use super::ffmpeg_path;
+use super::ffmpeg_command;
 
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -51,7 +51,6 @@ pub async fn handle_ffmpeg_process(
     ffmpeg_process: &mut tokio::process::Command,
 ) -> Result<(), String> {
     log::info!("[FFmpeg] {:?}", ffmpeg_process);
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
@@ -145,7 +144,7 @@ pub async fn concat_videos_with_transition(
     output_path: &Path,
     transition: Option<&str>,
 ) -> Result<(), String> {
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
@@ -292,7 +291,8 @@ pub async fn concat_videos_with_transition(
 
 #[cfg(test)]
 mod concat_videos_tests {
-    use super::{concat_videos, ffmpeg_path, random_filename};
+    use super::{concat_videos, random_filename};
+    use crate::ffmpeg::ffmpeg_path;
     use std::path::Path;
 
     #[cfg(target_os = "windows")]

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -83,6 +83,7 @@ pub async fn transcode(
         ffmpeg_process.args(["-threads", "0"]);
     }
 
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args([output_path.to_str().unwrap()])
         .args(["-y"])
@@ -145,6 +146,7 @@ pub async fn trim_video(
     ffmpeg_process.args(["-y"]);
     ffmpeg_process.args(["-progress", "pipe:2"]);
     ffmpeg_process.stderr(Stdio::piped());
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process.spawn();
     if let Err(e) = child {
         return Err(e.to_string());
@@ -195,6 +197,7 @@ pub async fn extract_audio_sample(file: &Path) -> Result<PathBuf, String> {
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args(["-i", file.to_str().unwrap()])
         .args(["-c:a", "libopus"])
@@ -327,6 +330,7 @@ pub async fn extract_audio_chunks(file: &Path, format: &str) -> Result<PathBuf, 
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process.args(&args).stderr(Stdio::piped()).spawn();
 
     if let Err(e) = child {
@@ -472,6 +476,7 @@ pub async fn encode_video_subtitle(
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
     ffmpeg_process.args(["-c:a", "copy"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args([output_path.to_str().unwrap()])
         .args(["-y"])
@@ -568,6 +573,7 @@ pub async fn encode_video_danmu(
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
     ffmpeg_process.args(["-c:a", "copy"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args([output_file_path.to_str().unwrap()])
         .args(["-y"])
@@ -628,6 +634,7 @@ pub async fn generic_ffmpeg_command(args: &[&str]) -> Result<String, String> {
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process.args(args).stderr(Stdio::piped()).spawn();
     if let Err(e) = child {
         return Err(e.to_string());
@@ -884,6 +891,7 @@ pub async fn clip_from_video_file(
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, None);
     ffmpeg_process.args(["-c:a", "aac"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
+    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args(["-avoid_negative_ts", "make_zero"])
         .args(["-y", output_path.to_str().unwrap()])

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -63,7 +63,7 @@ pub async fn transcode(
 ) -> Result<(), String> {
     // ffmpeg -i fixed_\[30655190\]1742887114_0325084106_81.5.mp4 -c:v libx264 -c:a aac -b:v 6000k -b:a 64k -compression_level 0 -threads 0 output.mp3
     log::info!("Transcode: {} copy: {}", file.display(), copy_codecs);
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
@@ -83,7 +83,6 @@ pub async fn transcode(
         ffmpeg_process.args(["-threads", "0"]);
     }
 
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args([output_path.to_str().unwrap()])
         .args(["-y"])
@@ -134,7 +133,7 @@ pub async fn trim_video(
 ) -> Result<(), String> {
     // ffmpeg -i fixed_\[30655190\]1742887114_0325084106_81.5.mp4 -ss 0 -t 10 output.mp4
     log::info!("Trim video task start: {}", file.display());
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
@@ -146,7 +145,6 @@ pub async fn trim_video(
     ffmpeg_process.args(["-y"]);
     ffmpeg_process.args(["-progress", "pipe:2"]);
     ffmpeg_process.stderr(Stdio::piped());
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process.spawn();
     if let Err(e) = child {
         return Err(e.to_string());
@@ -193,11 +191,10 @@ pub async fn extract_audio_sample(file: &Path) -> Result<PathBuf, String> {
     let output_path = file.with_extension("opus");
     let mut extract_error = None;
 
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args(["-i", file.to_str().unwrap()])
         .args(["-c:a", "libopus"])
@@ -326,11 +323,10 @@ pub async fn extract_audio_chunks(file: &Path, format: &str) -> Result<PathBuf, 
 
     args.push(segment_pattern_str);
 
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process.args(&args).stderr(Stdio::piped()).spawn();
 
     if let Err(e) = child {
@@ -466,7 +462,7 @@ pub async fn encode_video_subtitle(
     );
     log::info!("vf: {vf}");
 
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
@@ -476,7 +472,6 @@ pub async fn encode_video_subtitle(
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
     ffmpeg_process.args(["-c:a", "copy"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args([output_path.to_str().unwrap()])
         .args(["-y"])
@@ -562,7 +557,7 @@ pub async fn encode_video_danmu(
         format!("'{}'", subtitle.display())
     };
 
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
@@ -573,7 +568,6 @@ pub async fn encode_video_danmu(
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
     ffmpeg_process.args(["-c:a", "copy"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args([output_file_path.to_str().unwrap()])
         .args(["-y"])
@@ -630,11 +624,10 @@ pub async fn encode_video_danmu(
 }
 
 pub async fn generic_ffmpeg_command(args: &[&str]) -> Result<String, String> {
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process.args(args).stderr(Stdio::piped()).spawn();
     if let Err(e) = child {
         return Err(e.to_string());
@@ -847,6 +840,12 @@ pub async fn check_ffmpeg() -> Result<String, String> {
     }
 }
 
+pub fn ffmpeg_command() -> tokio::process::Command {
+    let mut command = tokio::process::Command::new(ffmpeg_path());
+    command.kill_on_drop(true);
+    command
+}
+
 pub fn ffmpeg_path() -> PathBuf {
     let mut path = Path::new("ffmpeg").to_path_buf();
     if cfg!(windows) {
@@ -878,7 +877,7 @@ pub async fn clip_from_video_file(
         std::fs::create_dir_all(output_folder).unwrap();
     }
 
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
@@ -891,7 +890,6 @@ pub async fn clip_from_video_file(
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, None);
     ffmpeg_process.args(["-c:a", "aac"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
-    ffmpeg_process.kill_on_drop(true);
     let child = ffmpeg_process
         .args(["-avoid_negative_ts", "make_zero"])
         .args(["-y", output_path.to_str().unwrap()])
@@ -1021,7 +1019,7 @@ pub async fn extract_video_metadata(file_path: &Path) -> Result<VideoMetadata, S
 /// # Returns
 /// The path to the generated thumbnail image.
 pub async fn generate_thumbnail(video_full_path: &Path, timestamp: f64) -> Result<PathBuf, String> {
-    let mut ffmpeg_process = tokio::process::Command::new(ffmpeg_path());
+    let mut ffmpeg_process = ffmpeg_command();
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 

--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -5,6 +5,7 @@ use crate::handlers::utils::get_disk_info_inner;
 use crate::progress::progress_reporter::{EventEmitter, ProgressReporter, ProgressReporterTrait};
 use crate::recorder_manager::ClipRangeParams;
 use crate::subtitle_generator::item_to_srt;
+use crate::task::{Task, TaskPriority};
 use crate::webhook::events;
 use base64::Engine;
 use chrono::{Local, Utc};
@@ -339,51 +340,86 @@ pub async fn clip_range(
     state.db.add_task(&task).await?;
     log::info!("Create task: {} {}", task.id, task.task_type);
 
-    let clip_result = clip_range_inner(&state, &reporter, params.clone()).await;
-    if let Err(e) = clip_result {
-        reporter.finish(false, &format!("切片失败: {e}")).await;
-        state
-            .db
-            .update_task(&event_id, "failed", &format!("切片失败: {e}"), None)
-            .await?;
-        return Err(e);
-    }
+    let (result_tx, result_rx) = tokio::sync::oneshot::channel();
 
-    let video = clip_result.unwrap();
+    #[cfg(feature = "gui")]
+    let state_clone = (*state).clone();
+    #[cfg(feature = "headless")]
+    let state_clone = state.clone();
 
-    reporter.finish(true, "切片完成").await;
+    let task_id = event_id.clone();
     state
-        .db
-        .update_task(&event_id, "success", "切片完成", None)
+        .task_manager
+        .add_task(Task::new(
+            task_id.clone(),
+            TaskPriority::Normal,
+            async move {
+                let result = match clip_range_inner(&state_clone, &reporter, params).await {
+                    Ok(video) => {
+                        reporter.finish(true, "切片完成").await;
+                        let _ = state_clone
+                            .db
+                            .update_task(&task_id, "success", "切片完成", None)
+                            .await;
+
+                        if state_clone.config.read().await.auto_subtitle {
+                            let subtitle_event_id = format!("{task_id}_subtitle");
+                            let result = generate_video_subtitle_inner(
+                                &state_clone,
+                                subtitle_event_id,
+                                video.id,
+                            )
+                            .await;
+                            if let Ok(subtitle) = result {
+                                let result =
+                                    update_video_subtitle_inner(&state_clone, video.id, subtitle)
+                                        .await;
+                                if let Err(e) = result {
+                                    log::error!("Update video subtitle error: {e}");
+                                }
+                            } else {
+                                log::error!(
+                                    "Generate video subtitle error: {}",
+                                    result.err().unwrap()
+                                );
+                            }
+                        }
+
+                        let event = events::new_webhook_event(
+                            events::CLIP_GENERATED,
+                            events::Payload::Clip(video.clone()),
+                        );
+
+                        if let Err(e) = state_clone.webhook_poster.post_event(&event).await {
+                            log::error!("Post webhook event error: {e}");
+                        }
+
+                        Ok(video)
+                    }
+                    Err(e) => {
+                        reporter.finish(false, &format!("切片失败: {e}")).await;
+                        let _ = state_clone
+                            .db
+                            .update_task(&task_id, "failed", &format!("切片失败: {e}"), None)
+                            .await;
+                        Err(e)
+                    }
+                };
+
+                let task_result = result.as_ref().map(|_| ()).map_err(Clone::clone);
+                let _ = result_tx.send(result);
+                task_result
+            },
+        ))
         .await?;
 
-    if state.config.read().await.auto_subtitle {
-        // generate a subtitle task event id
-        let subtitle_event_id = format!("{event_id}_subtitle");
-        let result = generate_video_subtitle(state.clone(), subtitle_event_id, video.id).await;
-        if let Ok(subtitle) = result {
-            let result = update_video_subtitle(state.clone(), video.id, subtitle).await;
-            if let Err(e) = result {
-                log::error!("Update video subtitle error: {e}");
-            }
-        } else {
-            log::error!("Generate video subtitle error: {}", result.err().unwrap());
-        }
-    }
-
-    // Emit webhook events
-    let event =
-        events::new_webhook_event(events::CLIP_GENERATED, events::Payload::Clip(video.clone()));
-
-    if let Err(e) = state.webhook_poster.post_event(&event).await {
-        log::error!("Post webhook event error: {e}");
-    }
-
-    Ok(video)
+    result_rx
+        .await
+        .unwrap_or_else(|_| Err("切片任务已取消".to_string()))
 }
 
 async fn clip_range_inner(
-    state: &state_type!(),
+    state: &State,
     reporter: &ProgressReporter,
     params: ClipRangeParams,
 ) -> Result<VideoRow, String> {
@@ -633,7 +669,17 @@ async fn upload_procedure_inner(
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn cancel(state: state_type!(), event_id: String) -> Result<(), String> {
     log::info!("Cancel task: {event_id}");
-    state.task_manager.cancel_task(&event_id).await?;
+    state
+        .task_manager
+        .cancel_task(&event_id)
+        .await
+        .or_else(|e| {
+            if e == "Task not found" {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        })?;
     state
         .db
         .update_task(&event_id, "cancelled", "任务取消", None)
@@ -763,6 +809,14 @@ pub async fn generate_video_subtitle(
     event_id: String,
     id: i64,
 ) -> Result<String, String> {
+    generate_video_subtitle_inner(&state, event_id, id).await
+}
+
+async fn generate_video_subtitle_inner(
+    state: &State,
+    event_id: String,
+    id: i64,
+) -> Result<String, String> {
     #[cfg(feature = "gui")]
     let emitter = EventEmitter::new(state.app_handle.clone());
     #[cfg(feature = "headless")]
@@ -832,7 +886,7 @@ pub async fn generate_video_subtitle(
                 .map(item_to_srt)
                 .collect::<String>();
 
-            let result = update_video_subtitle(state.clone(), id, subtitle.clone()).await;
+            let result = update_video_subtitle_inner(&state, id, subtitle.clone()).await;
             if let Err(e) = result {
                 log::error!("Update video subtitle error: {e}");
             }
@@ -852,6 +906,14 @@ pub async fn generate_video_subtitle(
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn update_video_subtitle(
     state: state_type!(),
+    id: i64,
+    subtitle: String,
+) -> Result<(), String> {
+    update_video_subtitle_inner(&state, id, subtitle).await
+}
+
+async fn update_video_subtitle_inner(
+    state: &State,
     id: i64,
     subtitle: String,
 ) -> Result<(), String> {

--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -669,21 +669,25 @@ async fn upload_procedure_inner(
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn cancel(state: state_type!(), event_id: String) -> Result<(), String> {
     log::info!("Cancel task: {event_id}");
-    state
-        .task_manager
-        .cancel_task(&event_id)
-        .await
-        .or_else(|e| {
-            if e == "Task not found" {
-                Ok(())
-            } else {
-                Err(e)
+    let cancel_result = state.task_manager.cancel_task(&event_id).await;
+    match cancel_result {
+        Ok(()) => {
+            state
+                .db
+                .update_task(&event_id, "cancelled", "任务取消", None)
+                .await?;
+        }
+        Err(e) if e == "Task not found" => {
+            let task = state.db.get_task(&event_id).await?;
+            if matches!(task.status.as_str(), "pending" | "processing") {
+                state
+                    .db
+                    .update_task(&event_id, "cancelled", "任务取消", None)
+                    .await?;
             }
-        })?;
-    state
-        .db
-        .update_task(&event_id, "cancelled", "任务取消", None)
-        .await?;
+        }
+        Err(e) => return Err(e),
+    }
     Ok(())
 }
 

--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -415,7 +415,7 @@ pub async fn clip_range(
 
     result_rx
         .await
-        .unwrap_or_else(|_| Err("切片任务已取消".to_string()))
+        .unwrap_or_else(|_| Err("切片任务失败".to_string()))
 }
 
 async fn clip_range_inner(

--- a/src/AppLive.svelte
+++ b/src/AppLive.svelte
@@ -411,14 +411,22 @@
     }
   }
 
+  function handleBeforeUnload(event: BeforeUnloadEvent) {
+    if (!current_clip_event_id) {
+      return;
+    }
+    const message = "切片任务将在后台继续运行，可前往任务页面管理后台任务。";
+    event.preventDefault();
+    event.returnValue = message;
+    return message;
+  }
+
   onDestroy(() => {
     // 清理滚动定时器
     if (scroll_timeout) {
       clearTimeout(scroll_timeout);
     }
-    if (current_clip_event_id) {
-      cancel_clip();
-    }
+    window.removeEventListener("beforeunload", handleBeforeUnload);
   });
 
   let archive: RecordItem = null;
@@ -496,6 +504,8 @@
       }
     );
     console.log(archive);
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
 
     // 初始化虚拟滚动
     setTimeout(() => {

--- a/src/AppLive.svelte
+++ b/src/AppLive.svelte
@@ -38,6 +38,8 @@
   });
 
   let current_clip_event_id = null;
+  let clear_clip_update_listener: (() => void) | null = null;
+  let clear_clip_finished_listener: (() => void) | null = null;
   let danmu_enabled = false;
   let fix_encoding = false;
   let clip_note: string = "";
@@ -557,68 +559,83 @@
     selected_video = target_video;
   }
 
+  function reset_clip_state() {
+    update_clip_prompt(`生成切片`);
+    current_clip_event_id = null;
+    clear_clip_update_listener?.();
+    clear_clip_update_listener = null;
+    clear_clip_finished_listener?.();
+    clear_clip_finished_listener = null;
+  }
+
   async function confirm_generate_clip() {
     show_clip_confirm = false;
     let new_cover = generateCover();
     update_clip_prompt(`切片生成中`);
     let event_id = generateEventId();
+    reset_clip_state();
     current_clip_event_id = event_id;
-    const clear_update_listener = await listen(
+    clear_clip_update_listener = await listen(
       `progress-update:${event_id}`,
       (e) => {
         update_clip_prompt(e.payload.content);
       }
     );
-    const clear_finished_listener = await listen(
+    clear_clip_finished_listener = await listen(
       `progress-finished:${event_id}`,
       (e) => {
-        update_clip_prompt(`生成切片`);
+        reset_clip_state();
         if (!e.payload.success) {
           alert("请检查 ffmpeg 是否配置正确：" + e.payload.message);
         }
-        current_clip_event_id = null;
-
-        clear_update_listener();
-        clear_finished_listener();
       }
     );
-    let new_video = (await clipRange(event_id, {
-      title: archive.title,
-      note: clip_note,
-      room_id: room_id,
-      platform: platform,
-      cover: new_cover,
-      live_id: live_id,
-      ranges: activeRanges,
-      danmu: danmu_enabled,
-      local_offset:
-        parseInt(localStorage.getItem(`local_offset:${live_id}`) || "0", 10) ||
-        0,
-      fix_encoding,
-      transition: transition !== "none" ? transition : undefined,
-    })) as VideoItem;
-    await get_video_list();
-    new_video.cover = await get_static_url("output", new_video.cover);
-    video_selected = new_video.id;
-    selected_video = videos.find((v) => {
-      return v.value == new_video.id;
-    });
-    if (selected_video) {
-      selected_video.cover = new_video.cover;
-    }
+    try {
+      let new_video = (await clipRange(event_id, {
+        title: archive.title,
+        note: clip_note,
+        room_id: room_id,
+        platform: platform,
+        cover: new_cover,
+        live_id: live_id,
+        ranges: activeRanges,
+        danmu: danmu_enabled,
+        local_offset:
+          parseInt(localStorage.getItem(`local_offset:${live_id}`) || "0", 10) ||
+          0,
+        fix_encoding,
+        transition: transition !== "none" ? transition : undefined,
+      })) as VideoItem;
+      await get_video_list();
+      new_video.cover = await get_static_url("output", new_video.cover);
+      video_selected = new_video.id;
+      selected_video = videos.find((v) => {
+        return v.value == new_video.id;
+      });
+      if (selected_video) {
+        selected_video.cover = new_video.cover;
+      }
 
-    // clean up previous input data
-    clip_note = "";
-    transition = "none";
+      // clean up previous input data
+      clip_note = "";
+      transition = "none";
+    } finally {
+      reset_clip_state();
+    }
   }
 
   async function cancel_clip() {
     if (!current_clip_event_id) {
       return;
     }
-    invoke("cancel", { eventId: current_clip_event_id }).catch((error) => {
-      log.warn("Failed to cancel clip task", error);
-    });
+    invoke("cancel", { eventId: current_clip_event_id })
+      .then(() => {
+        reset_clip_state();
+      })
+      .catch((error) => {
+        log.warn("Failed to cancel clip task", error);
+        reset_clip_state();
+      });
   }
 
   async function delete_video() {
@@ -802,6 +819,12 @@
                   {/if}
                 </div>
               </div>
+
+              {#if current_clip_event_id != null}
+                <div class="rounded-lg border border-[#0A84FF]/30 bg-[#0A84FF]/10 px-3 py-2 text-xs text-blue-100">
+                  切片任务将在后台继续运行，关闭页面不会取消任务；可前往任务页面管理后台任务。
+                </div>
+              {/if}
 
               <div class="flex flex-row items-center justify-between">
                 <select

--- a/src/AppLive.svelte
+++ b/src/AppLive.svelte
@@ -416,6 +416,9 @@
     if (scroll_timeout) {
       clearTimeout(scroll_timeout);
     }
+    if (current_clip_event_id) {
+      cancel_clip();
+    }
   });
 
   let archive: RecordItem = null;
@@ -603,7 +606,9 @@
     if (!current_clip_event_id) {
       return;
     }
-    invoke("cancel", { eventId: current_clip_event_id });
+    invoke("cancel", { eventId: current_clip_event_id }).catch((error) => {
+      log.warn("Failed to cancel clip task", error);
+    });
   }
 
   async function delete_video() {


### PR DESCRIPTION
## 问题背景

使用环境：群晖 DSM 7.2 Docker、Intel N100

在实时回放页面发起切片弹幕压制后，如果关闭 Web 页面，切片任务一直停留在 `processing` 状态。原因是切片任务原先直接在 `clip_range` 命令中执行，没有纳入 `TaskManager`，前端页面卸载时也没有主动取消当前切片任务；同时 FFmpeg 子进程会继续运行，数据库状态只在任务成功或失败返回时才更新。

## 根因

1. `src-tauri/src/handlers/video.rs` 中 `clip_range` 直接等待 `clip_range_inner` 执行完成，没有通过 `TaskManager` 管理。
2. `cancel` 命令只能取消 `TaskManager` 中的任务，无法取消直接执行的切片任务。
3. `src/AppLive.svelte` 的 `onDestroy` 只清理滚动定时器；这是预期行为，页面关闭不应取消切片任务。真正的问题是切片流程绑定在页面发起的 HTTP 请求生命周期上，导致请求断开时后端 future 可能被取消。
4. FFmpeg 子进程未设置随 Rust future 取消而退出，TaskManager abort 后可能留下后台 FFmpeg 进程继续运行。
5. 数据库任务状态依赖任务完成后的成功/失败更新，页面关闭导致执行链断开时容易停留在 `processing`。

## 修复内容

### 后端任务管理

文件：`src-tauri/src/handlers/video.rs`

- 将 `clip_range` 的实际执行流程交给 `TaskManager`。
- 使用 `oneshot` channel 保持原命令调用语义：前端调用 `clip_range` 仍会等待切片结果返回。
- 后台任务成功时：
  - 调用 `reporter.finish(true, "切片完成")`。
  - 更新数据库任务状态为 `success`。
  - 保留自动字幕生成和 webhook 事件逻辑。
- 后台任务失败时：
  - 调用 `reporter.finish(false, ...)`。
  - 更新数据库任务状态为 `failed`。
- `cancel` 命令现在统一调用 `TaskManager::cancel_task`，并在实际取消成功时将数据库任务状态写为 `cancelled`。
- 新增 `Database::get_task`，用于取消命令在 `Task not found` 时读取当前数据库任务状态。
- 对 `Task not found` 做幂等处理：只有数据库记录仍处于 `pending` 或 `processing` 时才补写 `cancelled`，避免覆盖已经 `success` / `failed` 的任务。
- 抽出内部函数：
  - `generate_video_subtitle_inner`
  - `update_video_subtitle_inner`

这样后台任务可以复用字幕逻辑，而不依赖只能由 Tauri 命令入口传入的 `tauri::State` 类型。

### FFmpeg 子进程取消

文件：

- `src-tauri/src/ffmpeg/mod.rs`
- `src-tauri/src/ffmpeg/general.rs`

本次 review 后将分散在多个 FFmpeg 入口的取消设置收敛为统一 helper：

```rust
pub fn ffmpeg_command() -> tokio::process::Command {
    let mut command = tokio::process::Command::new(ffmpeg_path());
    command.kill_on_drop(true);
    command
}
```

相关 FFmpeg 调用统一通过 `ffmpeg_command()` 创建 `tokio::process::Command`，避免每个调用点重复设置 `kill_on_drop(true)`。

这样当 `TaskManager` abort 运行中的 Rust future 时，对应的 FFmpeg 子进程会随命令/子进程生命周期结束而退出，避免页面关闭后后台继续压制，并减少后续新增 FFmpeg 调用时遗漏取消设置的风险。

覆盖的主要 FFmpeg 场景包括：

- 切片
- 转码
- 音频提取
- 字幕编码
- 弹幕压制
- 视频合并流程中的共享 FFmpeg handler

### 前端页面卸载行为

文件：`src/AppLive.svelte`

页面卸载时不取消当前切片任务，只清理前端本地资源；如果切片仍在运行，则通过 `beforeunload` 触发浏览器原生离开确认，并在页面内显示任务会后台运行、可前往任务页面管理的提示。浏览器不允许自定义原生离开确认文案，因此关闭时看到的是浏览器内置文案。

```ts
function handleBeforeUnload(event: BeforeUnloadEvent) {
  if (!current_clip_event_id) {
    return;
  }
  event.preventDefault();
  event.returnValue = "";
}

onMount(() => {
  window.addEventListener("beforeunload", handleBeforeUnload);
});

onDestroy(() => {
  if (scroll_timeout) {
    clearTimeout(scroll_timeout);
  }
  window.removeEventListener("beforeunload", handleBeforeUnload);
});
```

`cancel_clip` 仅用于用户显式取消切片任务，取消请求返回后会恢复前端按钮状态：

```ts
invoke("cancel", { eventId: current_clip_event_id })
  .then(() => {
    reset_clip_state();
  })
  .catch((error) => {
    log.warn("Failed to cancel clip task", error);
    reset_clip_state();
  });
```

这样关闭 Web 页面后，已经提交到 `TaskManager` 的切片任务会继续在后台运行；只有用户点击取消时才会中止后端任务和关联 FFmpeg 处理。切片完成、失败或取消后，前端会清理进度监听器并恢复生成按钮状态。

### 文档同步

已更新：

- `docs/development/backend/recorder-manager.md`
- `docs/development/frontend/invoker.md`

记录切片任务生命周期、页面卸载不取消任务、页面关闭提示、手动取消行为，以及 FFmpeg 子进程随任务取消退出的约束。

## 修复后的行为

1. 用户在实时回放页发起切片弹幕压制。
2. 后端创建数据库任务记录，并将实际切片流程交给 `TaskManager`。
3. FFmpeg 处理过程中持续通过 `ProgressReporter` 更新任务为 `processing`。
4. 如果页面关闭：
   - `AppLive.svelte` 的 `beforeunload` 触发浏览器原生离开确认，并在页面内提示切片任务会继续后台运行、可前往任务页面管理。
   - 后端 `TaskManager` 中的切片任务继续后台运行。
   - FFmpeg 子进程继续处理，直到任务正常完成或失败。
5. 如果任务正常完成：
   - 数据库任务状态更新为 `success`。
   - 前端收到完成事件并刷新切片列表。
6. 如果任务失败：
   - 数据库任务状态更新为 `failed`。
7. 如果用户显式取消：
   - 后端 `TaskManager` abort 对应任务。
   - FFmpeg 子进程随任务取消退出。
   - 数据库任务仍为 `pending` / `processing` 时更新为 `cancelled`；如果任务已 `success` / `failed`，不会被取消命令覆盖。

## Review 后补充调整

1. `cancel` 不再在 `Task not found` 时无条件写入 `cancelled`，而是先读取数据库任务状态，只对仍未结束的任务补写取消状态。
2. FFmpeg `kill_on_drop(true)` 不再分散在多个调用点，改为集中在 `ffmpeg_command()` helper 中设置。
3. 页面卸载不再自动调用 `cancel`；关闭 Web 页面后切片任务应继续由 `TaskManager` 在后台运行，并在任务运行时提示用户可前往任务页面管理。

