### PR TITLE
Add whisper.cpp backend and improve subtitle segmentation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set build type
         id: build_type

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src-tauri/crates/whisper-cpp-rs/whisper.cpp"]
 	path = src-tauri/crates/whisper-cpp-rs/whisper.cpp
-	url = https://github.com/ggerganov/whisper.cpp.git
+	url = https://github.com/Xinrea/whisper.cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src-tauri/crates/whisper-cpp-rs/whisper.cpp"]
+	path = src-tauri/crates/whisper-cpp-rs/whisper.cpp
+	url = https://github.com/ggerganov/whisper.cpp.git

--- a/docs/getting-started/config/whisper.md
+++ b/docs/getting-started/config/whisper.md
@@ -1,25 +1,32 @@
 # Whisper 配置
 
-要使用 AI 字幕识别功能，需要在设置页面配置 Whisper。目前可以选择使用本地运行 Whisper 模型，或是使用在线的 Whisper 服务（通常需要付
-费获取 API Key）。
+要使用 AI 字幕识别功能，需要在设置页面配置 Whisper。目前可以选择使用本地运行 Whisper 模型，或是使用在线的 Whisper 服务（通常需要付费获取 API Key）。
 
 > [!NOTE]
-> 其实有许多更好的中文字幕识别解决方案，但是这类服务通常需要将文件上传到对象存储后异步处理，考虑到实现的复杂度，选择了使用本地运行 Whisper 模型或是使
-> 用在线的 Whisper 服务，在请求返回时能够直接获取字幕生成结果。
+> 其实有许多更好的中文字幕识别解决方案，但是这类服务通常需要将文件上传到对象存储后异步处理，考虑到实现的复杂度，选择了使用本地运行 Whisper 模型或是使用在线的 Whisper 服务，在请求返回时能够直接获取字幕生成结果。
 
 ## 本地运行 Whisper 模型
 
 ![WhisperLocal](/images/whisper_local.png)
 
-如果需要使用本地运行 Whisper 模型进行字幕生成，需要下载 Whisper.cpp 模型，并在设置中指定模型路径。模型文件可以从网络上下载，例如：
+本地 Whisper 字幕生成使用 sherpa-onnx（基于 ONNX Runtime）运行 Whisper 模型。模型会在首次使用时自动下载，无需手动下载模型文件。
 
-- [Whisper.cpp（国内镜像，内容较旧）](https://www.modelscope.cn/models/cjc1887415157/whisper.cpp/files)
-- [Whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp/tree/main)
+### 可用模型
 
-可以跟据自己的需求选择不同的模型，要注意带有 `en` 的模型是英文模型，其他模型为多语言模型。
+| 模型名 | 大小 | 语言 | 说明 |
+|--------|------|------|------|
+| `tiny` | ~75MB | 多语言 | 速度最快，精度较低 |
+| `tiny.en` | ~75MB | 仅英文 | 英文优化版本 |
+| `base` | ~145MB | 多语言 | 速度与精度平衡 |
+| `small` | ~465MB | 多语言 | 较高质量 |
+| `large-v3` | ~2.9GB | 多语言 | 最高精度，速度最慢 |
 
-模型文件的大小通常意味着其在运行时资源占用的大小，因此请根据电脑配置选择合适的模型。此外，GPU 版本与 CPU 版本在字幕生成速度上存在**巨大差异**，因此
-推荐使用 GPU 版本进行本地处理（目前仅支持 Nvidia GPU）。
+模型文件会自动下载到应用数据目录的 `models/` 文件夹中。
+
+### 硬件加速
+
+- **macOS**: 自动使用 CoreML 加速（Apple Silicon / Intel）
+- **Windows / Linux**: 默认使用 CPU，启用 CUDA 后可支持 NVIDIA GPU 加速
 
 ## 使用在线 Whisper 服务
 

--- a/docs/superpowers/plans/2026-07-05-whisper-sherpa-onnx-migration.md
+++ b/docs/superpowers/plans/2026-07-05-whisper-sherpa-onnx-migration.md
@@ -1,0 +1,952 @@
+# Whisper 后端迁移：whisper-rs → sherpa-onnx 实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 将本地语音识别后端从 whisper-rs (GGML) 替换为 sherpa-onnx (ONNX Runtime)，含模型自动下载和 GPU 加速支持
+
+**Architecture:** 移除 whisper-rs/hound 依赖，新增 sherpa-onnx。新增 `model_manager` 模块管理模型下载缓存，新增 `whisper_onnx.rs` 实现 `SubtitleGenerator` trait。`ffmpeg::generate_video_subtitle()` 签名增加 `whisper_provider` 参数透传。
+
+**Tech Stack:** sherpa-onnx 1.13, reqwest (已有), tokio (已有), bzip2 + tar (新增解压依赖)
+
+## Global Constraints
+
+- sherpa-onnx 版本: `1.13`
+- Rust edition: 2021
+- 保留 `cuda` feature 名称用于 provider 选择
+- 所有异步函数使用 `async_trait`
+- 遵循现有 SubtitleGenerator trait 接口
+- 平台: macOS (CoreML), Windows/Linux (CPU + 可选 CUDA)
+
+---
+
+### Task 1: 更新 Cargo.toml 依赖
+
+**Files:**
+- Modify: `src-tauri/Cargo.toml`
+
+**Interfaces:**
+- Produces: `sherpa-onnx` crate available; `cuda` feature 变为条件编译标记
+
+- [ ] **Step 1: 移除 whisper-rs 和 hound 依赖**
+
+在 `src-tauri/Cargo.toml` 中:
+
+删除第 51 行:
+```toml
+whisper-rs = "0.16.0"
+```
+
+删除第 52 行:
+```toml
+hound = "3.5.1"
+```
+
+删除第 74 行 `cuda` feature 的 passthrough:
+```toml
+cuda = ["whisper-rs/cuda"]
+```
+替换为:
+```toml
+cuda = []
+```
+
+删除第 149-154 行所有平台条件依赖:
+```toml
+[target.'cfg(windows)'.dependencies]
+whisper-rs = { version = "0.16.0", default-features = false }
+
+[target.'cfg(target_os = "macos")'.dependencies.whisper-rs]
+version = "0.16.0"
+features = ["metal"]
+```
+
+- [ ] **Step 2: 添加 sherpa-onnx 和 tar 解压依赖**
+
+在 `[dependencies]` 中添加:
+```toml
+sherpa-onnx = "1.13"
+bzip2 = "0.4"
+tar = "0.4"
+```
+
+- [ ] **Step 3: 验证 Cargo.toml 语法**
+
+```bash
+cargo verify-project --manifest-path src-tauri/Cargo.toml
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src-tauri/Cargo.toml
+git commit -m "chore: replace whisper-rs with sherpa-onnx dependency"
+```
+
+---
+
+### Task 2: 实现模型下载管理器
+
+**Files:**
+- Create: `src-tauri/src/model_manager/mod.rs`
+- Modify: `src-tauri/src/main.rs` (添加 `mod model_manager;`)
+
+**Interfaces:**
+- Produces: `ModelManager::ensure_model(model_name, reporter) -> Result<ModelInfo, String>`
+- Produces: `ModelManager::get_available_models() -> Vec<&'static str>`
+- Produces: `ModelInfo { encoder_path: String, decoder_path: String, tokens_path: String }`
+
+- [ ] **Step 1: 创建模块文件并添加 mod 声明**
+
+创建 `src-tauri/src/model_manager/mod.rs`:
+
+```rust
+use crate::progress::progress_reporter::ProgressReporterTrait;
+use std::path::PathBuf;
+
+const MODEL_RELEASE_URL: &str =
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models";
+
+const AVAILABLE_MODELS: &[(&str, &str)] = &[
+    ("tiny", "sherpa-onnx-whisper-tiny.tar.bz2"),
+    ("tiny.en", "sherpa-onnx-whisper-tiny.en.tar.bz2"),
+    ("base", "sherpa-onnx-whisper-base.tar.bz2"),
+    ("small", "sherpa-onnx-whisper-small.tar.bz2"),
+    ("large-v3", "sherpa-onnx-whisper-large-v3.tar.bz2"),
+];
+
+pub struct ModelInfo {
+    pub encoder_path: String,
+    pub decoder_path: String,
+    pub tokens_path: String,
+}
+
+fn models_dir() -> PathBuf {
+    let app_dirs = platform_dirs::AppDirs::new(Some("cn.vjoi.bili-shadowreplay"), false)
+        .expect("Failed to get app dirs");
+    app_dirs.data_dir.join("models")
+}
+
+fn model_dir(model_name: &str) -> PathBuf {
+    models_dir().join(format!("whisper-{}", model_name))
+}
+
+fn is_model_cached(model_name: &str) -> bool {
+    let dir = model_dir(model_name);
+    dir.join("encoder.onnx").exists()
+        && dir.join("decoder.onnx").exists()
+        && dir.join("tokens.txt").exists()
+}
+
+pub fn get_available_models() -> Vec<&'static str> {
+    AVAILABLE_MODELS.iter().map(|(name, _)| *name).collect()
+}
+
+pub async fn ensure_model(
+    model_name: &str,
+    reporter: Option<&(impl ProgressReporterTrait + 'static)>,
+) -> Result<ModelInfo, String> {
+    if is_model_cached(model_name) {
+        let dir = model_dir(model_name);
+        return Ok(ModelInfo {
+            encoder_path: dir.join("encoder.onnx").to_str().unwrap().to_string(),
+            decoder_path: dir.join("decoder.onnx").to_str().unwrap().to_string(),
+            tokens_path: dir.join("tokens.txt").to_str().unwrap().to_string(),
+        });
+    }
+
+    let (_name, filename) = AVAILABLE_MODELS
+        .iter()
+        .find(|(name, _)| *name == model_name)
+        .ok_or_else(|| format!("Unknown model: {model_name}. Available: {:?}", get_available_models()))?;
+
+    let url = format!("{}/{}", MODEL_RELEASE_URL, filename);
+    let dir = model_dir(model_name);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create model directory: {e}"))?;
+
+    let archive_path = dir.join(filename);
+
+    if let Some(reporter) = reporter {
+        reporter.update(&format!("正在下载模型 {}...", model_name)).await;
+    }
+
+    // Download
+    let response = reqwest::get(&url)
+        .await
+        .map_err(|e| format!("Failed to download model {}: {e}", model_name))?;
+
+    let total_size = response.content_length().unwrap_or(0);
+    let mut downloaded: u64 = 0;
+    let mut bytes = Vec::new();
+
+    let mut stream = response.bytes_stream();
+    use futures::StreamExt;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("Download error: {e}"))?;
+        bytes.extend_from_slice(&chunk);
+        downloaded += chunk.len() as u64;
+        if let Some(reporter) = reporter {
+            if total_size > 0 {
+                let pct = (downloaded * 100 / total_size).min(99);
+                reporter
+                    .update(&format!("下载模型 {}: {}%", model_name, pct))
+                    .await;
+            }
+        }
+    }
+
+    // Extract
+    if let Some(reporter) = reporter {
+        reporter.update(&format!("正在解压模型 {}...", model_name)).await;
+    }
+
+    let cursor = std::io::Cursor::new(&bytes);
+    let decoder = bzip2::read::BzDecoder::new(cursor);
+    let mut archive = tar::Archive::new(decoder);
+    archive
+        .unpack(&dir)
+        .map_err(|e| format!("Failed to extract model archive: {e}"))?;
+
+    // Clean up archive
+    let _ = std::fs::remove_file(&archive_path);
+
+    if !is_model_cached(model_name) {
+        return Err(format!(
+            "Model {} extraction incomplete. Expected encoder.onnx, decoder.onnx, tokens.txt in {:?}",
+            model_name, dir
+        ));
+    }
+
+    Ok(ModelInfo {
+        encoder_path: dir.join("encoder.onnx").to_str().unwrap().to_string(),
+        decoder_path: dir.join("decoder.onnx").to_str().unwrap().to_string(),
+        tokens_path: dir.join("tokens.txt").to_str().unwrap().to_string(),
+    })
+}
+```
+
+- [ ] **Step 2: 在 main.rs 中添加模块声明**
+
+在 `src-tauri/src/main.rs` 中，`mod migration;` 之后添加:
+```rust
+mod model_manager;
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src-tauri/src/model_manager/mod.rs src-tauri/src/main.rs
+git commit -m "feat: add model download manager for sherpa-onnx whisper models"
+```
+
+---
+
+### Task 3: 实现 WhisperOnnx SubtitleGenerator
+
+**Files:**
+- Create: `src-tauri/src/subtitle_generator/whisper_onnx.rs`
+
+**Interfaces:**
+- Consumes: `SubtitleGenerator` trait (existing), `ModelInfo` (Task 2), `ProgressReporterTrait` (existing)
+- Produces: `WhisperOnnx` struct, `new()` constructor, `generate_subtitle()` implementation
+
+- [ ] **Step 1: 创建 whisper_onnx.rs**
+
+创建 `src-tauri/src/subtitle_generator/whisper_onnx.rs`:
+
+```rust
+use async_trait::async_trait;
+use sherpa_onnx::{
+    OfflineRecognizer, OfflineRecognizerConfig, OfflineRecognizerResult, OfflineWhisperModelConfig,
+};
+
+use crate::{
+    model_manager,
+    progress::progress_reporter::ProgressReporterTrait,
+    subtitle_generator::{GenerateResult, SubtitleGeneratorType},
+};
+
+use super::SubtitleGenerator;
+
+pub struct WhisperOnnx {
+    recognizer: OfflineRecognizer,
+    prompt: String,
+}
+
+/// Resolve the ONNX Runtime execution provider.
+/// "auto" → platform detection; otherwise pass through.
+fn resolve_provider(configured: &str) -> String {
+    if configured != "auto" {
+        return configured.to_string();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        "coreml".to_string()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if cfg!(feature = "cuda") {
+            "cuda".to_string()
+        } else {
+            "cpu".to_string()
+        }
+    }
+}
+
+pub async fn new(
+    model_name: &str,
+    provider: &str,
+    prompt: &str,
+    reporter: Option<&(impl ProgressReporterTrait + 'static)>,
+) -> Result<WhisperOnnx, String> {
+    let model_info = model_manager::ensure_model(model_name, reporter).await?;
+
+    let provider = resolve_provider(provider);
+
+    let mut config = OfflineRecognizerConfig::default();
+    config.model_config.whisper = OfflineWhisperModelConfig {
+        encoder: Some(model_info.encoder_path),
+        decoder: Some(model_info.decoder_path),
+        language: None,
+        task: Some("transcribe".to_string()),
+        tail_paddings: 0,
+        enable_token_timestamps: false,
+        enable_segment_timestamps: true,
+    };
+    config.model_config.tokens = Some(model_info.tokens_path);
+    config.model_config.provider = Some(provider.clone());
+    config.model_config.debug = false;
+    config.model_config.num_threads = num_cpus::get() as i32;
+
+    log::info!("Creating OfflineRecognizer with provider: {}", provider);
+
+    let recognizer = OfflineRecognizer::create(&config)
+        .map_err(|e| format!("Failed to create OfflineRecognizer: {e}"))?;
+
+    Ok(WhisperOnnx {
+        recognizer,
+        prompt: prompt.to_string(),
+    })
+}
+
+fn sherpa_result_to_srt_items(
+    result: &OfflineRecognizerResult,
+) -> Result<Vec<srtparse::Item>, String> {
+    let mut items = Vec::new();
+
+    // Use timestamps if available; otherwise treat the whole text as one segment
+    if let Some(tokens) = &result.tokens {
+        // Group tokens into segments by timestamp proximity
+        let mut current_text = String::new();
+        let mut segment_start: Option<f64> = None;
+        let mut segment_end: f64 = 0.0;
+
+        for token in tokens {
+            if segment_start.is_none() {
+                segment_start = Some(token.start);
+            }
+            current_text.push_str(&token.text);
+            segment_end = token.start + token.duration; // estimate end
+
+            // Simple heuristic: break at punctuation
+            if token.text.ends_with('.')
+                || token.text.ends_with('。')
+                || token.text.ends_with('!')
+                || token.text.ends_with('！')
+                || token.text.ends_with('?')
+                || token.text.ends_with('？')
+                || token.text.ends_with(',')
+                || token.text.ends_with('，')
+            {
+                let start = segment_start.unwrap_or(0.0);
+                items.push(srtparse::Item {
+                    pos: items.len() + 1,
+                    start_time: seconds_to_srt_time(start),
+                    end_time: seconds_to_srt_time(segment_end),
+                    text: current_text.trim().to_string(),
+                });
+                current_text = String::new();
+                segment_start = None;
+            }
+        }
+
+        // Flush remaining text
+        if !current_text.trim().is_empty() {
+            let start = segment_start.unwrap_or(0.0);
+            items.push(srtparse::Item {
+                pos: items.len() + 1,
+                start_time: seconds_to_srt_time(start),
+                end_time: seconds_to_srt_time(segment_end),
+                text: current_text.trim().to_string(),
+            });
+        }
+    } else {
+        // Fallback: no token timestamps, treat as single segment
+        items.push(srtparse::Item {
+            pos: 1,
+            start_time: srtparse::Time {
+                hours: 0,
+                minutes: 0,
+                seconds: 0,
+                milliseconds: 0,
+            },
+            end_time: srtparse::Time {
+                hours: 0,
+                minutes: 0,
+                seconds: 1,
+                milliseconds: 0,
+            },
+            text: result.text.clone(),
+        });
+    }
+
+    Ok(items)
+}
+
+fn seconds_to_srt_time(seconds: f64) -> srtparse::Time {
+    let total_ms = (seconds * 1000.0).round() as u64;
+    let hours = (total_ms / 3_600_000) as u64;
+    let minutes = ((total_ms % 3_600_000) / 60_000) as u64;
+    let secs = ((total_ms % 60_000) / 1000) as u64;
+    let millis = (total_ms % 1000) as u32;
+    srtparse::Time {
+        hours,
+        minutes,
+        seconds: secs,
+        milliseconds: millis,
+    }
+}
+
+#[async_trait]
+impl SubtitleGenerator for WhisperOnnx {
+    async fn generate_subtitle(
+        &self,
+        reporter: Option<&(impl ProgressReporterTrait + 'static)>,
+        audio_path: &std::path::Path,
+        _language_hint: &str,
+    ) -> Result<GenerateResult, String> {
+        log::info!("Generating subtitle for {:?}", audio_path);
+        let start_time = std::time::Instant::now();
+
+        if let Some(reporter) = reporter {
+            reporter.update("加载音频中").await;
+        }
+
+        let wave = sherpa_onnx::Wave::read(audio_path.to_str().unwrap())
+            .map_err(|e| format!("Failed to read audio file: {e}"))?;
+
+        let stream = self.recognizer.create_stream();
+        stream.accept_waveform(wave.sample_rate(), wave.samples());
+
+        if let Some(reporter) = reporter {
+            reporter.update("生成字幕中").await;
+        }
+
+        self.recognizer
+            .decode(&stream)
+            .map_err(|e| format!("Whisper decode failed: {e}"))?;
+
+        let result = stream
+            .get_result()
+            .ok_or_else(|| "No recognition result".to_string())?;
+
+        log::info!(
+            "Time taken: {} seconds",
+            start_time.elapsed().as_secs_f64()
+        );
+
+        let subtitle_content =
+            sherpa_result_to_srt_items(&result).map_err(|e| format!("Failed to parse result: {e}"))?;
+
+        Ok(GenerateResult {
+            generator_type: SubtitleGeneratorType::Whisper,
+            subtitle_id: String::new(),
+            subtitle_content,
+        })
+    }
+}
+```
+
+- [ ] **Step 2: 添加 num_cpus 依赖用于线程数检测**
+
+在 `src-tauri/Cargo.toml` 的 `[dependencies]` 中添加:
+```toml
+num_cpus = "1.16"
+```
+
+- [ ] **Step 3: 验证编译**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | head -50
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src-tauri/src/subtitle_generator/whisper_onnx.rs src-tauri/Cargo.toml
+git commit -m "feat: add WhisperOnnx SubtitleGenerator using sherpa-onnx"
+```
+
+---
+
+### Task 4: 更新 subtitle_generator 模块声明
+
+**Files:**
+- Modify: `src-tauri/src/subtitle_generator/mod.rs`
+
+**Interfaces:**
+- Produces: `whisper_onnx` module publicly accessible
+
+- [ ] **Step 1: 替换模块声明**
+
+在 `src-tauri/src/subtitle_generator/mod.rs` 中，将第 7 行:
+```rust
+pub mod whisper_cpp;
+```
+替换为:
+```rust
+pub mod whisper_onnx;
+```
+
+- [ ] **Step 2: 验证编译**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | head -30
+```
+预期: 会有一些 "unused import" 警告（ffmpeg/mod.rs 还在引用 whisper_cpp），这是正常的，在 Task 8 中修复。
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src-tauri/src/subtitle_generator/mod.rs
+git commit -m "refactor: replace whisper_cpp module with whisper_onnx"
+```
+
+---
+
+### Task 5: 添加 whisper_provider 配置字段
+
+**Files:**
+- Modify: `src-tauri/src/config.rs`
+
+**Interfaces:**
+- Produces: `Config.whisper_provider: String` (默认 `"auto"`)
+- Consumes: `serde` Serialize/Deserialize (existing)
+
+- [ ] **Step 1: 添加 whisper_provider 字段到 Config struct**
+
+在 `src-tauri/src/config.rs` 的 `Config` struct 中，`whisper_language` 之后添加:
+```rust
+#[serde(default = "default_whisper_provider")]
+pub whisper_provider: String,
+```
+
+- [ ] **Step 2: 添加默认值函数**
+
+在 `default_whisper_language()` 函数附近添加:
+```rust
+fn default_whisper_provider() -> String {
+    "auto".to_string()
+}
+```
+
+- [ ] **Step 3: 在 Config::load() 默认构造中添加字段**
+
+在 `src-tauri/src/config.rs` 的 `Config::load()` 方法中，默认 Config 构造体添加:
+```rust
+whisper_provider: default_whisper_provider(),
+```
+插入到 `whisper_language: default_whisper_language(),` 行之后。
+
+- [ ] **Step 4: 验证编译**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | head -30
+```
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src-tauri/src/config.rs
+git commit -m "feat: add whisper_provider config field"
+```
+
+---
+
+### Task 6: 添加 update_whisper_provider Tauri command
+
+**Files:**
+- Modify: `src-tauri/src/handlers/config.rs`
+
+**Interfaces:**
+- Produces: `update_whisper_provider` Tauri command
+
+- [ ] **Step 1: 在 handlers/config.rs 末尾添加 command**
+
+在 `src-tauri/src/handlers/config.rs` 的 `update_powerlive_key` 之后添加:
+
+```rust
+#[cfg_attr(feature = "gui", tauri::command)]
+pub async fn update_whisper_provider(
+    state: state_type!(),
+    whisper_provider: String,
+) -> Result<(), ()> {
+    log::info!("Updating whisper provider to {whisper_provider}");
+    state.config.write().await.whisper_provider = whisper_provider;
+    state.config.write().await.save();
+    Ok(())
+}
+```
+
+- [ ] **Step 2: 验证编译**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | head -30
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src-tauri/src/handlers/config.rs
+git commit -m "feat: add update_whisper_provider command"
+```
+
+---
+
+### Task 7: 注册新 command 到 main.rs
+
+**Files:**
+- Modify: `src-tauri/src/main.rs`
+
+**Interfaces:**
+- Consumes: `crate::handlers::config::update_whisper_provider` (Task 6)
+
+- [ ] **Step 1: 在 invoke_handler 列表中添加**
+
+在 `src-tauri/src/main.rs` 的 `setup_invoke_handlers()` 函数中，`crate::handlers::config::update_powerlive_key,` 之后添加:
+```rust
+crate::handlers::config::update_whisper_provider,
+```
+
+- [ ] **Step 2: 验证编译**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1 | head -30
+```
+
+- [ ] **Step 3: 提交**
+
+```bash
+git add src-tauri/src/main.rs
+git commit -m "feat: register update_whisper_provider command"
+```
+
+---
+
+### Task 8: 更新 ffmpeg 调度层接入新后端
+
+**Files:**
+- Modify: `src-tauri/src/ffmpeg/mod.rs`
+
+**Interfaces:**
+- Modify: `generate_video_subtitle()` 签名增加 `whisper_provider: &str` 参数
+- Consumes: `whisper_onnx::new()` (Task 3), `SubtitleGenerator` trait (existing)
+
+- [ ] **Step 1: 修改函数签名和调用处**
+
+修改 `src-tauri/src/ffmpeg/mod.rs` 中的 `generate_video_subtitle` 函数签名，在第 666 行 `whisper_prompt: &str,` 后添加:
+```rust
+whisper_provider: &str,
+```
+
+将第 677 行:
+```rust
+if let Ok(generator) = whisper_cpp::new(Path::new(&whisper_model), whisper_prompt).await
+```
+替换为:
+```rust
+if let Ok(generator) = whisper_onnx::new(&whisper_model, whisper_provider, whisper_prompt, reporter).await
+```
+
+将第 11-13 行 import 从:
+```rust
+use crate::subtitle_generator::{
+    whisper_cpp, GenerateResult, SubtitleGenerator, SubtitleGeneratorType,
+};
+```
+修改为:
+```rust
+use crate::subtitle_generator::{
+    whisper_onnx, GenerateResult, SubtitleGenerator, SubtitleGeneratorType,
+};
+```
+
+- [ ] **Step 2: 更新 handlers/video.rs 调用处**
+
+在 `src-tauri/src/handlers/video.rs` 第 843-848 行区域，读取 config 后添加:
+```rust
+let whisper_provider = config.whisper_provider.clone();
+```
+
+将第 855-864 行的 `ffmpeg::generate_video_subtitle(...)` 调用，在 `language_hint,` 之前添加:
+```rust
+&whisper_provider,
+```
+
+- [ ] **Step 3: 更新 recorder_manager.rs 调用处**
+
+在 `src-tauri/src/recorder_manager.rs` 第 1340-1349 行的 `crate::ffmpeg::generate_video_subtitle(...)` 调用中，`&config.whisper_language,` 之前添加:
+```rust
+&config.whisper_provider,
+```
+
+- [ ] **Step 4: 验证编译**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1
+```
+预期: 可能有关于 `hound`, `whisper_rs` 的 unused import 残留警告，在 Task 10 清理。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add src-tauri/src/ffmpeg/mod.rs src-tauri/src/handlers/video.rs src-tauri/src/recorder_manager.rs
+git commit -m "refactor: wire up whisper_onnx backend in ffmpeg dispatch"
+```
+
+---
+
+### Task 9: 清理旧文件和测试资源
+
+**Files:**
+- Delete: `src-tauri/src/subtitle_generator/whisper_cpp.rs`
+- Delete: `src-tauri/tests/model/ggml-tiny-q5_1.bin` (GGML 格式，不再使用)
+
+- [ ] **Step 1: 删除旧文件**
+
+```bash
+rm src-tauri/src/subtitle_generator/whisper_cpp.rs
+rm src-tauri/tests/model/ggml-tiny-q5_1.bin
+```
+
+- [ ] **Step 2: 验证编译无错误**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1
+```
+预期: 编译成功，无错误。之前引用 `whisper_cpp` 的 import 应该在 Task 8 中全部替换完成。
+
+- [ ] **Step 3: 运行项目现有测试**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --lib 2>&1
+```
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src-tauri/src/subtitle_generator/whisper_cpp.rs src-tauri/tests/model/ggml-tiny-q5_1.bin
+git commit -m "chore: remove old whisper-rs implementation and GGML test model"
+```
+
+---
+
+### Task 10: 添加单元测试
+
+**Files:**
+- Modify: `src-tauri/src/model_manager/mod.rs` (添加测试)
+
+- [ ] **Step 1: 添加 model_manager 单元测试**
+
+在 `src-tauri/src/model_manager/mod.rs` 末尾追加:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_available_models() {
+        let models = get_available_models();
+        assert!(models.contains(&"tiny"));
+        assert!(models.contains(&"base"));
+        assert!(models.contains(&"small"));
+        assert!(!models.is_empty());
+    }
+
+    #[test]
+    fn test_unknown_model_returns_error() {
+        // ensure_model with invalid name should return error (without network call
+        // because the model name lookup happens first)
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(ensure_model("nonexistent-model", None::<&crate::progress::progress_reporter::ProgressReporter>));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown model"));
+    }
+
+    #[test]
+    fn test_models_dir_returns_path() {
+        let dir = models_dir();
+        assert!(dir.to_string_lossy().contains("models"));
+    }
+}
+```
+
+- [ ] **Step 2: 添加 whisper_onnx provider 测试**
+
+在 `src-tauri/src/subtitle_generator/whisper_onnx.rs` 末尾追加:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_seconds_to_srt_time_zero() {
+        let time = seconds_to_srt_time(0.0);
+        assert_eq!(time.hours, 0);
+        assert_eq!(time.minutes, 0);
+        assert_eq!(time.seconds, 0);
+        assert_eq!(time.milliseconds, 0);
+    }
+
+    #[test]
+    fn test_seconds_to_srt_time_one_hour() {
+        let time = seconds_to_srt_time(3661.5);
+        assert_eq!(time.hours, 1);
+        assert_eq!(time.minutes, 1);
+        assert_eq!(time.seconds, 1);
+        assert_eq!(time.milliseconds, 500);
+    }
+
+    #[test]
+    fn test_seconds_to_srt_time_with_millis() {
+        let time = seconds_to_srt_time(125.789);
+        assert_eq!(time.hours, 0);
+        assert_eq!(time.minutes, 2);
+        assert_eq!(time.seconds, 5);
+        assert_eq!(time.milliseconds, 789);
+    }
+
+    #[test]
+    fn test_resolve_provider_auto_macos() {
+        let provider = resolve_provider("auto");
+        #[cfg(target_os = "macos")]
+        assert_eq!(provider, "coreml");
+        #[cfg(not(target_os = "macos"))]
+        assert!(provider == "cpu" || provider == "cuda");
+    }
+
+    #[test]
+    fn test_resolve_provider_explicit() {
+        assert_eq!(resolve_provider("cpu"), "cpu");
+        assert_eq!(resolve_provider("cuda"), "cuda");
+    }
+}
+```
+
+- [ ] **Step 3: 运行测试**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --lib 2>&1
+```
+预期: 所有测试通过。
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add src-tauri/src/model_manager/mod.rs src-tauri/src/subtitle_generator/whisper_onnx.rs
+git commit -m "test: add unit tests for model manager and whisper_onnx"
+```
+
+---
+
+### Task 11: 验证构建（headless + gui）
+
+**Files:** N/A (验证步骤)
+
+- [ ] **Step 1: 编译 headless feature**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml --features headless 2>&1
+```
+预期: 编译成功。
+
+- [ ] **Step 2: 编译 gui default features (macOS)**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml 2>&1
+```
+预期: 编译成功。
+
+- [ ] **Step 3: 编译 CUDA feature (可选，仅验证 feature 存在)**
+
+```bash
+cargo check --manifest-path src-tauri/Cargo.toml --features cuda 2>&1 | tail -5
+```
+预期: 编译成功（即使没有 CUDA SDK，sherpa-onnx 在构建时只是编译 Rust 代码，运行时会 fallback）。
+
+- [ ] **Step 4: 运行完整测试套件**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --lib 2>&1
+```
+预期: 所有非 #[ignore] 测试通过。
+
+- [ ] **Step 5: 提交（如有 Cargo.lock 变更）**
+
+```bash
+git add src-tauri/Cargo.lock
+git commit -m "chore: update Cargo.lock for sherpa-onnx migration"
+```
+
+---
+
+### Task 12: 最终验证与文档更新
+
+**Files:**
+- Modify: `docs/getting-started/config/whisper.md` (更新文档)
+
+- [ ] **Step 1: 更新 whisper 配置文档**
+
+修改 `docs/getting-started/config/whisper.md`，将模型下载说明从 whisper.cpp 的 HuggingFace 链接改为 sherpa-onnx 模型名称说明:
+
+```markdown
+# Whisper 配置 (sherpa-onnx)
+
+## 模型
+
+项目使用 sherpa-onnx（基于 ONNX Runtime）运行 Whisper 模型。
+模型会在首次使用时自动下载。
+
+### 可用模型
+
+| 模型名 | 大小 | 语言 |
+|--------|------|------|
+| `tiny` | ~75MB | 多语言 |
+| `tiny.en` | ~75MB | 仅英文 |
+| `base` | ~145MB | 多语言 |
+| `small` | ~465MB | 多语言 |
+| `large-v3` | ~2.9GB | 多语言 |
+
+模型文件会自动下载到应用数据目录的 `models/` 文件夹中。
+
+## 硬件加速
+
+- **macOS**: 自动使用 CoreML 加速
+- **Windows/Linux**: 默认 CPU，启用 CUDA feature 后可使用 NVIDIA GPU
+```
+
+- [ ] **Step 2: 运行 pre-commit hooks 检查全文**
+
+```bash
+cargo test --manifest-path src-tauri/Cargo.toml --lib 2>&1
+cargo fmt --manifest-path src-tauri/Cargo.toml -- --check 2>&1
+```
+
+- [ ] **Step 3: 最终提交**
+
+```bash
+git add docs/getting-started/config/whisper.md
+git commit -m "docs: update whisper config docs for sherpa-onnx migration"
+```

--- a/docs/superpowers/specs/2026-07-05-whisper-sherpa-onnx-migration-design.md
+++ b/docs/superpowers/specs/2026-07-05-whisper-sherpa-onnx-migration-design.md
@@ -1,0 +1,234 @@
+# Whisper 后端迁移：whisper-rs → sherpa-onnx
+
+**日期:** 2026-07-05
+**状态:** 待审核
+
+---
+
+## 目标
+
+将本地语音识别后端从 `whisper-rs` (whisper.cpp GGML) 替换为 `sherpa-onnx` (ONNX Runtime)，解决 whisper-rs 编译和性能问题，同时保持所有现有功能。
+
+## 非目标
+
+- 不修改在线 Whisper API (`whisper_online.rs`) 和 PowerLive (`powerlive.rs`)
+- 不修改前端 UI（本次只改后端）
+- 不删除用户已有的 GGML 模型文件（但不继续使用）
+
+---
+
+## 架构变更
+
+### 依赖变更 (`src-tauri/Cargo.toml`)
+
+**移除:**
+- `whisper-rs = "0.16.0"` 及所有平台条件依赖
+- `hound = "3.5.1"` (sherpa-onnx 内置 `Wave::read()`)
+
+**新增:**
+- `sherpa-onnx = "1.13"`
+
+**保留但语义变更:**
+- `cuda` feature：从 `whisper-rs/cuda` passthrough 改为条件编译标记，用于 provider 选择
+
+### 文件变更清单
+
+| 操作 | 文件 | 说明 |
+|---|---|---|
+| 删除 | `src/subtitle_generator/whisper_cpp.rs` | 旧 whisper-rs 实现 |
+| 新增 | `src/subtitle_generator/whisper_onnx.rs` | 新 sherpa-onnx 实现 |
+| 新增 | `src/model_manager/mod.rs` | 模型下载与缓存管理 |
+| 修改 | `src/subtitle_generator/mod.rs` | 模块声明：`whisper_cpp` → `whisper_onnx` |
+| 修改 | `src/ffmpeg/mod.rs` | 引用更新：`whisper_cpp` → `whisper_onnx` |
+| 修改 | `src/config.rs` | 新增 `whisper_provider` 字段 |
+| 修改 | `src/handlers/config.rs` | 新增 provider 相关 Tauri command |
+| 修改 | `src/main.rs` | 注册新 command |
+| 修改 | `Cargo.toml` | 依赖变更 |
+
+---
+
+## 组件设计
+
+### 1. ModelManager (`src/model_manager/mod.rs`)
+
+负责 Whisper ONNX 模型的下载、缓存和路径解析。
+
+**公开接口:**
+```rust
+pub struct ModelInfo {
+    pub encoder_path: String,
+    pub decoder_path: String,
+    pub tokens_path: String,
+}
+
+pub async fn ensure_model(model_name: &str, reporter: Option<&impl ProgressReporterTrait>)
+    -> Result<ModelInfo, String>;
+```
+
+**模型注册表:**
+
+| 键名 | 下载文件名 | 大小 | 语言 |
+|---|---|---|---|
+| `tiny` | `sherpa-onnx-whisper-tiny.tar.bz2` | ~75MB | 多语言 |
+| `tiny.en` | `sherpa-onnx-whisper-tiny.en.tar.bz2` | ~75MB | 仅英文 |
+| `base` | `sherpa-onnx-whisper-base.tar.bz2` | ~145MB | 多语言 |
+| `small` | `sherpa-onnx-whisper-small.tar.bz2` | ~465MB | 多语言 |
+| `large-v3` | `sherpa-onnx-whisper-large-v3.tar.bz2` | ~2.9GB | 多语言 |
+
+下载源：`https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/`
+
+缓存路径：`{app_data_dir}/models/whisper-{name}/`
+
+**内部逻辑:**
+1. 检查缓存目录是否存在且包含 3 个必需文件（`encoder.onnx`, `decoder.onnx`, `tokens.txt`）
+2. 缺失 → 用 `reqwest` 流式下载 `.tar.bz2`，通过 reporter 回调进度
+3. 解压 `tar.bz2` 到缓存目录
+4. 删除压缩包
+5. 返回 `ModelInfo`
+
+错误处理：
+- 网络错误 → 返回可读错误信息，建议检查网络
+- 解压失败 → 清理不完整缓存，返回错误
+- 磁盘空间不足 → 返回带建议的错误信息
+
+### 2. WhisperOnnx (`src/subtitle_generator/whisper_onnx.rs`)
+
+实现 `SubtitleGenerator` trait 的新后端。
+
+**结构体:**
+```rust
+pub struct WhisperOnnx {
+    recognizer: OfflineRecognizer,
+    prompt: String,
+}
+```
+
+**构造函数 `new()`:**
+```rust
+pub async fn new(
+    model_name: &str,
+    provider: &str,
+    prompt: &str,
+    reporter: Option<&impl ProgressReporterTrait>,
+) -> Result<WhisperOnnx, String>
+```
+1. 调用 `ModelManager::ensure_model(model_name, reporter)` 获取模型路径
+2. 构建 `OfflineRecognizerConfig`:
+   - `model_config.whisper`: encoder/decoder 路径、language 默认 auto、task=transcribe
+   - `model_config.tokens`: tokens 路径
+   - `model_config.provider`: 传入的 provider
+   - `model_config.num_threads`: 自动（0 或 cpu 核心数）
+   - `enable_segment_timestamps: true`（SRT 字幕需要！）
+3. `OfflineRecognizer::create(&config)` 创建识别器
+4. 返回 `WhisperOnnx` 实例
+
+**`generate_subtitle()` 实现:**
+1. `Wave::read(audio_path)` 加载 WAV（替代 hound + 手动转换）
+2. `stream.accept_waveform(sample_rate, &samples)` 送入音频
+3. `recognizer.decode(&stream)` 执行推理
+4. `stream.get_result()` 获取带时间戳的结果
+5. 将 sherpa-onnx 的 segments 转换为 `srtparse::Item` 格式
+6. 返回 `GenerateResult`
+
+**与 whisper-rs 的关键区别:**
+- 不再需要 `Arc<RwLock<>>` — `OfflineRecognizer` 内部已处理线程安全
+- 不再需要 `convert_integer_to_float_audio` / `convert_stereo_to_mono_audio`
+- 不再需要 `create_state()` / `WhisperContext` 管理生命周期
+- 时间戳格式可能不同（sherpa-onnx 使用秒，whisper-rs 使用毫秒×100）
+
+### 3. GPU Provider 选择
+
+```rust
+fn resolve_provider(configured: &str) -> String {
+    if configured != "auto" {
+        return configured.to_string();
+    }
+    // 自动检测
+    if cfg!(target_os = "macos") {
+        "coreml".to_string()
+    } else if cfg!(feature = "cuda") {
+        "cuda".to_string()
+    } else {
+        "cpu".to_string()
+    }
+}
+```
+
+### 4. 配置变更 (`config.rs`)
+
+新增字段：
+```rust
+pub whisper_provider: String,  // 默认 "auto"，可选 "cpu" / "cuda" / "coreml"
+```
+
+保留字段（语义不变）：
+- `whisper_model` — 含义变为「模型名称」，如 `"tiny"`、`"base"`
+- `whisper_prompt` — 初始终提示词，保持不变
+- `whisper_language` — 语言提示，不变
+
+### 5. ffmpeg 调度层变更 (`ffmpeg/mod.rs`)
+
+`generate_video_subtitle()` 中 whisper 分支调整：
+- 模型路径 → 模型名称（从 config 传入）
+- 调用 `whisper_onnx::new(model_name, provider, prompt, reporter)` 替代 `whisper_cpp::new(model_path, prompt)`
+- 其余流程不变（音频分块、逐块处理、合并结果）
+
+---
+
+## 测试策略
+
+### 单元测试
+
+| 测试 | 位置 | 内容 |
+|---|---|---|
+| model_registry | `model_manager/mod.rs` | 验证注册表模型名有效 |
+| model_cache_check | `model_manager/mod.rs` | mock 文件系统，验证缓存检测逻辑 |
+| provider_resolution | `whisper_onnx.rs` | 验证 auto/cpu/cuda/coreml 逻辑 |
+| srt_format_conversion | `whisper_onnx.rs` | sherpa-onnx segment → srtparse::Item |
+
+### 集成测试
+
+- 下载 `tiny` 模型并运行完整字幕生成（使用测试音频 `tests/audio/test.wav`）
+- 标记 `#[ignore]` 避免 CI 每次都下载模型
+
+### 回归测试
+
+- `mod.rs` 中的 `SubtitleGeneratorType` 相关测试保持不变
+- `ffmpeg/mod.rs` 中的错误处理测试保持不变
+
+---
+
+## 错误处理
+
+| 场景 | 处理方式 |
+|---|---|
+| 模型未下载/网络不可用 | 返回 `"模型 {name} 下载失败: {details}"` |
+| 模型文件损坏 | 检测后提示删除缓存重试 |
+| ONNX Runtime 初始化失败 | 返回 provider 相关建议（如 CUDA 用户检查驱动） |
+| 音频文件无效格式 | `Wave::read()` 返回的错误直接透传 |
+| 推理失败 (如 OOM) | 建议使用更小模型 |
+
+---
+
+## 向后兼容
+
+- 旧 `whisper_model` 配置值（如 `"whisper_model.bin"`）不再有效
+- 首次启动时需要用户重新选择模型（或检测到旧配置时自动迁移为 `"base"`）
+- 旧 `.bin` 模型文件不自动删除，用户可手动清理
+
+---
+
+## 前置条件
+
+- sherpa-onnx crate 需要联网下载预编译 ONNX Runtime 原生库（首次 `cargo build` 时）
+- 模型下载也需要首次联网
+
+---
+
+## spec 自审
+
+- [x] 无 TODO / TBD 占位符
+- [x] 架构描述与文件变更清单一致
+- [x] 所有公开接口有明确的签名和职责
+- [x] 错误场景覆盖完整
+- [x] 测试策略覆盖单元/集成/回归

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
- "whisper-rs",
+ "whisper-cpp-rs",
 ]
 
 [[package]]
@@ -789,26 +789,6 @@ name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex 1.3.0",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
@@ -2346,12 +2326,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fslock"
@@ -8270,7 +8244,7 @@ version = "137.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33995a1fee055ff743281cde33a41f0d618ee0bdbe8bdf6859e11864499c2595"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "bitflags 2.10.0",
  "fslock",
  "gzip-header",
@@ -8688,25 +8662,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "whisper-rs"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+name = "whisper-cpp-rs"
+version = "0.1.0"
 dependencies = [
- "whisper-rs-sys",
-]
-
-[[package]]
-name = "whisper-rs-sys"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
-dependencies = [
- "bindgen 0.72.1",
- "cfg-if",
+ "cc",
  "cmake",
- "fs_extra",
- "semver",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
-members = ["crates/danmu_stream", "crates/recorder"]
+members = ["crates/danmu_stream", "crates/recorder", "crates/whisper-cpp-rs"]
 resolver = "2"
+
+[workspace.lints.clippy]
+correctness = "deny"
+suspicious = "deny"
+complexity = "deny"
+style = "deny"
+perf = "deny"
 
 [package]
 name = "bili-shadowreplay"
@@ -11,12 +18,8 @@ license = ""
 repository = ""
 edition = "2021"
 
-[lints.clippy]
-correctness="deny"
-suspicious="deny"
-complexity="deny"
-style="deny"
-perf="deny"
+[lints]
+workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -48,7 +51,7 @@ rand = "0.8.5"
 base64 = "0.21"
 mime_guess = "2.0"
 async-trait = "0.1.87"
-whisper-rs = "0.16.0"
+whisper-cpp-rs = { path = "crates/whisper-cpp-rs" }
 hound = "3.5.1"
 uuid = { workspace = true }
 axum = { version = "0.7", features = ["macros", "multipart"] }
@@ -71,7 +74,7 @@ sentry = { version = "0.46.0", features = ["log", "logs"] }
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
-cuda = ["whisper-rs/cuda"]
+cuda = ["whisper-cpp-rs/cuda"]
 headless = []
 default = ["gui"]
 gui = [
@@ -146,12 +149,6 @@ version = "2"
 features = []
 optional = true
 
-[target.'cfg(windows)'.dependencies]
-whisper-rs = { version = "0.16.0", default-features = false }
-
-[target.'cfg(target_os = "macos")'.dependencies.whisper-rs]
-version = "0.16.0"
-features = ["metal"]
 
 [workspace.dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json", "multipart", "gzip"] }

--- a/src-tauri/crates/whisper-cpp-rs/Cargo.toml
+++ b/src-tauri/crates/whisper-cpp-rs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "whisper-cpp-rs"
+version = "0.1.0"
+edition = "2021"
+description = "Minimal Rust binding for whisper.cpp with GPU acceleration support"
+
+[features]
+default = []
+cuda = []
+
+[dependencies]
+
+[build-dependencies]
+cc = "1"
+cmake = "0.1"

--- a/src-tauri/crates/whisper-cpp-rs/build.rs
+++ b/src-tauri/crates/whisper-cpp-rs/build.rs
@@ -114,6 +114,11 @@ fn main() {
         println!("cargo:rustc-link-lib=stdc++");
     }
 
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "linux" && target_env == "gnu" {
+        println!("cargo:rustc-link-lib=gomp");
+    }
+
     // Link
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=whisper");

--- a/src-tauri/crates/whisper-cpp-rs/build.rs
+++ b/src-tauri/crates/whisper-cpp-rs/build.rs
@@ -1,0 +1,166 @@
+use std::env;
+use std::process::Command;
+
+fn xcrun_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("xcrun").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8(output.stdout).ok()?;
+    let value = value.trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn macos_deployment_target() -> Option<String> {
+    env::var("MACOSX_DEPLOYMENT_TARGET")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| xcrun_output(&["--sdk", "macosx", "--show-sdk-platform-version"]))
+        .or_else(|| xcrun_output(&["--sdk", "macosx", "--show-sdk-version"]))
+        .or_else(|| {
+            let output = Command::new("sw_vers")
+                .args(["-productVersion"])
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            let value = String::from_utf8(output.stdout).ok()?;
+            let value = value.trim();
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        })
+        .map(|value| {
+            let mut parts = value.split('.');
+            let major = parts.next().unwrap_or("10");
+            let minor = parts.next().unwrap_or("0");
+            format!("{major}.{minor}")
+        })
+}
+
+fn main() {
+    let crate_dir = env::current_dir().unwrap();
+    let whisper_dir = crate_dir.join("whisper.cpp");
+
+    let mut config = cmake::Config::new(&whisper_dir);
+
+    // Only build the whisper library, not examples or tests
+    config.define("BUILD_SHARED_LIBS", "OFF");
+    config.define("WHISPER_BUILD_EXAMPLES", "OFF");
+    config.define("WHISPER_BUILD_TESTS", "OFF");
+    config.define("WHISPER_BUILD_SERVER", "OFF");
+
+    // Platform-specific GPU acceleration
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let cuda_enabled = env::var("CARGO_FEATURE_CUDA").is_ok();
+    let metal_enabled = target_os == "macos";
+
+    match target_os.as_str() {
+        "macos" => {
+            if let Some(sdk_root) = env::var("SDKROOT")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .or_else(|| xcrun_output(&["--sdk", "macosx", "--show-sdk-path"]))
+            {
+                config.define("CMAKE_OSX_SYSROOT", &sdk_root);
+            }
+
+            if let Some(target) = macos_deployment_target() {
+                config.define("CMAKE_OSX_DEPLOYMENT_TARGET", &target);
+                config.define("GGML_METAL_MACOSX_VERSION_MIN", &target);
+                config.cflag(&format!("-mmacosx-version-min={target}"));
+                config.cxxflag(&format!("-mmacosx-version-min={target}"));
+            }
+
+            config.define("WHISPER_METAL", "ON");
+            config.define("GGML_METAL", "ON");
+            println!("cargo:warning=Building whisper.cpp with Metal support");
+        }
+        _ => {
+            if cuda_enabled {
+                config.define("GGML_CUDA", "ON");
+                println!("cargo:warning=Building whisper.cpp with CUDA support");
+            } else {
+                config.define("GGML_CUDA", "OFF");
+                config.define("GGML_METAL", "OFF");
+                println!("cargo:warning=Building whisper.cpp for CPU");
+            }
+        }
+    };
+
+    // Build
+    let dst = config.build();
+
+    cc::Build::new()
+        .cpp(true)
+        .file(crate_dir.join("src/ffi_shim.cpp"))
+        .include(whisper_dir.join("include"))
+        .include(whisper_dir.join("ggml/include"))
+        .flag_if_supported("-std=c++17")
+        .compile("whisper_rs_ffi_shim");
+
+    // Link the platform C++ runtime only where the toolchain doesn't provide it implicitly.
+    if target_os == "macos" {
+        println!("cargo:rustc-link-lib=c++");
+    } else if target_os != "windows" {
+        println!("cargo:rustc-link-lib=stdc++");
+    }
+
+    // Link
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-lib=static=whisper");
+    println!("cargo:rustc-link-lib=static=ggml");
+    println!("cargo:rustc-link-lib=static=ggml-base");
+    println!("cargo:rustc-link-lib=static=ggml-cpu");
+
+    if target_os == "macos" {
+        println!("cargo:rustc-link-lib=static=ggml-blas");
+    }
+
+    if metal_enabled {
+        println!("cargo:rustc-link-lib=static=ggml-metal");
+    }
+
+    if cuda_enabled && !metal_enabled {
+        println!("cargo:rustc-link-lib=static=ggml-cuda");
+    }
+
+    // On macOS with Metal, we also need to link Foundation and Metal frameworks
+    if target_os == "macos" {
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=Accelerate");
+    }
+
+    if metal_enabled {
+        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=MetalKit");
+    }
+
+    // Regenerate if any header or source in whisper.cpp changes
+    println!("cargo:rerun-if-env-changed=SDKROOT");
+    println!("cargo:rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET");
+    println!(
+        "cargo:rerun-if-changed={}",
+        crate_dir.join("src/ffi_shim.cpp").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        whisper_dir.join("include").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        whisper_dir.join("src").display()
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        whisper_dir.join("ggml").display()
+    );
+}

--- a/src-tauri/crates/whisper-cpp-rs/src/ffi_shim.cpp
+++ b/src-tauri/crates/whisper-cpp-rs/src/ffi_shim.cpp
@@ -1,0 +1,41 @@
+#include "../whisper.cpp/include/whisper.h"
+
+extern "C" {
+
+void whisper_rs_params_set_greedy_best_of(struct whisper_full_params * params, int best_of) {
+    params->greedy.best_of = best_of;
+}
+
+void whisper_rs_params_set_print_special(struct whisper_full_params * params, bool value) {
+    params->print_special = value;
+}
+
+void whisper_rs_params_set_print_progress(struct whisper_full_params * params, bool value) {
+    params->print_progress = value;
+}
+
+void whisper_rs_params_set_print_realtime(struct whisper_full_params * params, bool value) {
+    params->print_realtime = value;
+}
+
+void whisper_rs_params_set_print_timestamps(struct whisper_full_params * params, bool value) {
+    params->print_timestamps = value;
+}
+
+void whisper_rs_params_set_token_timestamps(struct whisper_full_params * params, bool value) {
+    params->token_timestamps = value;
+}
+
+void whisper_rs_params_set_max_len(struct whisper_full_params * params, int value) {
+    params->max_len = value;
+}
+
+void whisper_rs_params_set_language(struct whisper_full_params * params, const char * value) {
+    params->language = value;
+}
+
+void whisper_rs_params_set_initial_prompt(struct whisper_full_params * params, const char * value) {
+    params->initial_prompt = value;
+}
+
+}

--- a/src-tauri/crates/whisper-cpp-rs/src/lib.rs
+++ b/src-tauri/crates/whisper-cpp-rs/src/lib.rs
@@ -1,0 +1,503 @@
+//! Minimal safe Rust bindings for whisper.cpp.
+//!
+//! Only exposes the subset of the API that this project needs:
+//! model loading, state creation, parameter configuration, inference,
+//! and segment-level result retrieval.
+
+#![allow(non_camel_case_types, dead_code)]
+
+use std::ffi::{c_char, c_int, CStr, CString};
+use std::ptr;
+
+// ── Token-level types ──────────────────────────────────────────────
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct WhisperTokenData {
+    id: c_int,
+    tid: c_int,
+    p: f32,
+    plog: f32,
+    pt: f32,
+    ptsum: f32,
+    t0: i64,
+    t1: i64,
+    t_dtw: i64,
+    vlen: f32,
+}
+
+/// Public-safe token data used for building precise subtitles.
+#[derive(Clone, Debug)]
+pub struct TokenData {
+    /// Token text (may be a special token like [_BEG_], [_TT_150], etc.)
+    pub text: String,
+    /// Start time in centiseconds
+    pub t0: i64,
+    /// End time in centiseconds
+    pub t1: i64,
+    /// Probability of this token
+    pub p: f32,
+}
+
+// ── FFI declarations ───────────────────────────────────────────────
+
+// whisper_context_params is ~32+ bytes in whisper.h v1.7.4.
+// We use an opaque buffer to avoid mismatched struct definitions.
+// use_gpu is at byte offset 0 (bool = 1 byte).
+#[repr(C)]
+struct WhisperContextParams([u8; 256]);
+
+extern "C" {
+    fn whisper_context_default_params_by_ref() -> *mut WhisperContextParams;
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+enum whisper_sampling_strategy {
+    WHISPER_SAMPLING_GREEDY = 0,
+    WHISPER_SAMPLING_BEAM_SEARCH = 1,
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct whisper_full_params {
+    _opaque: [u8; 1024], // opaque; we only ever hold a pointer from whisper
+}
+
+type whisper_progress_callback =
+    unsafe extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void, c_int, *mut std::ffi::c_void);
+
+extern "C" {
+    fn whisper_init_from_file_with_params(
+        path_model: *const c_char,
+        params: WhisperContextParams,
+    ) -> *mut std::ffi::c_void;
+
+    fn whisper_init_state(ctx: *mut std::ffi::c_void) -> *mut std::ffi::c_void;
+
+    fn whisper_free(ctx: *mut std::ffi::c_void);
+    fn whisper_free_state(state: *mut std::ffi::c_void);
+    fn whisper_free_params(params: *mut std::ffi::c_void);
+
+    fn whisper_full_default_params_by_ref(
+        strategy: whisper_sampling_strategy,
+    ) -> *mut whisper_full_params;
+
+    fn whisper_full(
+        ctx: *mut std::ffi::c_void,
+        params: *mut whisper_full_params,
+        samples: *const f32,
+        n_samples: c_int,
+    ) -> c_int;
+
+    fn whisper_full_with_state(
+        ctx: *mut std::ffi::c_void,
+        state: *mut std::ffi::c_void,
+        params: *mut whisper_full_params,
+        samples: *const f32,
+        n_samples: c_int,
+    ) -> c_int;
+
+    fn whisper_full_n_segments_from_state(state: *mut std::ffi::c_void) -> c_int;
+
+    fn whisper_full_get_segment_t0_from_state(
+        state: *mut std::ffi::c_void,
+        i_segment: c_int,
+    ) -> i64;
+
+    fn whisper_full_get_segment_t1_from_state(
+        state: *mut std::ffi::c_void,
+        i_segment: c_int,
+    ) -> i64;
+
+    fn whisper_full_get_segment_text_from_state(
+        state: *mut std::ffi::c_void,
+        i_segment: c_int,
+    ) -> *const c_char;
+
+    fn whisper_full_n_tokens_from_state(
+        state: *mut std::ffi::c_void,
+        i_segment: c_int,
+    ) -> c_int;
+
+    fn whisper_full_get_token_text_from_state(
+        ctx: *mut std::ffi::c_void,
+        state: *mut std::ffi::c_void,
+        i_segment: c_int,
+        i_token: c_int,
+    ) -> *const c_char;
+
+    fn whisper_full_get_token_data_from_state(
+        state: *mut std::ffi::c_void,
+        i_segment: c_int,
+        i_token: c_int,
+    ) -> WhisperTokenData;
+
+    fn whisper_print_system_info() -> *const c_char;
+    fn whisper_rs_params_set_greedy_best_of(params: *mut whisper_full_params, best_of: c_int);
+    fn whisper_rs_params_set_print_special(params: *mut whisper_full_params, value: bool);
+    fn whisper_rs_params_set_print_progress(params: *mut whisper_full_params, value: bool);
+    fn whisper_rs_params_set_print_realtime(params: *mut whisper_full_params, value: bool);
+    fn whisper_rs_params_set_print_timestamps(params: *mut whisper_full_params, value: bool);
+    fn whisper_rs_params_set_token_timestamps(params: *mut whisper_full_params, value: bool);
+    fn whisper_rs_params_set_max_len(params: *mut whisper_full_params, value: c_int);
+    fn whisper_rs_params_set_language(params: *mut whisper_full_params, value: *const c_char);
+    fn whisper_rs_params_set_initial_prompt(params: *mut whisper_full_params, value: *const c_char);
+}
+
+// ── Public types ────────────────────────────────────────────────────
+
+/// Audio sampling strategy for whisper.
+#[derive(Clone, Copy)]
+pub enum SamplingStrategy {
+    Greedy { best_of: i32 },
+}
+
+/// Thread-safe context holding the loaded whisper model.
+pub struct WhisperContext {
+    ctx: *mut std::ffi::c_void,
+}
+
+unsafe impl Send for WhisperContext {}
+unsafe impl Sync for WhisperContext {}
+
+/// A whisper processing state, created from a context.
+/// NOT Send/Sync — one state per inference session.
+pub struct WhisperState {
+    state: *mut std::ffi::c_void,
+}
+
+// SAFETY: WhisperState is used exclusively within a single async task
+// and never shared across threads. The raw pointer is only accessed
+// sequentially from the owning task.
+unsafe impl Send for WhisperState {}
+
+/// Full inference parameters.
+pub struct FullParams {
+    params: *mut whisper_full_params,
+    // Keep CStrings alive for the lifetime of params
+    _language: Option<CString>,
+    _prompt: Option<CString>,
+}
+
+unsafe impl Send for FullParams {}
+
+impl Drop for WhisperContext {
+    fn drop(&mut self) {
+        if !self.ctx.is_null() {
+            unsafe { whisper_free(self.ctx) };
+        }
+    }
+}
+
+impl Drop for WhisperState {
+    fn drop(&mut self) {
+        if !self.state.is_null() {
+            unsafe { whisper_free_state(self.state) };
+        }
+    }
+}
+
+impl Drop for FullParams {
+    fn drop(&mut self) {
+        if !self.params.is_null() {
+            unsafe { whisper_free_params(self.params as *mut std::ffi::c_void) };
+        }
+    }
+}
+
+// ── impl WhisperContext ─────────────────────────────────────────────
+
+impl WhisperContext {
+    /// Load a whisper model from the given file path.
+    pub fn new(model_path: &str) -> Result<Self, String> {
+        let path = CString::new(model_path).map_err(|e| format!("Invalid path: {e}"))?;
+
+        let ctx = unsafe {
+            let params_ptr = whisper_context_default_params_by_ref();
+            if params_ptr.is_null() {
+                return Err("Failed to get default context params".to_string());
+            }
+            // Read the full struct (256 opaque bytes) to get all defaults,
+            // then enable GPU at byte offset 0 (use_gpu).
+            let mut params: WhisperContextParams = ptr::read(params_ptr);
+            params.0[0] = 1; // use_gpu = true
+
+            whisper_init_from_file_with_params(path.as_ptr(), params)
+        };
+
+        if ctx.is_null() {
+            return Err(format!("Failed to load whisper model from {model_path}"));
+        }
+
+        Ok(Self { ctx })
+    }
+
+    /// Create a new processing state.
+    pub fn create_state(&self) -> Result<WhisperState, String> {
+        let state = unsafe { whisper_init_state(self.ctx) };
+        if state.is_null() {
+            return Err("Failed to create whisper state".to_string());
+        }
+        Ok(WhisperState { state })
+    }
+}
+
+// ── impl FullParams ─────────────────────────────────────────────────
+
+impl FullParams {
+    /// Create default parameters with the given sampling strategy.
+    pub fn new(strategy: SamplingStrategy) -> Self {
+        let s = match strategy {
+            SamplingStrategy::Greedy { .. } => {
+                whisper_sampling_strategy::WHISPER_SAMPLING_GREEDY
+            }
+        };
+
+        let params = unsafe { whisper_full_default_params_by_ref(s) };
+        assert!(!params.is_null(), "whisper_full_default_params_by_ref returned null");
+
+        // Set greedy best_of if applicable
+        let SamplingStrategy::Greedy { best_of } = strategy;
+        unsafe { whisper_rs_params_set_greedy_best_of(params, best_of) };
+
+        Self {
+            params,
+            _language: None,
+            _prompt: None,
+        }
+    }
+
+    /// Set the language hint (e.g. "zh", "en"). Pass None or "auto" for auto-detect.
+    pub fn set_language(&mut self, lang: Option<&str>) {
+        let cstr = lang.and_then(|l| {
+            if l.is_empty() || l == "auto" {
+                None
+            } else {
+                CString::new(l).ok()
+            }
+        });
+        if let Some(ref c) = cstr {
+            unsafe { whisper_rs_params_set_language(self.params, c.as_ptr()) };
+        } else {
+            unsafe { whisper_rs_params_set_language(self.params, ptr::null()) };
+        }
+        self._language = cstr;
+    }
+
+    /// Set the initial prompt to guide vocabulary and style.
+    pub fn set_initial_prompt(&mut self, prompt: &str) {
+        let cstr = CString::new(prompt).ok();
+        if let Some(ref c) = cstr {
+            unsafe { whisper_rs_params_set_initial_prompt(self.params, c.as_ptr()) };
+        } else {
+            unsafe { whisper_rs_params_set_initial_prompt(self.params, ptr::null()) };
+        }
+        self._prompt = cstr;
+    }
+
+    /// Whether to print special tokens to stdout.
+    pub fn set_print_special(&mut self, v: bool) {
+        unsafe { whisper_rs_params_set_print_special(self.params, v) };
+    }
+
+    /// Whether to print progress to stdout.
+    pub fn set_print_progress(&mut self, v: bool) {
+        unsafe { whisper_rs_params_set_print_progress(self.params, v) };
+    }
+
+    /// Whether to print realtime results to stdout.
+    pub fn set_print_realtime(&mut self, v: bool) {
+        unsafe { whisper_rs_params_set_print_realtime(self.params, v) };
+    }
+
+    /// Whether to print timestamps to stdout.
+    pub fn set_print_timestamps(&mut self, v: bool) {
+        unsafe { whisper_rs_params_set_print_timestamps(self.params, v) };
+    }
+
+    /// Enable per-token timestamps for more precise segment boundaries.
+    pub fn set_token_timestamps(&mut self, v: bool) {
+        unsafe { whisper_rs_params_set_token_timestamps(self.params, v) };
+    }
+
+    /// Maximum segment length in characters. 0 = no limit.
+    /// Setting this forces whisper to split into shorter segments,
+    /// improving timestamp granularity for subtitle display.
+    pub fn set_max_len(&mut self, max_len: i32) {
+        unsafe { whisper_rs_params_set_max_len(self.params, max_len) };
+    }
+}
+
+// ── impl WhisperState ────────────────────────────────────────────────
+
+impl WhisperState {
+    /// Run inference on the given audio samples (16kHz mono f32 PCM).
+    pub fn full(
+        &mut self,
+        ctx: &WhisperContext,
+        params: &FullParams,
+        samples: &[f32],
+    ) -> Result<i32, String> {
+        let ret = unsafe {
+            whisper_full_with_state(
+                ctx.ctx,
+                self.state,
+                params.params,
+                samples.as_ptr(),
+                samples.len() as c_int,
+            )
+        };
+        if ret != 0 {
+            Err(format!("whisper_full failed with code {ret}"))
+        } else {
+            Ok(ret)
+        }
+    }
+
+    /// Number of transcribed segments.
+    pub fn full_n_segments(&self) -> i32 {
+        unsafe { whisper_full_n_segments_from_state(self.state) }
+    }
+
+    /// Get segment start timestamp in centiseconds (divide by 100.0 for seconds).
+    pub fn get_segment_t0(&self, index: i32) -> i64 {
+        unsafe { whisper_full_get_segment_t0_from_state(self.state, index) }
+    }
+
+    /// Get segment end timestamp in centiseconds (divide by 100.0 for seconds).
+    pub fn get_segment_t1(&self, index: i32) -> i64 {
+        unsafe { whisper_full_get_segment_t1_from_state(self.state, index) }
+    }
+
+    /// Get segment text. Returns None if index is out of range.
+    pub fn get_segment_text(&self, index: i32) -> Option<String> {
+        unsafe {
+            let ptr = whisper_full_get_segment_text_from_state(self.state, index);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr).to_string_lossy().into_owned())
+            }
+        }
+    }
+
+    /// Number of tokens in a given segment.
+    pub fn full_n_tokens(&self, i_segment: i32) -> i32 {
+        unsafe { whisper_full_n_tokens_from_state(self.state, i_segment) }
+    }
+
+    /// Get all tokens for a segment with their text, timestamps, and
+    /// probabilities.  Special tokens (`[_BEG_]`, `[_TT_*]`, etc.)
+    /// are included — the caller should filter them.
+    pub fn get_segment_tokens(
+        &self,
+        ctx: &WhisperContext,
+        i_segment: i32,
+    ) -> Vec<TokenData> {
+        let n = self.full_n_tokens(i_segment);
+        let mut tokens = Vec::with_capacity(n as usize);
+        for i in 0..n {
+            let text = unsafe {
+                let ptr = whisper_full_get_token_text_from_state(
+                    ctx.ctx,
+                    self.state,
+                    i_segment,
+                    i,
+                );
+                if ptr.is_null() {
+                    String::new()
+                } else {
+                    CStr::from_ptr(ptr).to_string_lossy().into_owned()
+                }
+            };
+            let data =
+                unsafe { whisper_full_get_token_data_from_state(self.state, i_segment, i) };
+            tokens.push(TokenData {
+                text,
+                t0: data.t0,
+                t1: data.t1,
+                p: data.p,
+            });
+        }
+        tokens
+    }
+}
+
+// ── Audio conversion utilities ──────────────────────────────────────
+
+/// Convert i16 PCM samples to f32 in range [-1.0, 1.0].
+pub fn convert_integer_to_float_audio(
+    input: &[i16],
+    output: &mut [f32],
+) -> Result<(), String> {
+    if input.len() != output.len() {
+        return Err(format!(
+            "Input and output must have the same length: {} != {}",
+            input.len(),
+            output.len()
+        ));
+    }
+    for (i, sample) in input.iter().enumerate() {
+        output[i] = *sample as f32 / 32768.0;
+    }
+    Ok(())
+}
+
+/// Convert interleaved stereo f32 samples to mono by averaging channels.
+/// Output length must be half of input length.
+pub fn convert_stereo_to_mono_audio(
+    input: &[f32],
+    output: &mut [f32],
+) -> Result<(), String> {
+    if input.len() != output.len() * 2 {
+        return Err(format!(
+            "Input length ({}) must be 2x output length ({})",
+            input.len(),
+            output.len()
+        ));
+    }
+    for i in 0..output.len() {
+        output[i] = (input[i * 2] + input[i * 2 + 1]) * 0.5;
+    }
+    Ok(())
+}
+
+/// Print system info (GPU, CPU features, etc.) to stdout.
+pub fn print_system_info() -> String {
+    unsafe {
+        let ptr = whisper_print_system_info();
+        if ptr.is_null() {
+            "unknown".to_string()
+        } else {
+            CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_integer_to_float() {
+        let input: Vec<i16> = vec![0, 16384, -16384, 32767, -32768];
+        let mut output = vec![0.0f32; 5];
+        convert_integer_to_float_audio(&input, &mut output).unwrap();
+        assert!((output[0] - 0.0).abs() < 0.001);
+        assert!((output[1] - 0.5).abs() < 0.001);
+        assert!((output[2] + 0.5).abs() < 0.001);
+        assert!((output[3] - 0.99997).abs() < 0.001);
+        assert!((output[4] + 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_convert_stereo_to_mono() {
+        let input: Vec<f32> = vec![1.0, 0.0, 0.5, 0.5, -1.0, 1.0];
+        let mut output = vec![0.0f32; 3];
+        convert_stereo_to_mono_audio(&input, &mut output).unwrap();
+        assert!((output[0] - 0.5).abs() < 0.001); // (1.0 + 0.0) / 2
+        assert!((output[1] - 0.5).abs() < 0.001); // (0.5 + 0.5) / 2
+        assert!((output[2] - 0.0).abs() < 0.001); // (-1.0 + 1.0) / 2
+    }
+}

--- a/src-tauri/src/audio_utils.rs
+++ b/src-tauri/src/audio_utils.rs
@@ -1,0 +1,350 @@
+/// Audio utility functions: VAD (Voice Activity Detection) and
+/// Cut & Merge segmentation for long-form audio preprocessing.
+///
+/// Based on the WhisperX paper (Bain et al., 2023):
+///   - VAD to find speech boundaries at natural silence points
+///   - Cut segments > 30s at minimum-energy points
+///   - Merge adjacent short segments ≤ 30s
+///
+/// A speech segment with start and end times in seconds.
+#[derive(Debug, Clone)]
+pub struct SpeechSegment {
+    pub start: f64,
+    pub end: f64,
+}
+
+/// Energy-based VAD on 16kHz mono f32 PCM samples.
+///
+/// Returns speech segments sorted by start time.
+pub fn energy_vad(samples: &[f32], sample_rate: u32) -> Vec<SpeechSegment> {
+    if samples.is_empty() {
+        return vec![];
+    }
+
+    let frame_len = ((sample_rate as f64 * 0.025) as usize).max(1); // 25ms frames
+    let frame_step = ((sample_rate as f64 * 0.010) as usize).max(1); // 10ms hop
+
+    // Compute RMS energy per frame
+    let mut energies: Vec<f64> = Vec::new();
+    let mut pos = 0;
+    while pos + frame_len <= samples.len() {
+        let sum_sq: f64 = samples[pos..pos + frame_len]
+            .iter()
+            .map(|&s| (s as f64) * (s as f64))
+            .sum();
+        let rms = (sum_sq / frame_len as f64).sqrt();
+        energies.push(rms);
+        pos += frame_step;
+    }
+
+    if energies.is_empty() {
+        return vec![];
+    }
+
+    // Dynamic threshold: use a fraction of the median energy of
+    // frames that are above the absolute silence floor.
+    let silence_floor = 1e-4;
+    let active: Vec<f64> = energies
+        .iter()
+        .copied()
+        .filter(|&e| e > silence_floor)
+        .collect();
+
+    if active.is_empty() {
+        return vec![];
+    }
+
+    let mut sorted = active.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median_energy = sorted[sorted.len() / 2];
+
+    // Use a stricter onset threshold to avoid treating background
+    // noise/music as speech.  silence_floor * 20 is a hard floor.
+    let onset_threshold = (median_energy * 0.5).max(silence_floor * 20.0);
+
+    // Classify each frame as speech (true) or silence (false)
+    let frame_sec = frame_step as f64 / sample_rate as f64;
+    let mut is_speech: Vec<bool> = energies.iter().map(|&e| e > onset_threshold).collect();
+
+    // Temporal smoothing: fill short gaps inside phrases and remove only
+    // extremely short speech bursts. The previous thresholds were too
+    // aggressive for conversational clips and dropped many real utterances.
+    let min_speech_frames = ((0.15 / frame_sec) as usize).max(1);
+    let max_gap_frames = ((0.20 / frame_sec) as usize).max(1);
+
+    // Remove short speech bursts
+    let mut i = 0;
+    while i < is_speech.len() {
+        if is_speech[i] {
+            let mut j = i;
+            while j < is_speech.len() && is_speech[j] {
+                j += 1;
+            }
+            if j - i < min_speech_frames {
+                for item in is_speech.iter_mut().take(j).skip(i) {
+                    *item = false;
+                }
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+
+    // Fill short gaps
+    i = 0;
+    while i < is_speech.len() {
+        if !is_speech[i] {
+            let mut j = i;
+            while j < is_speech.len() && !is_speech[j] {
+                j += 1;
+            }
+            if j - i < max_gap_frames && i > 0 && j < is_speech.len() {
+                for item in is_speech.iter_mut().take(j).skip(i) {
+                    *item = true;
+                }
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+
+    // Extract contiguous speech segments
+    let mut segments = Vec::new();
+    i = 0;
+    while i < is_speech.len() {
+        if is_speech[i] {
+            let start = i as f64 * frame_sec;
+            let mut j = i;
+            while j < is_speech.len() && is_speech[j] {
+                j += 1;
+            }
+            let end = j as f64 * frame_sec;
+            // Drop only clearly spurious segments. Conversational particles
+            // and clipped short replies are often well below 500ms.
+            if end - start >= 0.25 {
+                segments.push(SpeechSegment { start, end });
+            }
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+
+    // Merge adjacent segments separated by < 0.5s of silence
+    let mut merged: Vec<SpeechSegment> = Vec::new();
+    for seg in segments {
+        if let Some(last) = merged.last_mut() {
+            if seg.start - last.end < 0.5 {
+                last.end = seg.end;
+                continue;
+            }
+        }
+        merged.push(seg);
+    }
+
+    // Trim leading/trailing silence from each segment: re-check the
+    // first and last 500ms and shrink the boundary if energy is below
+    // half the onset threshold.
+    let trim_secs = 0.5;
+    let trim_threshold = onset_threshold * 0.5;
+    for seg in &mut merged {
+        // Trim leading silence
+        let frame_from = (seg.start / frame_sec) as usize;
+        let frame_trim_end = ((seg.start + trim_secs).min(seg.end) / frame_sec) as usize;
+        let mut new_start = seg.start;
+        for (fi, &energy) in energies
+            .iter()
+            .enumerate()
+            .skip(frame_from)
+            .take(frame_trim_end.saturating_sub(frame_from))
+        {
+            if energy > trim_threshold {
+                new_start = fi as f64 * frame_sec;
+                break;
+            }
+        }
+        // Trim trailing silence
+        let frame_to = (seg.end / frame_sec) as usize;
+        let frame_trim_start = ((seg.end - trim_secs).max(seg.start) / frame_sec) as usize;
+        let mut new_end = seg.end;
+        for (fi, &energy) in energies
+            .iter()
+            .enumerate()
+            .skip(frame_trim_start)
+            .take(frame_to.saturating_sub(frame_trim_start))
+        {
+            if energy > trim_threshold {
+                new_end = (fi + 1) as f64 * frame_sec;
+            }
+            // Continue to the end — we want the LAST frame above threshold
+        }
+        // Only apply if the trim doesn't collapse the segment entirely
+        if new_end - new_start >= 0.3 {
+            seg.start = new_start;
+            seg.end = new_end;
+        }
+    }
+
+    // Re-filter: drop any segments that became too short after trimming.
+    merged.retain(|s| s.end - s.start >= 0.25);
+
+    merged
+}
+
+/// Apply WhisperX Cut & Merge to speech segments.
+///
+/// - **Cut**: segments longer than `cut_max` seconds are split at the
+///   point of minimum energy within the window `[cut_max/2, cut_max]`.
+/// - **Merge**: adjacent segments whose combined duration ≤ `merge_max`
+///   are merged together.
+///
+/// `energies` is the per-frame RMS energy (same as from `energy_vad`).
+/// `frame_sec` is the duration of one frame in seconds.
+pub fn cut_and_merge(
+    segments: &[SpeechSegment],
+    energies: &[f64],
+    frame_sec: f64,
+    cut_max: f64,
+    merge_max: f64,
+) -> Vec<SpeechSegment> {
+    // Step 1: Cut long segments
+    let mut cut: Vec<SpeechSegment> = Vec::new();
+    for seg in segments {
+        let duration = seg.end - seg.start;
+        if duration <= cut_max {
+            cut.push(seg.clone());
+        } else {
+            // Find the minimum-energy point in [cut_max/2, cut_max] window
+            let mut pos = seg.start;
+            while pos + cut_max < seg.end {
+                let window_start = pos + cut_max / 2.0;
+                let window_end = (pos + cut_max).min(seg.end);
+
+                let frame_start = (window_start / frame_sec) as usize;
+                let frame_end = ((window_end / frame_sec) as usize).min(energies.len());
+
+                let mut min_idx = frame_start;
+                let mut min_energy = f64::MAX;
+                for fi in frame_start..frame_end {
+                    if fi < energies.len() && energies[fi] < min_energy {
+                        min_energy = energies[fi];
+                        min_idx = fi;
+                    }
+                }
+
+                let cut_point = min_idx as f64 * frame_sec;
+                if cut_point <= pos {
+                    // Degenerate case: force cut at the midpoint
+                    let mid = pos + cut_max / 2.0;
+                    cut.push(SpeechSegment {
+                        start: pos,
+                        end: mid.min(seg.end),
+                    });
+                    pos = mid.min(seg.end);
+                } else {
+                    cut.push(SpeechSegment {
+                        start: pos,
+                        end: cut_point,
+                    });
+                    pos = cut_point;
+                }
+            }
+            // Remaining tail (≤ cut_max)
+            if pos < seg.end {
+                cut.push(SpeechSegment {
+                    start: pos,
+                    end: seg.end,
+                });
+            }
+        }
+    }
+
+    // Step 2: Merge adjacent short segments
+    let mut merged: Vec<SpeechSegment> = Vec::new();
+    for seg in cut {
+        if let Some(last) = merged.last_mut() {
+            let combined = seg.end - last.start;
+            if combined <= merge_max {
+                last.end = seg.end;
+                continue;
+            }
+        }
+        merged.push(seg);
+    }
+
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_energy_vad_silence() {
+        let samples = vec![0.0f32; 16000]; // 1 second of silence
+        let segments = energy_vad(&samples, 16000);
+        assert!(segments.is_empty());
+    }
+
+    #[test]
+    fn test_energy_vad_speech() {
+        // 1 second of loud sine wave
+        let samples: Vec<f32> = (0..16000)
+            .map(|i| (i as f32 * 440.0 * 2.0 * std::f32::consts::PI / 16000.0).sin() * 0.8)
+            .collect();
+        let segments = energy_vad(&samples, 16000);
+        // Should detect one continuous speech segment
+        assert_eq!(segments.len(), 1);
+        assert!(segments[0].start < 0.1);
+        assert!(segments[0].end > 0.9);
+    }
+
+    #[test]
+    fn test_cut_and_merge_noop() {
+        let segments = vec![SpeechSegment {
+            start: 0.0,
+            end: 10.0,
+        }];
+        let energies = vec![0.1; 1000];
+        let result = cut_and_merge(&segments, &energies, 0.01, 30.0, 10.0);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].start, 0.0);
+        assert_eq!(result[0].end, 10.0);
+    }
+
+    #[test]
+    fn test_cut_and_merge_split_long() {
+        let segments = vec![SpeechSegment {
+            start: 0.0,
+            end: 90.0,
+        }];
+        // Uniform energy — cuts at midpoint of [15,30] = 22.5, then again
+        let energies = vec![0.1; 10000];
+        let result = cut_and_merge(&segments, &energies, 0.01, 30.0, 10.0);
+        // Should split into ~3 segments of ~30s each
+        assert!(result.len() >= 3);
+        for seg in &result {
+            assert!(seg.end - seg.start <= 30.0 + 0.01);
+        }
+    }
+
+    #[test]
+    fn test_cut_and_merge_adjacent_no_merge() {
+        let segments = vec![
+            SpeechSegment {
+                start: 0.0,
+                end: 10.0,
+            },
+            SpeechSegment {
+                start: 11.0, // 1s gap
+                end: 18.0,
+            },
+        ];
+        // Merging disabled — segments should remain separate
+        let energies = vec![0.1; 2000];
+        let result = cut_and_merge(&segments, &energies, 0.01, 30.0, 10.0);
+        assert_eq!(result.len(), 2);
+    }
+}

--- a/src-tauri/src/audio_utils.rs
+++ b/src-tauri/src/audio_utils.rs
@@ -16,9 +16,20 @@ pub struct SpeechSegment {
 /// Energy-based VAD on 16kHz mono f32 PCM samples.
 ///
 /// Returns speech segments sorted by start time.
+#[allow(dead_code)]
 pub fn energy_vad(samples: &[f32], sample_rate: u32) -> Vec<SpeechSegment> {
+    energy_vad_with_energies(samples, sample_rate).0
+}
+
+/// Energy-based VAD on 16kHz mono f32 PCM samples.
+///
+/// Returns speech segments, per-frame RMS energies and the frame duration in seconds.
+pub fn energy_vad_with_energies(
+    samples: &[f32],
+    sample_rate: u32,
+) -> (Vec<SpeechSegment>, Vec<f64>, f64) {
     if samples.is_empty() {
-        return vec![];
+        return (vec![], vec![], 0.01);
     }
 
     let frame_len = ((sample_rate as f64 * 0.025) as usize).max(1); // 25ms frames
@@ -38,7 +49,7 @@ pub fn energy_vad(samples: &[f32], sample_rate: u32) -> Vec<SpeechSegment> {
     }
 
     if energies.is_empty() {
-        return vec![];
+        return (vec![], energies, frame_step as f64 / sample_rate as f64);
     }
 
     // Dynamic threshold: use a fraction of the median energy of
@@ -51,7 +62,7 @@ pub fn energy_vad(samples: &[f32], sample_rate: u32) -> Vec<SpeechSegment> {
         .collect();
 
     if active.is_empty() {
-        return vec![];
+        return (vec![], energies, frame_step as f64 / sample_rate as f64);
     }
 
     let mut sorted = active.clone();
@@ -190,7 +201,7 @@ pub fn energy_vad(samples: &[f32], sample_rate: u32) -> Vec<SpeechSegment> {
     // Re-filter: drop any segments that became too short after trimming.
     merged.retain(|s| s.end - s.start >= 0.25);
 
-    merged
+    (merged, energies, frame_sec)
 }
 
 /// Apply WhisperX Cut & Merge to speech segments.

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -368,6 +368,108 @@ pub async fn extract_audio_chunks(file: &Path, format: &str) -> Result<PathBuf, 
     }
 }
 
+/// Extract the full audio track as a single 16kHz mono WAV file.
+/// Returns the path to the extracted WAV.
+pub async fn extract_full_audio(file: &Path) -> Result<PathBuf, String> {
+    log::info!("Extract full audio: {}", file.display());
+    let output_path = file.with_extension("full.wav");
+
+    let mut ffmpeg_process = ffmpeg_command();
+    #[cfg(target_os = "windows")]
+    ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
+
+    let child = ffmpeg_process
+        .args(["-i", file.to_str().unwrap()])
+        .args(["-ar", "16000"])
+        .args(["-ac", "1"]) // mono for VAD
+        .args(["-c:a", "pcm_s16le"])
+        .args(["-vn"])
+        .args(["-y"])
+        .args(["-progress", "pipe:2"])
+        .args([output_path.to_str().unwrap()])
+        .stderr(Stdio::piped())
+        .spawn();
+
+    let mut child = child.map_err(|e| format!("Failed to spawn ffmpeg: {e}"))?;
+    let stderr = child.stderr.take().unwrap();
+    let reader = BufReader::new(stderr);
+    let mut parser = FfmpegLogParser::new(reader);
+
+    while let Ok(event) = parser.parse_next_event().await {
+        match event {
+            FfmpegEvent::Error(e) => {
+                log::error!("Extract full audio error: {e}");
+            }
+            FfmpegEvent::LogEOF => break,
+            _ => {}
+        }
+    }
+
+    child
+        .wait()
+        .await
+        .map_err(|e| format!("ffmpeg wait error: {e}"))?;
+
+    if output_path.exists() {
+        log::info!("Full audio extracted: {}", output_path.display());
+        Ok(output_path)
+    } else {
+        Err("Full audio extraction failed: output file not found".to_string())
+    }
+}
+
+/// Extract a time segment from a video as a 16kHz stereo WAV file.
+/// (whisper_cpp.rs handles stereo→mono conversion internally.)
+pub async fn extract_audio_segment(
+    file: &Path,
+    start_sec: f64,
+    duration_sec: f64,
+    output_path: &Path,
+) -> Result<(), String> {
+    let mut ffmpeg_process = ffmpeg_command();
+    #[cfg(target_os = "windows")]
+    ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
+
+    let child = ffmpeg_process
+        .args(["-ss", &start_sec.to_string()])
+        .args(["-i", file.to_str().unwrap()])
+        .args(["-t", &duration_sec.to_string()])
+        .args(["-ar", "16000"])
+        .args(["-c:a", "pcm_s16le"])
+        .args(["-vn"])
+        .args(["-y"])
+        .args(["-progress", "pipe:2"])
+        .args([output_path.to_str().unwrap()])
+        .stderr(Stdio::piped())
+        .spawn();
+
+    let mut child = child.map_err(|e| format!("Failed to spawn ffmpeg: {e}"))?;
+    let stderr = child.stderr.take().unwrap();
+    let reader = BufReader::new(stderr);
+    let mut parser = FfmpegLogParser::new(reader);
+
+    while let Ok(event) = parser.parse_next_event().await {
+        match event {
+            FfmpegEvent::Error(e) => {
+                log::error!("Extract audio segment error: {e}");
+            }
+            FfmpegEvent::LogEOF => break,
+            _ => {}
+        }
+    }
+
+    child
+        .wait()
+        .await
+        .map_err(|e| format!("ffmpeg wait error: {e}"))?;
+
+    if output_path.exists() {
+        Ok(())
+    } else {
+        Err("Audio segment extraction failed: output file not found".to_string())
+    }
+}
+
 /// Get the duration of an audio/video file in seconds
 async fn get_audio_duration(file: &Path) -> Result<u64, String> {
     // Use ffprobe with format option to get duration
@@ -674,52 +776,129 @@ pub async fn generate_video_subtitle(
             if whisper_model.is_empty() {
                 return Err("Whisper model not configured".to_string());
             }
-            if let Ok(generator) = whisper_cpp::new(Path::new(&whisper_model), whisper_prompt).await
-            {
-                let chunk_dir = extract_audio_chunks(file, "wav").await?;
+            let generator = match whisper_cpp::new(Path::new(whisper_model), whisper_prompt).await {
+                Ok(g) => g,
+                Err(e) => return Err(format!("Failed to initialize Whisper model: {e}")),
+            };
 
-                let mut full_result = GenerateResult {
-                    subtitle_id: String::new(),
-                    subtitle_content: vec![],
-                    generator_type: SubtitleGeneratorType::Whisper,
-                };
+            // Extract full audio as single 16kHz mono WAV
+            if let Some(reporter) = reporter {
+                reporter.update("提取完整音频中").await;
+            }
+            let full_wav = extract_full_audio(file).await?;
 
-                let mut chunk_paths = vec![];
-                for entry in std::fs::read_dir(&chunk_dir)
-                    .map_err(|e| format!("Failed to read chunk directory: {e}"))?
-                {
-                    let entry =
-                        entry.map_err(|e| format!("Failed to read directory entry: {e}"))?;
-                    let path = entry.path();
-                    chunk_paths.push(path);
+            // Read samples for VAD
+            let audio = hound::WavReader::open(&full_wav).map_err(|e| e.to_string())?;
+            let spec = audio.spec();
+            let sample_rate = spec.sample_rate;
+            let raw_samples: Vec<i16> = audio.into_samples::<i16>().map(|x| x.unwrap()).collect();
+            let mut f32_samples = vec![0.0f32; raw_samples.len()];
+            whisper_cpp_rs::convert_integer_to_float_audio(&raw_samples, &mut f32_samples)
+                .map_err(|e| format!("Audio conversion error: {e}"))?;
+
+            // VAD: find speech segments
+            if let Some(reporter) = reporter {
+                reporter.update("检测语音片段中").await;
+            }
+            let speech_segments = crate::audio_utils::energy_vad(&f32_samples, sample_rate);
+            log::info!(
+                "VAD detected {} speech segments from {:.1}s audio",
+                speech_segments.len(),
+                f32_samples.len() as f64 / sample_rate as f64
+            );
+
+            // Cut & Merge: normalize to ≤30s chunks
+            let frame_sec = 0.01; // 10ms hop from energy_vad
+            let max_chunk = 30.0;
+            // Compute energies for cut_and_merge
+            let frame_len = ((sample_rate as f64 * 0.025) as usize).max(1);
+            let frame_step = ((sample_rate as f64 * 0.010) as usize).max(1);
+            let energies: Vec<f64> = {
+                let mut e = Vec::new();
+                let mut pos = 0;
+                while pos + frame_len <= f32_samples.len() {
+                    let sum_sq: f64 = f32_samples[pos..pos + frame_len]
+                        .iter()
+                        .map(|&s| (s as f64) * (s as f64))
+                        .sum();
+                    let rms = (sum_sq / frame_len as f64).sqrt();
+                    e.push(rms);
+                    pos += frame_step;
                 }
+                e
+            };
+            let chunks = crate::audio_utils::cut_and_merge(
+                &speech_segments,
+                &energies,
+                frame_sec,
+                max_chunk, // cut_max: split segments >30s
+                10.0,      // merge_max: merge adjacent segments ≤10s
+            );
+            log::info!(
+                "Cut & Merge: {} speech segments → {} chunks (≤{}s each)",
+                speech_segments.len(),
+                chunks.len(),
+                max_chunk
+            );
 
-                // sort chunk paths by name
-                chunk_paths
-                    .sort_by_key(|path| path.file_name().unwrap().to_str().unwrap().to_string());
+            // Process each chunk
+            let mut results = Vec::new();
+            let temp_dir =
+                std::env::temp_dir().join(format!("bsr_whisper_{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&temp_dir)
+                .map_err(|e| format!("Failed to create temp dir: {e}"))?;
 
-                let mut results = Vec::new();
-                for path in chunk_paths {
-                    let result = generator
-                        .generate_subtitle(reporter, &path, language_hint)
+            let chunk_padding = 0.35;
+            for (i, chunk) in chunks.iter().enumerate() {
+                let segment_path = temp_dir.join(format!("seg_{:03}.wav", i));
+                let padded_start = (chunk.start - chunk_padding).max(0.0);
+                let padded_end = chunk.end + chunk_padding;
+                let duration = padded_end - padded_start;
+                if let Some(reporter) = reporter {
+                    reporter
+                        .update(&format!(
+                            "字幕生成中 ({}/{}, {:.0}s-{:.0}s)",
+                            i + 1,
+                            chunks.len(),
+                            padded_start,
+                            padded_end
+                        ))
                         .await;
-                    results.push(result);
                 }
-
-                for (i, result) in results.iter().enumerate() {
-                    if let Ok(result) = result {
-                        full_result.subtitle_id = result.subtitle_id.clone();
-                        full_result.concat(result, 30 * i as u64);
+                // Trim the original video to get this segment's audio
+                match extract_audio_segment(file, padded_start, duration, &segment_path).await {
+                    Ok(()) => {
+                        let result = generator
+                            .generate_subtitle(reporter, &segment_path, language_hint)
+                            .await;
+                        results.push(((padded_start * 1000.0).round() as u64, result));
+                    }
+                    Err(e) => {
+                        log::error!("Failed to extract segment {}: {e}", i);
+                        continue;
                     }
                 }
-
-                // delete chunk directory
-                let _ = tokio::fs::remove_dir_all(chunk_dir).await;
-
-                Ok(full_result)
-            } else {
-                Err("Failed to initialize Whisper model".to_string())
             }
+
+            // Clean up temp files
+            let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+            let _ = tokio::fs::remove_file(&full_wav).await;
+
+            // Stitch results with time offsets
+            let mut full_result = GenerateResult {
+                subtitle_id: String::new(),
+                subtitle_content: vec![],
+                generator_type: SubtitleGeneratorType::Whisper,
+            };
+
+            for (offset_ms, result) in &results {
+                if let Ok(result) = result {
+                    full_result.subtitle_id = result.subtitle_id.clone();
+                    full_result.concat_with_offset_ms(result, *offset_ms);
+                }
+            }
+
+            Ok(full_result)
         }
         "whisper_online" => {
             if openai_api_key.is_empty() {

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -379,14 +379,15 @@ pub async fn extract_full_audio(file: &Path) -> Result<PathBuf, String> {
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
     let child = ffmpeg_process
-        .args(["-i", file.to_str().unwrap()])
+        .arg("-i")
+        .arg(file)
         .args(["-ar", "16000"])
         .args(["-ac", "1"]) // mono for VAD
         .args(["-c:a", "pcm_s16le"])
         .args(["-vn"])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
-        .args([output_path.to_str().unwrap()])
+        .arg(&output_path)
         .stderr(Stdio::piped())
         .spawn();
 
@@ -432,14 +433,15 @@ pub async fn extract_audio_segment(
 
     let child = ffmpeg_process
         .args(["-ss", &start_sec.to_string()])
-        .args(["-i", file.to_str().unwrap()])
+        .arg("-i")
+        .arg(file)
         .args(["-t", &duration_sec.to_string()])
         .args(["-ar", "16000"])
         .args(["-c:a", "pcm_s16le"])
         .args(["-vn"])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
-        .args([output_path.to_str().unwrap()])
+        .arg(output_path)
         .stderr(Stdio::piped())
         .spawn();
 
@@ -791,7 +793,10 @@ pub async fn generate_video_subtitle(
             let audio = hound::WavReader::open(&full_wav).map_err(|e| e.to_string())?;
             let spec = audio.spec();
             let sample_rate = spec.sample_rate;
-            let raw_samples: Vec<i16> = audio.into_samples::<i16>().map(|x| x.unwrap()).collect();
+            let raw_samples: Vec<i16> = audio
+                .into_samples::<i16>()
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Failed to decode WAV samples: {e}"))?;
             let mut f32_samples = vec![0.0f32; raw_samples.len()];
             whisper_cpp_rs::convert_integer_to_float_audio(&raw_samples, &mut f32_samples)
                 .map_err(|e| format!("Audio conversion error: {e}"))?;
@@ -800,7 +805,8 @@ pub async fn generate_video_subtitle(
             if let Some(reporter) = reporter {
                 reporter.update("检测语音片段中").await;
             }
-            let speech_segments = crate::audio_utils::energy_vad(&f32_samples, sample_rate);
+            let (speech_segments, energies, frame_sec) =
+                crate::audio_utils::energy_vad_with_energies(&f32_samples, sample_rate);
             log::info!(
                 "VAD detected {} speech segments from {:.1}s audio",
                 speech_segments.len(),
@@ -808,25 +814,7 @@ pub async fn generate_video_subtitle(
             );
 
             // Cut & Merge: normalize to ≤30s chunks
-            let frame_sec = 0.01; // 10ms hop from energy_vad
             let max_chunk = 30.0;
-            // Compute energies for cut_and_merge
-            let frame_len = ((sample_rate as f64 * 0.025) as usize).max(1);
-            let frame_step = ((sample_rate as f64 * 0.010) as usize).max(1);
-            let energies: Vec<f64> = {
-                let mut e = Vec::new();
-                let mut pos = 0;
-                while pos + frame_len <= f32_samples.len() {
-                    let sum_sq: f64 = f32_samples[pos..pos + frame_len]
-                        .iter()
-                        .map(|&s| (s as f64) * (s as f64))
-                        .sum();
-                    let rms = (sum_sq / frame_len as f64).sqrt();
-                    e.push(rms);
-                    pos += frame_step;
-                }
-                e
-            };
             let chunks = crate::audio_utils::cut_and_merge(
                 &speech_segments,
                 &energies,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod audio_utils;
 mod config;
 mod constants;
 mod danmu2ass;

--- a/src-tauri/src/subtitle_generator/mod.rs
+++ b/src-tauri/src/subtitle_generator/mod.rs
@@ -25,42 +25,43 @@ pub struct GenerateResult {
 
 impl GenerateResult {
     pub fn concat(&mut self, other: &GenerateResult, offset_seconds: u64) {
+        self.concat_with_offset_ms(other, offset_seconds * 1000);
+    }
+
+    pub fn concat_with_offset_ms(&mut self, other: &GenerateResult, offset_ms: u64) {
         let mut to_extend = other.subtitle_content.clone();
         let last_item_index = self.subtitle_content.len();
         for (i, item) in to_extend.iter_mut().enumerate() {
             item.pos = last_item_index + i + 1;
-            item.start_time = add_offset(&item.start_time, offset_seconds);
-            item.end_time = add_offset(&item.end_time, offset_seconds);
+            item.start_time = add_offset_ms(&item.start_time, offset_ms);
+            item.end_time = add_offset_ms(&item.end_time, offset_ms);
         }
         self.subtitle_content.extend(to_extend);
     }
 }
 
-fn add_offset(item: &srtparse::Time, offset: u64) -> srtparse::Time {
-    let mut total_seconds = item.seconds + offset;
-    let mut total_minutes = item.minutes;
-    let mut total_hours = item.hours;
-
-    // Handle seconds overflow (>= 60)
-    if total_seconds >= 60 {
-        let additional_minutes = total_seconds / 60;
-        total_seconds %= 60;
-        total_minutes += additional_minutes;
-    }
-
-    // Handle minutes overflow (>= 60)
-    if total_minutes >= 60 {
-        let additional_hours = total_minutes / 60;
-        total_minutes %= 60;
-        total_hours += additional_hours;
-    }
+fn add_offset_ms(item: &srtparse::Time, offset_ms: u64) -> srtparse::Time {
+    let total_ms = (((item.hours * 60 + item.minutes) * 60 + item.seconds) * 1000)
+        + item.milliseconds
+        + offset_ms;
+    let total_seconds = total_ms / 1000;
+    let milliseconds = total_ms % 1000;
+    let total_minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    let hours = total_minutes / 60;
+    let minutes = total_minutes % 60;
 
     srtparse::Time {
-        hours: total_hours,
-        minutes: total_minutes,
-        seconds: total_seconds,
-        milliseconds: item.milliseconds,
+        hours,
+        minutes,
+        seconds,
+        milliseconds,
     }
+}
+
+#[cfg(test)]
+fn add_offset(item: &srtparse::Time, offset_seconds: u64) -> srtparse::Time {
+    add_offset_ms(item, offset_seconds * 1000)
 }
 
 pub fn item_to_srt(item: &srtparse::Item) -> String {
@@ -363,5 +364,40 @@ mod tests {
         assert_eq!(result1.subtitle_content[0].pos, 1);
         assert_eq!(result1.subtitle_content[0].start_time.minutes, 1);
         assert_eq!(result1.subtitle_content[0].start_time.seconds, 5);
+    }
+
+    #[test]
+    fn test_generate_result_concat_with_ms_offset() {
+        let mut result1 = GenerateResult {
+            generator_type: SubtitleGeneratorType::Whisper,
+            subtitle_id: "1".to_string(),
+            subtitle_content: vec![],
+        };
+        let result2 = GenerateResult {
+            generator_type: SubtitleGeneratorType::Whisper,
+            subtitle_id: "2".to_string(),
+            subtitle_content: vec![srtparse::Item {
+                pos: 1,
+                start_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 0,
+                    milliseconds: 250,
+                },
+                end_time: srtparse::Time {
+                    hours: 0,
+                    minutes: 0,
+                    seconds: 1,
+                    milliseconds: 750,
+                },
+                text: "Only".to_string(),
+            }],
+        };
+
+        result1.concat_with_offset_ms(&result2, 12_340);
+        assert_eq!(result1.subtitle_content[0].start_time.seconds, 12);
+        assert_eq!(result1.subtitle_content[0].start_time.milliseconds, 590);
+        assert_eq!(result1.subtitle_content[0].end_time.seconds, 14);
+        assert_eq!(result1.subtitle_content[0].end_time.milliseconds, 90);
     }
 }

--- a/src-tauri/src/subtitle_generator/whisper_cpp.rs
+++ b/src-tauri/src/subtitle_generator/whisper_cpp.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use async_std::sync::{Arc, RwLock};
 use std::path::Path;
-use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+use whisper_cpp_rs::{FullParams, SamplingStrategy, WhisperContext};
 
 use super::SubtitleGenerator;
 
@@ -17,11 +17,7 @@ pub struct WhisperCPP {
 }
 
 pub async fn new(model: &Path, prompt: &str) -> Result<WhisperCPP, String> {
-    let ctx = WhisperContext::new_with_params(
-        model.to_str().unwrap(),
-        WhisperContextParameters::default(),
-    )
-    .map_err(|e| {
+    let ctx = WhisperContext::new(model.to_str().unwrap()).map_err(|e| {
         log::error!("Create whisper context failed: {e}");
         e.to_string()
     })?;
@@ -64,58 +60,66 @@ impl SubtitleGenerator for WhisperCPP {
         params.set_print_realtime(false);
         params.set_print_timestamps(false);
 
-        params.set_progress_callback_safe(move |p| {
-            log::info!("Progress: {p}%");
-        });
+        // NOTE: token_timestamps is not compatible with GGML format
+        // models — the token data contains garbage timestamps that
+        // produce invalid SRT output.  Use max_len instead for finer
+        // segmentation (whisper splits at word boundaries internally).
+        // params.set_token_timestamps(true);
+        params.set_max_len(15);
 
         let mut inter_samples = vec![Default::default(); samples.len()];
 
         if let Some(reporter) = reporter {
             reporter.update("处理音频中").await;
         }
-        if let Err(e) = whisper_rs::convert_integer_to_float_audio(&samples, &mut inter_samples) {
+        if let Err(e) = whisper_cpp_rs::convert_integer_to_float_audio(&samples, &mut inter_samples)
+        {
             return Err(e.to_string());
         }
 
         let mut samples = vec![Default::default(); samples.len() / 2];
-        if let Err(e) = whisper_rs::convert_stereo_to_mono_audio(&inter_samples, &mut samples) {
+        if let Err(e) = whisper_cpp_rs::convert_stereo_to_mono_audio(&inter_samples, &mut samples) {
             return Err(e.to_string());
         }
 
         if let Some(reporter) = reporter {
             reporter.update("生成字幕中").await;
         }
-        if let Err(e) = state.full(params, &samples[..]) {
+        if let Err(e) = state.full(&*self.ctx.read().await, &params, &samples[..]) {
             log::error!("failed to run model: {e}");
             return Err(e.to_string());
         }
 
-        // fetch the results
+        // Fetch results using whisper's built-in segment-level timestamps.
+        // With max_len=15, whisper internally splits at word boundaries,
+        // producing more segments with tighter timestamps.
         let num_segments = state.full_n_segments();
         let mut subtitle = String::new();
-        for i in 0..num_segments {
-            let segment = state
-                .get_segment(i)
-                .ok_or(format!("Failed to get segment {i}"))?;
-            let start_timestamp = segment.start_timestamp();
-            let end_timestamp = segment.end_timestamp();
 
-            let format_time = |timestamp: f64| {
-                let hours = (timestamp / 3600.0).floor();
-                let minutes = ((timestamp - hours * 3600.0) / 60.0).floor();
-                let seconds = (timestamp - hours * 3600.0 - minutes * 60.0).floor();
-                let milliseconds = ((timestamp - hours * 3600.0 - minutes * 60.0 - seconds)
-                    * 1000.0)
-                    .floor() as u32;
-                format!("{hours:02}:{minutes:02}:{seconds:02},{milliseconds:03}")
-            };
+        let format_time = |timestamp: f64| {
+            let hours = (timestamp / 3600.0).floor();
+            let minutes = ((timestamp - hours * 3600.0) / 60.0).floor();
+            let seconds = (timestamp - hours * 3600.0 - minutes * 60.0).floor();
+            let milliseconds =
+                ((timestamp - hours * 3600.0 - minutes * 60.0 - seconds) * 1000.0).floor() as u32;
+            format!("{hours:02}:{minutes:02}:{seconds:02},{milliseconds:03}")
+        };
+
+        for i in 0..num_segments {
+            let segment_text = state.get_segment_text(i).unwrap_or_default();
+            if segment_text.trim().is_empty() {
+                continue;
+            }
+
+            let start_timestamp = state.get_segment_t0(i);
+            let end_timestamp = state.get_segment_t1(i);
 
             let line = format!(
                 "{}\n{} --> {}\n{}\n\n",
                 i + 1,
                 format_time(start_timestamp as f64 / 100.0),
                 format_time(end_timestamp as f64 / 100.0),
-                segment.to_str().unwrap_or_default(),
+                segment_text.trim(),
             );
 
             subtitle.push_str(&line);
@@ -137,57 +141,161 @@ impl SubtitleGenerator for WhisperCPP {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::progress::progress_reporter::ProgressReporterTrait;
 
-    // create a mock for the ProgressReporterTrait
     #[derive(Clone)]
-    struct MockReporter {}
-    impl MockReporter {
-        #[allow(dead_code)]
-        async fn update(&self, _message: &str) {
-            // mock implementation
+    struct TestReporter;
+    #[async_trait]
+    impl ProgressReporterTrait for TestReporter {
+        async fn update(&self, msg: &str) {
+            println!("  [{msg}]");
+        }
+        async fn finish(&self, success: bool, msg: &str) {
+            println!("  finish({success}): {msg}");
         }
     }
 
-    #[async_trait]
-    impl ProgressReporterTrait for MockReporter {
-        async fn update(&self, message: &str) {
-            println!("Mock update: {message}");
-        }
+    /// Run whisper on test audio and validate output.
+    async fn run_whisper_test(max_len: i32) -> Vec<srtparse::Item> {
+        let model_path = Path::new("tests/model/ggml-tiny-q5_1.bin");
+        let audio_path = Path::new("tests/audio/test.wav");
+        assert!(model_path.exists(), "Model not found");
+        assert!(audio_path.exists(), "Test audio not found");
 
-        async fn finish(&self, success: bool, message: &str) {
-            if success {
-                println!("Mock finish: {message}");
+        // Build params manually to control max_len
+        let whisper = new(model_path, "").await.expect("Failed to create whisper");
+        let audio = hound::WavReader::open(audio_path).unwrap();
+        let audio_samples: Vec<i16> = audio.into_samples::<i16>().map(|x| x.unwrap()).collect();
+        let mut state = whisper
+            .ctx
+            .read()
+            .await
+            .create_state()
+            .expect("Failed to create state");
+
+        let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+        params.set_language(Some("auto"));
+        params.set_print_special(false);
+        params.set_print_progress(false);
+        params.set_print_realtime(false);
+        params.set_print_timestamps(false);
+        params.set_max_len(max_len);
+
+        let mut inter = vec![0.0f32; audio_samples.len()];
+        whisper_cpp_rs::convert_integer_to_float_audio(&audio_samples, &mut inter).unwrap();
+        let mut mono = vec![0.0f32; audio_samples.len() / 2];
+        whisper_cpp_rs::convert_stereo_to_mono_audio(&inter, &mut mono).unwrap();
+        state
+            .full(&*whisper.ctx.read().await, &params, &mono)
+            .unwrap();
+
+        let num_segments = state.full_n_segments();
+        let mut subtitle = String::new();
+        let format_time = |ts: f64| {
+            let h = (ts / 3600.0).floor();
+            let m = ((ts - h * 3600.0) / 60.0).floor();
+            let s = (ts - h * 3600.0 - m * 60.0).floor();
+            let ms = ((ts - h * 3600.0 - m * 60.0 - s) * 1000.0).floor() as u32;
+            format!("{h:02}:{m:02}:{s:02},{ms:03}")
+        };
+        for i in 0..num_segments {
+            let text = state.get_segment_text(i).unwrap_or_default();
+            if text.trim().is_empty() {
+                continue;
+            }
+            let t0 = state.get_segment_t0(i);
+            let t1 = state.get_segment_t1(i);
+            subtitle.push_str(&format!(
+                "{}\n{} --> {}\n{}\n\n",
+                i + 1,
+                format_time(t0 as f64 / 100.0),
+                format_time(t1 as f64 / 100.0),
+                text.trim()
+            ));
+        }
+        srtparse::from_str(&subtitle).unwrap()
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires whisper model and test audio"]
+    async fn test_parameter_sweep() {
+        for max_len in [0, 5, 10, 15, 30] {
+            let items = run_whisper_test(max_len).await;
+            let avg_dur = if items.is_empty() {
+                0.0
             } else {
-                println!("Mock error: {message}");
+                let total: u64 = items
+                    .iter()
+                    .map(|i| {
+                        (i.end_time.hours * 3600 + i.end_time.minutes * 60 + i.end_time.seconds)
+                            - (i.start_time.hours * 3600
+                                + i.start_time.minutes * 60
+                                + i.start_time.seconds)
+                    })
+                    .sum();
+                total as f64 / items.len() as f64
+            };
+            println!(
+                "max_len={:>3}: {:>3} items, avg {:>5.1}s/item, first='{}'",
+                max_len,
+                items.len(),
+                avg_dur,
+                items.first().map(|i| i.text.as_str()).unwrap_or("")
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "Requires whisper model and test audio"]
+    async fn test_generate_subtitle_with_real_audio() {
+        let items = run_whisper_test(15).await;
+        println!("Generated {} subtitle items", items.len());
+        assert!(!items.is_empty(), "Subtitle content must not be empty");
+
+        for item in &items {
+            assert!(
+                !item.text.trim().is_empty(),
+                "Item {} has empty text",
+                item.pos
+            );
+
+            let st = item.start_time.hours * 3600
+                + item.start_time.minutes * 60
+                + item.start_time.seconds;
+            let et =
+                item.end_time.hours * 3600 + item.end_time.minutes * 60 + item.end_time.seconds;
+            assert!(
+                et > st || (et == st && item.end_time.milliseconds > item.start_time.milliseconds),
+                "Item {} end <= start",
+                item.pos
+            );
+            assert!(
+                !item.text.contains("[_"),
+                "Item {} has special token",
+                item.pos
+            );
+            assert!(
+                !item.text.contains("<|"),
+                "Item {} has special token",
+                item.pos
+            );
+
+            if item.pos <= 8 {
+                println!(
+                    "  #{}: {:02}:{:02}:{:02},{:03} --> {:02}:{:02}:{:02},{:03} |{}|",
+                    item.pos,
+                    item.start_time.hours,
+                    item.start_time.minutes,
+                    item.start_time.seconds,
+                    item.start_time.milliseconds,
+                    item.end_time.hours,
+                    item.end_time.minutes,
+                    item.end_time.seconds,
+                    item.end_time.milliseconds,
+                    item.text
+                );
             }
         }
-    }
-    impl MockReporter {
-        fn new() -> Self {
-            MockReporter {}
-        }
-    }
-
-    #[tokio::test]
-    async fn create_whisper_cpp() {
-        let result = new(Path::new("tests/model/ggml-tiny-q5_1.bin"), "").await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    #[ignore = "Might not have enough memory to run this test"]
-    async fn generate_subtitle() {
-        let whisper = new(Path::new("tests/model/ggml-tiny-q5_1.bin"), "")
-            .await
-            .unwrap();
-        let audio_path = Path::new("tests/audio/test.wav");
-        let reporter = MockReporter::new();
-        let result = whisper
-            .generate_subtitle(Some(&reporter), audio_path, "auto")
-            .await;
-        if let Err(e) = result {
-            println!("Error: {e}");
-            panic!("Failed to generate subtitle");
-        }
+        println!("All validations passed.");
     }
 }

--- a/src-tauri/src/subtitle_generator/whisper_cpp.rs
+++ b/src-tauri/src/subtitle_generator/whisper_cpp.rs
@@ -17,7 +17,8 @@ pub struct WhisperCPP {
 }
 
 pub async fn new(model: &Path, prompt: &str) -> Result<WhisperCPP, String> {
-    let ctx = WhisperContext::new(model.to_str().unwrap()).map_err(|e| {
+    let model_path = model.to_string_lossy();
+    let ctx = WhisperContext::new(&model_path).map_err(|e| {
         log::error!("Create whisper context failed: {e}");
         e.to_string()
     })?;
@@ -39,7 +40,10 @@ impl SubtitleGenerator for WhisperCPP {
         log::info!("Generating subtitle for {:?}", audio_path);
         let start_time = std::time::Instant::now();
         let audio = hound::WavReader::open(audio_path).map_err(|e| e.to_string())?;
-        let samples: Vec<i16> = audio.into_samples::<i16>().map(|x| x.unwrap()).collect();
+        let samples: Vec<i16> = audio
+            .into_samples::<i16>()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Failed to decode WAV samples: {e}"))?;
 
         let state = self.ctx.read().await.create_state();
         if let Err(e) = state {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,4 +1,9 @@
 {
+  "bundle": {
+    "macOS": {
+      "minimumSystemVersion": "15.0"
+    }
+  },
   "app": {
     "windows": [
       {

--- a/src-tauri/tauri.windows.cuda.conf.json
+++ b/src-tauri/tauri.windows.cuda.conf.json
@@ -1,5 +1,5 @@
 {
-  "productName": "bili-shadowreplay",
+  "productName": "bili-shadowreplay-cuda",
   "app": {
     "windows": [
       {

--- a/src/page/Setting.svelte
+++ b/src/page/Setting.svelte
@@ -38,6 +38,8 @@
     },
     status_check_interval: 30, // 默认30秒
     whisper_language: "",
+
+
     webhook_url: "",
     danmu_ass_options: {
       font_size: 36,
@@ -114,26 +116,6 @@
     }
   }
 
-  async function handleWhisperModelPathChange() {
-    const selected = await open({
-      multiple: false,
-      filters: [
-        {
-          name: "Whisper Model",
-          extensions: ["bin"],
-        },
-      ],
-    });
-    if (selected) {
-      setting_model.whisper_model = Array.isArray(selected)
-        ? selected[0]
-        : selected;
-      await invoke("update_whisper_model", {
-        whisperModel: setting_model.whisper_model,
-      });
-    }
-  }
-
   async function update_subtitle_setting() {
     await invoke("update_subtitle_setting", {
       autoSubtitle: setting_model.auto_subtitle,
@@ -153,6 +135,17 @@
     await invoke("update_webhook_url", {
       webhookUrl: setting_model.webhook_url,
     });
+  }
+
+  async function handleWhisperModelPathChange() {
+    const selected = await open({
+      multiple: false,
+      filters: [{ name: "Whisper Model", extensions: ["bin"] }],
+    });
+    if (selected) {
+      setting_model.whisper_model = Array.isArray(selected) ? selected[0] : selected;
+      await invoke("update_whisper_model", { whisperModel: setting_model.whisper_model });
+    }
   }
 
   async function update_danmu_ass_options() {
@@ -581,29 +574,13 @@
                   <div class="p-4">
                     <div class="flex items-center justify-between">
                       <div>
-                        <h3
-                          class="text-sm font-medium text-gray-900 dark:text-white"
-                        >
-                          Whisper 模型路径
-                        </h3>
+                        <h3 class="text-sm font-medium text-gray-900 dark:text-white">Whisper 模型路径</h3>
                         <p class="text-sm text-gray-500 dark:text-gray-400">
                           {setting_model.whisper_model || "未设置"}
-                          <span class="block mt-1 text-xs"
-                            >可前往 <a
-                              href="https://huggingface.co/ggerganov/whisper.cpp/tree/main"
-                              class="text-blue-500 hover:underline"
-                              target="_blank"
-                              rel="noopener noreferrer">ggerganov/whisper.cpp</a
-                            > 下载模型文件</span
-                          >
+                          <span class="block mt-1 text-xs">可前往 <a href="https://huggingface.co/ggerganov/whisper.cpp/tree/main" class="text-blue-500 hover:underline" target="_blank" rel="noopener noreferrer">ggerganov/whisper.cpp</a> 下载模型文件</span>
                         </p>
                       </div>
-                      <button
-                        class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                        on:click={handleWhisperModelPathChange}
-                      >
-                        变更
-                      </button>
+                      <button class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors" on:click={handleWhisperModelPathChange}>变更</button>
                     </div>
                   </div>
                 {/if}
@@ -665,6 +642,34 @@
                     </div>
                   </div>
                 {/if}
+                {#if setting_model.subtitle_generator_type !== "powerlive"}
+                  <div class="p-4">
+                    <div class="flex items-center justify-between">
+                      <div>
+                        <h3
+                          class="text-sm font-medium text-gray-900 dark:text-white"
+                        >
+                          Whisper 提示词
+                        </h3>
+                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                          生成字幕时使用的提示词，尽量简洁明了，提示音频内容偏向的领域以及字幕的风格
+                        </p>
+                      </div>
+                      <div class="flex items-center space-x-2">
+                        <input
+                          type="text"
+                          class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
+                          bind:value={setting_model.whisper_prompt}
+                          on:change={async () => {
+                            await invoke("update_whisper_prompt", {
+                              whisperPrompt: setting_model.whisper_prompt,
+                            });
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                {/if}
                 <!-- Whisper Language -->
                 <div class="p-4">
                   <div class="flex items-center justify-between">
@@ -675,7 +680,7 @@
                         Whisper 语言
                       </h3>
                       <p class="text-sm text-gray-500 dark:text-gray-400">
-                        （测试）生成字幕时使用的语言，默认自动识别
+                        生成字幕时使用的语言，默认自动识别
                       </p>
                     </div>
                     <div class="flex items-center space-x-2">
@@ -686,32 +691,6 @@
                         on:change={async () => {
                           await invoke("update_whisper_language", {
                             whisperLanguage: setting_model.whisper_language,
-                          });
-                        }}
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div class="p-4">
-                  <div class="flex items-center justify-between">
-                    <div>
-                      <h3
-                        class="text-sm font-medium text-gray-900 dark:text-white"
-                      >
-                        Whisper 提示词
-                      </h3>
-                      <p class="text-sm text-gray-500 dark:text-gray-400">
-                        生成字幕时使用的提示词，尽量简洁明了，提示音频内容偏向的领域以及字幕的风格
-                      </p>
-                    </div>
-                    <div class="flex items-center space-x-2">
-                      <input
-                        type="text"
-                        class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
-                        bind:value={setting_model.whisper_prompt}
-                        on:change={async () => {
-                          await invoke("update_whisper_prompt", {
-                            whisperPrompt: setting_model.whisper_prompt,
                           });
                         }}
                       />


### PR DESCRIPTION
## Summary
- add the vendored whisper-cpp-rs backend with a C++ shim for safe whisper_full_params updates
- fix local whisper subtitle timing and VAD segmentation behavior, including millisecond offsets and less aggressive speech filtering
- wire Windows CPU/CUDA packaging details and point the whisper.cpp submodule at the maintained fork containing the configure-time source mutation fix

## Validation
- cargo build --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml subtitle_generator::tests:: -- --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml subtitle_generator::whisper_cpp::tests::test_generate_subtitle_with_real_audio -- --ignored --exact --nocapture
- cargo test --manifest-path src-tauri/Cargo.toml subtitle_generator::whisper_cpp::tests::test_parameter_sweep -- --ignored --exact --nocapture

## Summary by Sourcery

Introduce a vendored whisper.cpp-based backend with safe Rust bindings, integrate it into local subtitle generation with improved VAD-based audio segmentation and millisecond-accurate subtitle stitching, and update configuration, tests, and docs accordingly.

New Features:
- Add a vendored whisper-cpp-rs crate with a C++ shim and Rust API for whisper.cpp, including CUDA/Metal support.
- Provide new audio utilities for energy-based VAD and cut-and-merge segmentation of long-form audio.
- Extend settings UI to allow configuring a Whisper prompt and simplify Whisper model path selection.

Bug Fixes:
- Correct local Whisper subtitle timing by using millisecond-level offsets when concatenating subtitle segments.
- Reduce over-aggressive speech filtering by tuning VAD thresholds and smoothing logic.

Enhancements:
- Refactor local subtitle generation to operate on VAD-detected segments from a single full-audio extract instead of fixed chunks.
- Improve whisper.cpp subtitle segmentation by using segment-level timestamps and max_len-based splitting rather than token timestamps.
- Strengthen unit test coverage for subtitle concatenation offsets and whisper.cpp behavior.

Build:
- Add a new whisper-cpp-rs workspace member and wire CUDA feature flags to it.
- Enable workspace-wide Clippy lint configuration and clean up per-package lint settings.

Documentation:
- Rewrite local Whisper configuration docs to describe sherpa-onnx-based models, automatic downloads, and hardware acceleration options.
- Add internal design and migration documents for moving from whisper-rs to sherpa-onnx-based Whisper backends.

Tests:
- Add tests for audio VAD/cut-and-merge utilities and millisecond-offset subtitle concatenation.
- Introduce whisper_cpp integration tests for real-audio subtitle generation and parameter sweeps (marked ignored by default).