### PR TITLE
ci: upload Sentry debug symbols and configure DSN at build time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,6 +103,9 @@ jobs:
           CMAKE_OSX_DEPLOYMENT_TARGET: "13.3"
           CMAKE_CUDA_ARCHITECTURES: "75"
           WHISPER_BACKEND: ${{ matrix.features }}
+          # Sentry DSN baked into the binary at build time (option_env! in main.rs).
+          # When unset, Sentry is disabled in the build instead of using a default.
+          SENTRY_ENDPOINT: ${{ secrets.SENTRY_ENDPOINT }}
         with:
           tagName: v__VERSION__
           releaseName: "BiliBili ShadowReplay v__VERSION__"
@@ -110,3 +113,44 @@ jobs:
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }} ${{ matrix.platform == 'windows-latest' && matrix.features == 'cuda' && '--config src-tauri/tauri.windows.cuda.conf.json' || '' }}
+
+      - name: Generate dSYM for Sentry (macOS only)
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Rust on macOS keeps DWARF in the object files; run dsymutil to
+          # produce a .dSYM bundle next to the binary so Sentry can symbolicate.
+          TARGET=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([^ ]*\).*/\1/p')
+          BIN="src-tauri/target/$TARGET/release/bili-shadowreplay"
+          if [ -f "$BIN" ]; then
+            echo "Running dsymutil on $BIN"
+            dsymutil "$BIN"
+          else
+            echo "Binary not found, skipping dsymutil: $BIN"
+          fi
+
+      - name: Upload debug symbols to Sentry
+        # Requires repository secrets: SENTRY_URL, SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
+        shell: bash
+        env:
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+            echo "SENTRY_AUTH_TOKEN not set, skipping debug symbol upload."
+            exit 0
+          fi
+          # Derive the cargo target directory from the matrix args (if any).
+          ARGS="${{ matrix.args }}"
+          if [[ "$ARGS" == *"--target "* ]]; then
+            TARGET=$(echo "$ARGS" | sed -n 's/.*--target \([^ ]*\).*/\1/p')
+            DEBUG_DIR="src-tauri/target/$TARGET/release"
+          else
+            DEBUG_DIR="src-tauri/target/release"
+          fi
+          echo "Uploading debug files from: $DEBUG_DIR"
+          npx --yes @sentry/cli@latest debug-files upload --include-sources "$DEBUG_DIR"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,16 +14,21 @@ jobs:
         include:
           - platform: "macos-latest" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
+            target: "x86_64-apple-darwin"
           - platform: "macos-latest" # for Apple silicon macs.
             args: "--target aarch64-apple-darwin"
+            target: "aarch64-apple-darwin"
           - platform: "ubuntu-22.04"
             args: ""
+            target: ""
           - platform: "windows-latest"
             args: "--features cuda"
             features: "cuda"
+            target: ""
           - platform: "windows-latest"
             args: ""
             features: "cpu"
+            target: ""
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -117,12 +122,13 @@ jobs:
       - name: Generate dSYM for Sentry (macOS only)
         if: matrix.platform == 'macos-latest'
         shell: bash
+        env:
+          RUST_TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
           # Rust on macOS keeps DWARF in the object files; run dsymutil to
           # produce a .dSYM bundle next to the binary so Sentry can symbolicate.
-          TARGET=$(echo "${{ matrix.args }}" | sed -n 's/.*--target \([^ ]*\).*/\1/p')
-          BIN="src-tauri/target/$TARGET/release/bili-shadowreplay"
+          BIN="src-tauri/target/$RUST_TARGET/release/bili-shadowreplay"
           if [ -f "$BIN" ]; then
             echo "Running dsymutil on $BIN"
             dsymutil "$BIN"
@@ -138,19 +144,18 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          RUST_TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
           if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
             echo "SENTRY_AUTH_TOKEN not set, skipping debug symbol upload."
             exit 0
           fi
-          # Derive the cargo target directory from the matrix args (if any).
-          ARGS="${{ matrix.args }}"
-          if [[ "$ARGS" == *"--target "* ]]; then
-            TARGET=$(echo "$ARGS" | sed -n 's/.*--target \([^ ]*\).*/\1/p')
-            DEBUG_DIR="src-tauri/target/$TARGET/release"
+          # Use the explicit target triple from the matrix to locate the build output.
+          if [ -n "$RUST_TARGET" ]; then
+            DEBUG_DIR="src-tauri/target/$RUST_TARGET/release"
           else
             DEBUG_DIR="src-tauri/target/release"
           fi
           echo "Uploading debug files from: $DEBUG_DIR"
-          npx --yes @sentry/cli@latest debug-files upload --include-sources "$DEBUG_DIR"
+          npx --yes @sentry/cli@2 debug-files upload --include-sources "$DEBUG_DIR"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -75,4 +75,4 @@ jobs:
           CID=$(docker create "$IMAGE")
           docker cp "$CID:/app/bili-shadowreplay" debug-files/bili-shadowreplay
           docker rm "$CID"
-          npx --yes @sentry/cli@latest debug-files upload debug-files
+          npx --yes @sentry/cli@2 debug-files upload debug-files

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,3 +49,30 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SENTRY_ENDPOINT=${{ secrets.SENTRY_ENDPOINT }}
+
+      - name: Upload debug symbols to Sentry
+        # Requires repository secrets: SENTRY_URL, SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
+        shell: bash
+        env:
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+            echo "SENTRY_AUTH_TOKEN not set, skipping debug symbol upload."
+            exit 0
+          fi
+          # The headless Linux binary keeps DWARF embedded (profile.release debug = 1).
+          # Pull the just-pushed image and extract the binary to upload its debug info.
+          IMAGE=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          echo "Extracting binary from image: $IMAGE"
+          docker pull "$IMAGE"
+          mkdir -p debug-files
+          CID=$(docker create "$IMAGE")
+          docker cp "$CID:/app/bili-shadowreplay" debug-files/bili-shadowreplay
+          docker rm "$CID"
+          npx --yes @sentry/cli@latest debug-files upload debug-files

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,11 @@ COPY src-tauri/Cargo.toml src-tauri/Cargo.lock ./src-tauri/
 COPY src-tauri/src ./src-tauri/src
 COPY src-tauri/crates ./src-tauri/crates
 
+# Sentry DSN baked into the binary at build time (option_env! in main.rs).
+# Empty by default so Sentry stays disabled unless a DSN is provided.
+ARG SENTRY_ENDPOINT=""
+ENV SENTRY_ENDPOINT=${SENTRY_ENDPOINT}
+
 # Build Rust backend
 WORKDIR /app/src-tauri
 RUN rustup component add rustfmt

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -728,22 +728,30 @@ fn setup_invoke_handlers(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<
     ])
 }
 
-#[cfg(feature = "gui")]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Only enable Sentry when a DSN is provided at build time via SENTRY_ENDPOINT.
-    let _guard = option_env!("SENTRY_ENDPOINT")
+/// Initializes Sentry only when a DSN is provided at build time via the
+/// `SENTRY_ENDPOINT` env var. Returns `None` (Sentry disabled) when unset or
+/// empty. The returned guard must be kept alive for the lifetime of the app.
+fn init_sentry_from_env() -> Option<sentry::ClientInitGuard> {
+    option_env!("SENTRY_ENDPOINT")
         .filter(|s| !s.is_empty())
         .map(|dsn| {
             sentry::init((
                 dsn,
                 sentry::ClientOptions {
                     release: sentry::release_name!(),
-                    session_mode: sentry::SessionMode::Application,
+                    // Capture user IPs and potentially sensitive headers when using HTTP server integrations
+                    // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
                     send_default_pii: true,
+                    session_mode: sentry::SessionMode::Application,
                     ..Default::default()
                 },
             ))
-        });
+        })
+}
+
+#[cfg(feature = "gui")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = init_sentry_from_env();
 
     let _ = fix_path_env::fix();
 
@@ -804,22 +812,7 @@ struct Args {
 #[cfg(feature = "headless")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Only enable Sentry when a DSN is provided at build time via SENTRY_ENDPOINT.
-    let _guard = option_env!("SENTRY_ENDPOINT")
-        .filter(|s| !s.is_empty())
-        .map(|dsn| {
-            sentry::init((
-                dsn,
-                sentry::ClientOptions {
-                    release: sentry::release_name!(),
-                    // Capture user IPs and potentially sensitive headers when using HTTP server integrations
-                    // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
-                    send_default_pii: true,
-                    session_mode: sentry::SessionMode::Application,
-                    ..Default::default()
-                },
-            ))
-        });
+    let _guard = init_sentry_from_env();
     // get params from command line
     let args = Args::parse();
     let state = setup_server_state(args)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -730,15 +730,20 @@ fn setup_invoke_handlers(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<
 
 #[cfg(feature = "gui")]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let _guard = sentry::init((
-        "https://2dc627cc3cbf40653fa93f97fcb0f96c@sentry.vjoi.cn/2",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            session_mode: sentry::SessionMode::Application,
-            send_default_pii: true,
-            ..Default::default()
-        },
-    ));
+    // Only enable Sentry when a DSN is provided at build time via SENTRY_ENDPOINT.
+    let _guard = option_env!("SENTRY_ENDPOINT")
+        .filter(|s| !s.is_empty())
+        .map(|dsn| {
+            sentry::init((
+                dsn,
+                sentry::ClientOptions {
+                    release: sentry::release_name!(),
+                    session_mode: sentry::SessionMode::Application,
+                    send_default_pii: true,
+                    ..Default::default()
+                },
+            ))
+        });
 
     let _ = fix_path_env::fix();
 
@@ -799,17 +804,22 @@ struct Args {
 #[cfg(feature = "headless")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let _guard = sentry::init((
-        "https://fbf803d994a257326ea8f043d79058eb@sentry.vjoi.cn/2",
-        sentry::ClientOptions {
-            release: sentry::release_name!(),
-            // Capture user IPs and potentially sensitive headers when using HTTP server integrations
-            // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
-            send_default_pii: true,
-            session_mode: sentry::SessionMode::Application,
-            ..Default::default()
-        },
-    ));
+    // Only enable Sentry when a DSN is provided at build time via SENTRY_ENDPOINT.
+    let _guard = option_env!("SENTRY_ENDPOINT")
+        .filter(|s| !s.is_empty())
+        .map(|dsn| {
+            sentry::init((
+                dsn,
+                sentry::ClientOptions {
+                    release: sentry::release_name!(),
+                    // Capture user IPs and potentially sensitive headers when using HTTP server integrations
+                    // see https://docs.sentry.io/platforms/rust/data-management/data-collected for more info
+                    send_default_pii: true,
+                    session_mode: sentry::SessionMode::Application,
+                    ..Default::default()
+                },
+            ))
+        });
     // get params from command line
     let args = Args::parse();
     let state = setup_server_state(args)


### PR DESCRIPTION
Build the DSN into the binary at compile time via the SENTRY_ENDPOINT env var (option_env!), disabling Sentry when it is unset instead of using a hardcoded default. The Release and Docker workflows now inject the DSN and upload debug files to the self-hosted Sentry, including macOS dSYM generation.

## Summary by Sourcery

Make Sentry configuration build-time driven and integrate debug symbol upload into release workflows.

New Features:
- Allow configuring the Sentry DSN at build time via the SENTRY_ENDPOINT environment variable baked into the binary.
- Upload Rust and Docker build debug symbols to Sentry from CI release and packaging workflows, including macOS dSYM support.

Enhancements:
- Disable Sentry by default when no SENTRY_ENDPOINT is provided instead of using hardcoded DSNs.

Build:
- Add SENTRY_ENDPOINT as a Docker build argument and environment variable so images can be built with a specific Sentry DSN.

CI:
- Inject SENTRY_ENDPOINT into release builds and add CI steps to generate macOS dSYM bundles and upload debug symbols to Sentry from both desktop and Docker packaging workflows.