### PR TITLE
fix: quality param for NVENC

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 jobs:
-  pre-commit:
+  pr-check:
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y ffmpeg libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/src-tauri/src/ffmpeg/hwaccel.rs
+++ b/src-tauri/src/ffmpeg/hwaccel.rs
@@ -18,6 +18,7 @@ pub const H264_SCALE_PAD_FILTER: &str =
     "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2";
 
 const VAAPI_ENCODER: &str = "h264_vaapi";
+const NVENC_ENCODER: &str = "h264_nvenc";
 const VAAPI_DEVICE_DIR: &str = "/dev/dri";
 const VAAPI_RENDER_PREFIX: &str = "renderD";
 const VAAPI_FILTER_SUFFIX: &str = "format=nv12,hwupload";
@@ -56,6 +57,11 @@ pub fn is_vaapi_encoder(encoder: &str) -> bool {
     encoder == VAAPI_ENCODER
 }
 
+/// 判断编码器是否为 NVIDIA NVENC。
+pub fn is_nvenc_encoder(encoder: &str) -> bool {
+    encoder == NVENC_ENCODER
+}
+
 /// 返回 VAAPI 硬件上传滤镜片段。
 pub fn vaapi_filter_suffix() -> &'static str {
     VAAPI_FILTER_SUFFIX
@@ -80,11 +86,17 @@ pub fn apply_x264_encoder_only(command: &mut tokio::process::Command, encoder: &
 
 /// 按编码器类型追加质量参数。
 pub fn apply_x264_quality_args(command: &mut tokio::process::Command, encoder: &str) {
+    command.args(quality_args_for_encoder(encoder));
+}
+
+/// 返回指定 H.264 编码器应使用的质量参数。
+pub fn quality_args_for_encoder(encoder: &str) -> &'static [&'static str] {
     if is_vaapi_encoder(encoder) {
-        command.args(["-qp", "20"]);
+        &["-qp", "20"]
+    } else if is_nvenc_encoder(encoder) {
+        &["-preset", "p5", "-rc", "vbr", "-cq", "20", "-b:v", "0"]
     } else {
-        command.args(["-crf", "20"]);
-        command.args(["-preset", "medium"]);
+        &["-crf", "20", "-preset", "medium"]
     }
 }
 
@@ -335,5 +347,34 @@ pub async fn get_x264_encoder() -> &'static str {
             // 其他线程已经设置了，返回缓存的值
             ENCODER_CACHE.get().unwrap().as_str()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::quality_args_for_encoder;
+
+    #[test]
+    fn test_quality_args_for_libx264() {
+        assert_eq!(
+            quality_args_for_encoder("libx264"),
+            &["-crf", "20", "-preset", "medium"]
+        );
+    }
+
+    #[test]
+    fn test_quality_args_for_nvenc() {
+        let args = quality_args_for_encoder("h264_nvenc");
+
+        assert_eq!(
+            args,
+            &["-preset", "p5", "-rc", "vbr", "-cq", "20", "-b:v", "0"]
+        );
+        assert!(!args.contains(&"-crf"));
+    }
+
+    #[test]
+    fn test_quality_args_for_vaapi() {
+        assert_eq!(quality_args_for_encoder("h264_vaapi"), &["-qp", "20"]);
     }
 }

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -1214,15 +1214,13 @@ pub async fn check_videos(video_paths: &[&Path]) -> bool {
         if !Path::new(video_path).exists() {
             continue;
         }
-        let metadata = extract_video_metadata(Path::new(video_path)).await;
-        if metadata.is_err() {
-            log::error!(
-                "Failed to extract video metadata: {}",
-                metadata.unwrap_err()
-            );
-            return false;
-        }
-        let metadata = metadata.unwrap();
+        let metadata = match extract_video_metadata(Path::new(video_path)).await {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                log::error!("Failed to extract video metadata: {error}");
+                return false;
+            }
+        };
 
         // check video codec
         if !video_codec.is_empty() && metadata.video_codec != video_codec {


### PR DESCRIPTION
## Summary by Sourcery

Adjust H.264 hardware encoder quality handling to support NVENC-specific settings and centralize quality argument selection.

Bug Fixes:
- Fix NVENC quality parameters to use appropriate preset and rate-control options instead of generic x264 settings.

Enhancements:
- Introduce a reusable helper to derive encoder-specific quality arguments for H.264 encoders, including VAAPI, NVENC, and libx264.

Tests:
- Add unit tests covering quality argument selection for libx264, NVENC, and VAAPI encoders.