### PR TITLE
fix bug: video cover missing

### DIFF
--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -999,6 +999,20 @@ async fn encode_video_subtitle_inner(
 
     let output_filename =
         ffmpeg::encode_video_subtitle(reporter, &filepath, &subtitle_path, srt_style).await?;
+    let output_filepath = filepath.with_file_name(&output_filename);
+    let cover_path = filepath.with_extension("jpg");
+    let output_cover_path = output_filepath.with_extension("jpg");
+
+    if cover_path.exists() {
+        tokio::fs::copy(&cover_path, &output_cover_path)
+            .await
+            .map_err(|e| format!("复制字幕视频封面失败: {e}"))?;
+    } else {
+        log::warn!(
+            "Cover file not found for subtitle video: {}",
+            cover_path.display()
+        );
+    }
 
     let new_video = state
         .db

--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -1006,7 +1006,13 @@ async fn encode_video_subtitle_inner(
     if cover_path.exists() {
         tokio::fs::copy(&cover_path, &output_cover_path)
             .await
-            .map_err(|e| format!("复制字幕视频封面失败: {e}"))?;
+            .map_err(|e| {
+                format!(
+                    "复制字幕视频封面失败: {} -> {}: {e}",
+                    cover_path.display(),
+                    output_cover_path.display()
+                )
+            })?;
     } else {
         log::warn!(
             "Cover file not found for subtitle video: {}",


### PR DESCRIPTION
# 字幕烧录封面缺失修复记录

## 问题背景

字幕烧录会生成新的视频文件 `[subtitle]xxx.mp4`，并将数据库中的 `video_row.file` 更新为该新文件名，但不会同步生成或重命名对应的封面文件。

投稿上传时，封面路径由视频文件名直接派生：

```rust
let file = Path::new(&output).join(&video_row.file);
let cover_path = file.with_extension("jpg");
```

因此当 `video_row.file` 为 `[subtitle]xxx.mp4` 时，上传逻辑会查找 `[subtitle]xxx.jpg`。实际切片阶段只生成了原始封面 `xxx.jpg`，导致投稿失败。投稿错误提示如下图：
<img width="856" height="272" alt="image" src="https://github.com/user-attachments/assets/14b36197-b8f1-4416-baf0-d192ac07b5a3" />


## 问题链路

```text
切片生成: xxx.mp4 + xxx.jpg
         ↓
AI 字幕烧录: 生成 [subtitle]xxx.mp4，并更新 video_row.file
         ↓
封面仍然是 xxx.jpg，未生成 [subtitle]xxx.jpg
         ↓
投稿时查找 [subtitle]xxx.jpg 失败
```

## 修复方案

修复位置：`src-tauri/src/handlers/video.rs` 的 `encode_video_subtitle_inner`。

在字幕烧录成功后、创建新的 `VideoRow` 前：

1. 根据原始视频路径 `filepath` 派生原封面路径 `xxx.jpg`。
2. 根据字幕烧录输出文件名 `output_filename` 派生新封面路径 `[subtitle]xxx.jpg`。
3. 如果原封面存在，则复制到新封面路径。
4. 如果原封面不存在，只记录 warning，不阻塞字幕烧录流程。

核心逻辑：

```rust
let output_filepath = filepath.with_file_name(&output_filename);
let cover_path = filepath.with_extension("jpg");
let output_cover_path = output_filepath.with_extension("jpg");

if cover_path.exists() {
    tokio::fs::copy(&cover_path, &output_cover_path)
        .await
        .map_err(|e| format!("复制字幕视频封面失败: {e}"))?;
} else {
    log::warn!(
        "Cover file not found for subtitle video: {}",
        cover_path.display()
    );
}
```

## 验证环境：

- 系统：群晖DSM7.2-Docker
- CPU：Intel N100

## Summary by Sourcery

Bug Fixes:
- Copy the original video cover image to a new cover file matching the subtitle-encoded video filename to prevent missing-cover failures during upload.