### PR TITLE
fix(web): normalize endpoint to drop trailing slash

### DIFF
--- a/src/lib/invoker.ts
+++ b/src/lib/invoker.ts
@@ -13,7 +13,11 @@ declare global {
   }
 }
 
-const ENDPOINT = localStorage.getItem("endpoint") || "";
+function normalizeEndpoint(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+const ENDPOINT = normalizeEndpoint(localStorage.getItem("endpoint") || "");
 const TAURI_ENV = typeof window.__TAURI_INTERNALS__ !== "undefined";
 
 const log = {
@@ -291,4 +295,5 @@ export {
   close_window,
   onOpenUrl,
   get_static_url,
+  normalizeEndpoint,
 };

--- a/src/page/Setting.svelte
+++ b/src/page/Setting.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { invoke } from "../lib/invoker";
+  import { invoke, TAURI_ENV, normalizeEndpoint } from "../lib/invoker";
   import { open } from "@tauri-apps/plugin-dialog";
-  import { TAURI_ENV } from "../lib/invoker";
   import { clickOutside } from "../lib/actions/clickOutside";
 
   import type { Config } from "../lib/interface";
@@ -52,6 +51,7 @@
   let endpointValue = endpoint;
 
   function handleEndpointChange() {
+    endpointValue = normalizeEndpoint(endpointValue);
     localStorage.setItem("endpoint", endpointValue);
     // reload page
     location.reload();


### PR DESCRIPTION
## 背景

设置页「API 服务器地址」输入框会把用户填写的值原样存进 localStorage,不做任何清理。当用户填入末尾带 `/` 的地址(例如 `http://192.168.123.101:8132/`,或粘贴时带了空格 / 多个 `/`)时,前端拼接请求会产生双斜杠。

## 原因

`ENDPOINT` 在 `src/lib/invoker.ts` 中是所有请求的拼接前缀,形如 `${ENDPOINT}/api/...`、`${ENDPOINT}/${base}/...`、socket 的 `${ENDPOINT}/ws`、上传与 HLS 等。若 `ENDPOINT` 带末尾 `/`,会拼出 `…:8132//api/…`、`…:8132//cache/…` 这类双斜杠 URL,后端 axum 路由匹配不到,直接 404。而保存逻辑 `handleEndpointChange` 未做任何修剪。

## 修复工作

新增一个共享的 `normalizeEndpoint(value)`,去除首尾空白与末尾斜杠,并在两处使用,避免逻辑重复:

- `src/lib/invoker.ts`:读取 `ENDPOINT` 时归一化(消费端兜底,任何来源的值都生效);
- `src/page/Setting.svelte`:`handleEndpointChange` 保存前归一化(输入框同步显示干净值);顺带合并了重复的 `invoker` import 行。

```ts
function normalizeEndpoint(value: string): string {
  return value.trim().replace(/\/+$/, "");
}
```

## 预期结果

- 末尾带 `/`(或多余空白 / 多个 `/`)的地址保存后被规整,请求不再出现双斜杠。
- 末尾正则只锚定结尾,不影响 URL 中间的斜杠,故路径型反代 `https://host/bsr/` → `https://host/bsr` 同样是修正而非破坏。
- 对正常无斜杠地址,`replace` 为空操作,行为不变,无回归。

## 测试结果

- `yarn build`(vite 生产构建)通过。
- 本地实测:设置页填入 `http://<host>:8132/`,失焦保存后输入框值被修剪为无末尾斜杠,封面 / 接口请求路径无双斜杠。

## Summary by Sourcery

Normalize the configured API endpoint to remove trailing slashes and whitespace so requests no longer generate double-slash URLs.

Bug Fixes:
- Trim and strip trailing slashes from the stored endpoint value to prevent malformed double-slash request URLs.
- Ensure the settings page saves and displays a cleaned endpoint value after user edits.

Enhancements:
- Expose a shared normalizeEndpoint helper in the invoker module for consistent endpoint normalization across the app.