### PR TITLE
fix(web): follow endpoint origin for static assets in headless mode

### DIFF
--- a/src/lib/invoker.ts
+++ b/src/lib/invoker.ts
@@ -131,13 +131,17 @@ async function get_static_url(base: string, path: string) {
   if (config === null) {
     config = (await invoke("get_config")) as any;
   }
-  if (STATIC_PORT === 0) {
-    STATIC_PORT = await invoke("get_static_port");
-  }
-  let staticUrl = `http://localhost:${STATIC_PORT}`;
-  if (!TAURI_ENV) {
-    // replace port in ENDPOINT
-    staticUrl = ENDPOINT.replace(/:\d+/, `:${STATIC_PORT}`);
+  let staticUrl;
+  if (TAURI_ENV) {
+    if (STATIC_PORT === 0) {
+      STATIC_PORT = await invoke("get_static_port");
+    }
+    staticUrl = `http://localhost:${STATIC_PORT}`;
+  } else {
+    // In headless/web mode static assets are served by the same server as the
+    // API, so follow the configured endpoint as-is. Rewriting the port here
+    // breaks remapped ports, reverse proxies and HTTPS.
+    staticUrl = ENDPOINT;
   }
 
   const encodedPath = path.split('/').map(encodeURIComponent).join('/');


### PR DESCRIPTION
## 背景

在 headless / Docker 模式下,通过浏览器访问 Web 界面时,部分图片(直播间封面、录播封面、用户头像等)无法正常加载,或被请求到了错误的端口。

具体表现:当反向代理 / 容器端口映射后,Web 应用访问地址的端口与容器内部 API 端口不一致时(例如对外用 8132,容器内部仍是 3000),封面、头像等静态资源会被强行请求到 3000 端口,而页面其余请求走的是访问地址端口,于是出现「有的图走 8132、有的图走 3000」、且 3000 不可达时图片直接裂掉的情况。

## 原因

#245(修复 #244)已经在后端做了统一:headless 模式下 `/cache`、`/output` 等静态资源改由 API 服务器在同一个 `API_PORT` 上提供,目标是「只需暴露一个端口」。

但该 PR 只改了后端,**前端 `src/lib/invoker.ts` 的 `get_static_url` 未同步调整**:它仍然调用 `get_static_port`(headless 下恒为 `API_PORT` = 3000),并把用户配置的 endpoint 端口**强行替换**成这个值:

```ts
staticUrl = ENDPOINT.replace(/:\d+/, `:${STATIC_PORT}`);
```

既然静态资源已经和 API 同源同端口,这段端口改写就成了多余且有害的逻辑,在「端口映射 / 反向代理 / HTTPS」等部署场景下会把静态资源指向错误端口。

## 修复工作

仅改动前端 `src/lib/invoker.ts` 的 `get_static_url`:

- **桌面(Tauri)模式**:行为不变,静态服务仍走本地 `localhost:STATIC_PORT`。
- **Web / headless 模式**:直接沿用已配置的 endpoint(origin),不再改写端口,自然兼容端口映射、反向代理与 HTTPS。

```ts
let staticUrl;
if (TAURI_ENV) {
  if (STATIC_PORT === 0) {
    STATIC_PORT = await invoke("get_static_port");
  }
  staticUrl = `http://localhost:${STATIC_PORT}`;
} else {
  // headless/web 模式下静态资源与 API 由同一服务提供,
  // 直接沿用 endpoint,改写端口会破坏端口映射 / 反代 / HTTPS。
  staticUrl = ENDPOINT;
}
```

## 预期结果

- Web 模式下,封面 / 头像等静态资源跟随访问地址的 origin(端口),与 API 请求保持一致。
- 反向代理、容器端口映射(如对外 8132 → 容器 3000)、HTTPS 等场景下图片均可正常加载,**无需额外暴露 3000 端口**。
- 默认 Docker 部署(endpoint 配置为 `:3000`)下,改写本就是空操作,行为不变,无回归。

## 测试结果

- `yarn build`(vite 生产构建)通过,改动文件正常编译打包。
- 端到端实测:以改动后的前端连接一个 headless 后端(对外端口 8132、容器内部 3000),用浏览器加载页面并统计图片请求:
  - 20 张封面 / 头像**全部**请求到 `:8132` 且加载成功(例:`http://<host>:8132/cache/bilibili/<room>/<live>/cover.jpg`);
  - **0 张**请求到 `:3000`,无加载失败。

Refs #244, #245

## Summary by Sourcery

Bug Fixes:
- Fix incorrect static asset URLs in web/headless mode when ports are remapped, reverse proxied, or using HTTPS by no longer overriding the endpoint port.