### PR TITLE
feat: migrate AI agent to Rust Rig

### DIFF
--- a/docs/development/architecture/overview.md
+++ b/docs/development/architecture/overview.md
@@ -9,7 +9,7 @@ BiliBili ShadowReplay 是一个基于 Tauri 2 的混合桌面应用，采用前�
 - **框架**: Svelte 3 + TypeScript
 - **构建工具**: Vite
 - **UI 框架**: Tailwind CSS + Flowbite
-- **AI 集成**: LangChain (@langchain/core, @langchain/deepseek, @langchain/ollama)
+- **AI 集成**: Rust Rig Agent（OpenAI 兼容 API、Ollama）
 - **音频可视化**: WaveSurfer.js
 - **实时通信**: Socket.io
 
@@ -144,7 +144,7 @@ src-tauri/
 
 - **Stores**: 使用 Svelte 的响应式存储管理全局状态
 - **Invoker**: 封装 Tauri 命令调用，提供类型安全的前后端通信
-- **Agent**: 基于 LangChain 的 AI 助手，支持内容分析和总结
+- **Agent**: 基于 Rig 的 Rust AI 助手，支持内容分析和工具确认
 - **Components**: 可复用的 UI 组件库
 
 ### 后端核心模块
@@ -243,11 +243,11 @@ sequenceDiagram
   - macOS: 默认启用 Metal 加速
   - Linux: CPU 推理
 
-### LangChain 集成
+### AI Agent 集成
 
-- AI 助手用于内容分析和总结
-- 支持多个 LLM 提供商 (DeepSeek, Ollama)
-- 位于 `src/lib/agent/` 目录
+- Rust Rig Agent 用于内容分析、数据查询和 BSR 工具编排
+- 支持 OpenAI 兼容 API 和 Ollama
+- Agent 位于 `src-tauri/src/agent/`，前端消息与确认执行器位于 `src/lib/agent/`
 
 ## 构建配置
 

--- a/docs/development/frontend/agent.md
+++ b/docs/development/frontend/agent.md
@@ -2,445 +2,114 @@
 
 ## 概述
 
-BiliBili ShadowReplay 集成了基于 LangChain 的 AI Agent，用于内容分析、总结和智能辅助。Agent 实现位于 `src/lib/agent/` 目录。
+BiliBili ShadowReplay 使用基于 [Rig](https://github.com/0xPlaygrounds/rig) 的 Rust AI Agent，用于查询和分析 Recorder、Archive、Video、字幕与弹幕数据。
 
-## 技术栈
-
-- **LangChain Core** (@langchain/core): 核心框架
-- **LangChain DeepSeek** (@langchain/deepseek): DeepSeek LLM 集成
-- **LangChain Ollama** (@langchain/ollama): Ollama 本地模型支持
+Agent 主体位于 `src-tauri/src/agent/`。前端的 `src/lib/agent/agent.ts` 负责发送消息；只读工具由 Rust 执行，需要确认的工具则由前端在用户明确同意后调用现有 Tauri 工具实现。
 
 ## 架构
 
 ```mermaid
 graph LR
-    UI[用户界面] --> Agent[AI Agent]
-    Agent --> LangChain[LangChain Core]
-    LangChain --> DeepSeek[DeepSeek API]
-    LangChain --> Ollama[Ollama 本地]
-    Agent --> Tools[工具集]
-    Tools --> Invoker[Tauri Invoker]
-    Invoker --> Backend[Rust 后端]
+    UI[AI 页面] --> Command[agent_chat]
+    Command --> Agent[Rust Rig Agent]
+    Agent --> LLM[OpenAI 兼容 API / Ollama]
+    Agent --> Tool[BsrTool]
+    Tool --> Backend[Database / RecorderManager]
 ```
 
-## 主要功能
+每次请求会携带前端当前保存的完整对话记录。用户、助手和工具消息会转换为 Rig 的真实角色消息，而不是拼接成单个文本提示。Rust Agent 在单次 command 内完成模型调用和只读工具循环，并将最终文本、工具调用轨迹及错误状态一起返回。
 
-### 1. 内容分析
+## 模型配置
 
-分析直播录播内容，提取关键信息：
+UI 支持以下 Provider：
 
-```typescript
-import { analyzeContent } from '$lib/agent';
+- `openai`：使用 OpenAI Chat Completions 兼容接口，需要 endpoint、API Key 和模型名。
+- `ollama`：使用 Ollama 接口；endpoint 为空时默认使用 `http://localhost:11434`。
 
-const analysis = await analyzeContent({
-  recordingId: 'xxx',
-  transcript: '直播文字记录...',
-});
+API Key 只随当前 `agent_chat` 请求传入 Rust 端，不写入后端数据库或工具结果。现有 UI 会在浏览器本地设置中保存模型配置，因此不要在共享设备上保存敏感密钥。
 
-// 返回结果
-{
-  summary: '直播内容总结',
-  highlights: ['精彩片段1', '精彩片段2'],
-  tags: ['游戏', '娱乐'],
-  suggestedTitle: '建议的标题'
-}
-```
-
-### 2. 智能切片建议
-
-基于内容分析，建议切片时间点：
+前端准备模型配置：
 
 ```typescript
-import { suggestClips } from '$lib/agent';
+import { agentChat, type AgentConfig } from '$lib/agent/agent';
 
-const suggestions = await suggestClips({
-  recordingId: 'xxx',
-  transcript: '...',
-  danmaku: [...], // 弹幕数据
-});
-
-// 返回建议的切片区间
-[
-  { start: 120, end: 300, reason: '精彩操作' },
-  { start: 1200, end: 1500, reason: '搞笑片段' }
-]
-```
-
-### 3. 标题和描述生成
-
-为切片生成标题和描述：
-
-```typescript
-import { generateMetadata } from '$lib/agent';
-
-const metadata = await generateMetadata({
-  clipContent: '切片内容描述',
-  context: '直播背景信息',
-});
-
-// 返回
-{
-  title: '生成的标题',
-  description: '生成的描述',
-  tags: ['标签1', '标签2']
-}
-```
-
-## LLM 配置
-
-### DeepSeek 配置
-
-```typescript
-import { ChatDeepSeek } from '@langchain/deepseek';
-
-const model = new ChatDeepSeek({
+const config: AgentConfig = {
+  provider: 'openai',
+  baseURL: 'https://api.example.com/v1',
   apiKey: 'your-api-key',
-  model: 'deepseek-chat',
-  temperature: 0.7,
-});
+  model: 'model-name',
+};
 ```
 
-### Ollama 本地模型
+## 请求流程
+
+前端直接传入完整消息列表：
 
 ```typescript
-import { Ollama } from '@langchain/ollama';
-
-const model = new Ollama({
-  baseUrl: 'http://localhost:11434',
-  model: 'llama2',
-});
+const response = await agentChat(config, messages);
+// response.content: 最终回答或错误信息
+// response.toolCalls: 已执行的只读调用，以及等待用户确认的调用
 ```
 
-## Agent 实现
-
-### 基础 Agent 结构
+`agentChat` 最终调用的 Tauri command 请求结构为：
 
 ```typescript
-import { ChatPromptTemplate } from '@langchain/core/prompts';
-import { RunnableSequence } from '@langchain/core/runnables';
-
-// 创建提示模板
-const prompt = ChatPromptTemplate.fromMessages([
-  ['system', '你是一个直播内容分析助手...'],
-  ['human', '{input}'],
-]);
-
-// 创建处理链
-const chain = RunnableSequence.from([
-  prompt,
-  model,
-  outputParser,
-]);
-
-// 执行
-const result = await chain.invoke({
-  input: '分析这段直播内容...'
-});
-```
-
-### 带工具的 Agent
-
-```typescript
-import { DynamicStructuredTool } from '@langchain/core/tools';
-import { AgentExecutor, createOpenAIFunctionsAgent } from 'langchain/agents';
-
-// 定义工具
-const tools = [
-  new DynamicStructuredTool({
-    name: 'get_recording_info',
-    description: '获取录播信息',
-    schema: z.object({
-      recordingId: z.string(),
-    }),
-    func: async ({ recordingId }) => {
-      const info = await invoke('get_recording', { recordingId });
-      return JSON.stringify(info);
-    },
-  }),
-  new DynamicStructuredTool({
-    name: 'get_danmaku',
-    description: '获取弹幕数据',
-    schema: z.object({
-      recordingId: z.string(),
-      startTime: z.number().optional(),
-      endTime: z.number().optional(),
-    }),
-    func: async ({ recordingId, startTime, endTime }) => {
-      const danmaku = await invoke('get_danmaku', {
-        recordingId,
-        startTime,
-        endTime,
-      });
-      return JSON.stringify(danmaku);
-    },
-  }),
-];
-
-// 创建 Agent
-const agent = await createOpenAIFunctionsAgent({
-  llm: model,
-  tools,
-  prompt,
-});
-
-// 创建执行器
-const executor = new AgentExecutor({
-  agent,
-  tools,
-});
-
-// 执行任务
-const result = await executor.invoke({
-  input: '分析录播 xxx 的内容并建议切片'
-});
-```
-
-## 提示工程
-
-### 内容分析提示
-
-```typescript
-const ANALYSIS_PROMPT = `你是一个专业的直播内容分析助手。
-
-任务：分析给定的直播录播内容，提取关键信息。
-
-输入信息：
-- 直播标题：{title}
-- 直播时长：{duration}
-- 文字记录：{transcript}
-- 弹幕数据：{danmaku}
-
-请提供：
-1. 内容总结（100字以内）
-2. 3-5个精彩片段的时间点和描述
-3. 5个相关标签
-4. 建议的切片标题
-
-输出格式：JSON
-`;
-```
-
-### 切片建议提示
-
-```typescript
-const CLIP_SUGGESTION_PROMPT = `基于直播内容分析，建议值得制作成切片的片段。
-
-考虑因素：
-1. 弹幕密度突然增加的时间段
-2. 文字记录中的关键词（如"精彩"、"哈哈"、"牛"等）
-3. 情绪高涨的片段
-4. 完整的故事或事件
-
-每个建议包括：
-- 开始时间
-- 结束时间
-- 片段描述
-- 推荐理由
-- 预估热度（1-10分）
-
-输出格式：JSON数组
-`;
-```
-
-## 流式输出
-
-对于长文本生成，使用流式输出提升用户体验：
-
-```typescript
-import { writable } from 'svelte/store';
-
-export const streamingText = writable('');
-
-async function generateWithStreaming(input: string) {
-  streamingText.set('');
-
-  const stream = await chain.stream({ input });
-
-  for await (const chunk of stream) {
-    streamingText.update(text => text + chunk.content);
-  }
+interface AgentRequest {
+  provider: 'openai' | 'ollama';
+  endpoint: string;
+  apiKey?: string;
+  model: string;
+  messages: Array<{
+    role: 'user' | 'assistant' | 'tool';
+    content: string;
+    toolCalls?: Array<{ id: string; name: string; args: object }>;
+    toolCallId?: string;
+  }>;
 }
 ```
 
-在组件中使用：
+## BSR 工具
 
-```svelte
-<script>
-  import { streamingText } from '$lib/agent';
-</script>
+Rust Agent 注册一个名为 `bsr` 的工具，通过带类型约束的 `oneOf` schema 选择具体 `action` 和参数。工具覆盖账户、录制器、录播、视频、字幕、弹幕、剪辑、转码和上传等原有能力。
 
-<div class="streaming-output">
-  {$streamingText}
-</div>
+- 账户与录制器：`get_accounts`、`get_recorder_list`、`get_recorder_info`
+- 录播：`get_archives`、`get_archive`、`get_recent_record`、`get_recent_record_all`
+- 视频与任务：`get_videos`、`get_all_videos`、`get_video`、`get_background_tasks`
+- 字幕与弹幕：`get_archive_subtitle`、`get_danmu_record`
+- 内容分析：`analyze_danmu_highlights`、`search_danmu_keywords`
+
+工具在 Rust 进程内直接访问 `Database` 和 `RecorderManager`。`get_accounts` 返回前会屏蔽 Cookie，避免凭据进入模型上下文。
+
+删除、上传、修改录制配置以及生成文件等操作不会在 Rust Agent 中自动执行。工具先返回 `confirmation_required`，前端展示工具名和完整参数；用户点击确认后，前端只执行该调用一次，追加具有匹配 `toolCallId` 的 ToolMessage，再携带完整历史继续 Agent。拒绝也会生成对应的 ToolMessage。存在未处理调用时，普通消息发送会被禁用。
+
+## 工具调用轨迹
+
+每次工具调用都会记录：
+
+```typescript
+interface ToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  executed: boolean;
+  error?: string;
+}
 ```
+
+`executed: true` 表示工具已经在 Rust 端执行，仅用于展示，浏览器不会再次调用。`executed: false` 表示等待用户确认，前端只允许通过确认按钮执行。即使 Agent 在后续模型轮次中失败，已产生的工具轨迹也会随错误响应返回。
 
 ## 错误处理
 
-```typescript
-async function safeAgentCall<T>(
-  agentFunc: () => Promise<T>,
-  fallback: T
-): Promise<T> {
-  try {
-    return await agentFunc();
-  } catch (error) {
-    console.error('Agent call failed:', error);
+配置错误或不支持的 Provider 会使 Tauri command 直接失败。模型请求失败、工具循环超出轮次等运行期错误会作为正常的 `AgentResponse` 返回，并包含：
 
-    // 检查是否是 API 限流
-    if (error.message.includes('rate limit')) {
-      throw new Error('API 调用频率过高，请稍后再试');
-    }
+- `error`：错误信息
+- `toolCalls`：失败前已经执行的工具轨迹
+- `content`：成功时的最终回答
 
-    // 检查是否是网络错误
-    if (error.message.includes('network')) {
-      throw new Error('网络连接失败，请检查网络设置');
-    }
+前端将带有 `error` 的响应渲染为错误消息，同时保留工具调用记录。
 
-    // 返回默认值
-    return fallback;
-  }
-}
-```
+## 对话历史
 
-## 性能优化
+AI 页面将消息保存到浏览器 `localStorage`，刷新页面后恢复展示。每次新请求会发送当前完整消息列表，因此模型可以继续此前对话。
 
-### 1. 缓存结果
-
-```typescript
-const analysisCache = new Map<string, any>();
-
-async function analyzeWithCache(recordingId: string) {
-  if (analysisCache.has(recordingId)) {
-    return analysisCache.get(recordingId);
-  }
-
-  const result = await analyzeContent({ recordingId });
-  analysisCache.set(recordingId, result);
-
-  return result;
-}
-```
-
-### 2. 批量处理
-
-```typescript
-async function batchAnalyze(recordingIds: string[]) {
-  // 并发处理，但限制并发数
-  const concurrency = 3;
-  const results = [];
-
-  for (let i = 0; i < recordingIds.length; i += concurrency) {
-    const batch = recordingIds.slice(i, i + concurrency);
-    const batchResults = await Promise.all(
-      batch.map(id => analyzeContent({ recordingId: id }))
-    );
-    results.push(...batchResults);
-  }
-
-  return results;
-}
-```
-
-### 3. 超时控制
-
-```typescript
-async function analyzeWithTimeout(input: any, timeout = 30000) {
-  return Promise.race([
-    analyzeContent(input),
-    new Promise((_, reject) =>
-      setTimeout(() => reject(new Error('Analysis timeout')), timeout)
-    ),
-  ]);
-}
-```
-
-## 配置管理
-
-在用户配置中管理 LLM 设置：
-
-```typescript
-interface LLMConfig {
-  provider: 'deepseek' | 'ollama';
-  apiKey?: string;
-  baseUrl?: string;
-  model: string;
-  temperature: number;
-  maxTokens: number;
-}
-
-// 从配置加载
-export async function loadLLMConfig(): Promise<LLMConfig> {
-  return await invoke('get_llm_config');
-}
-
-// 保存配置
-export async function saveLLMConfig(config: LLMConfig) {
-  await invoke('save_llm_config', { config });
-}
-```
-
-## 最佳实践
-
-1. **提示优化**: 清晰、具体的提示能获得更好的结果
-2. **错误处理**: 始终处理 API 调用可能的失败
-3. **用户反馈**: 显示加载状态和进度
-4. **成本控制**: 缓存结果，避免重复调用
-5. **隐私保护**: 不要将敏感信息发送到外部 API
-
-## 调试
-
-```typescript
-// 启用调试日志
-if (import.meta.env.DEV) {
-  // 记录所有 LLM 调用
-  const originalInvoke = chain.invoke;
-  chain.invoke = async (input) => {
-    console.log('[LLM Input]', input);
-    const result = await originalInvoke.call(chain, input);
-    console.log('[LLM Output]', result);
-    return result;
-  };
-}
-```
-
-## 示例：完整的分析流程
-
-```typescript
-import { ChatDeepSeek } from '@langchain/deepseek';
-import { ChatPromptTemplate } from '@langchain/core/prompts';
-import { invoke } from '@tauri-apps/api/core';
-
-export async function analyzeRecording(recordingId: string) {
-  // 1. 获取录播信息
-  const recording = await invoke('get_recording', { recordingId });
-
-  // 2. 获取字幕（如果有）
-  const subtitle = await invoke('get_subtitle', { recordingId });
-
-  // 3. 获取弹幕数据
-  const danmaku = await invoke('get_danmaku', { recordingId });
-
-  // 4. 准备输入
-  const input = {
-    title: recording.title,
-    duration: recording.duration,
-    transcript: subtitle?.text || '',
-    danmakuCount: danmaku.length,
-    danmakuSample: danmaku.slice(0, 100), // 采样
-  };
-
-  // 5. 调用 LLM
-  const model = new ChatDeepSeek({
-    apiKey: await invoke('get_deepseek_key'),
-    model: 'deepseek-chat',
-  });
-
-  const prompt = ChatPromptTemplate.fromTemplate(ANALYSIS_PROMPT);
-  const chain = prompt.pipe(model);
-
-  const result = await chain.invoke(input);
-
-  // 6. 解析结果
-  return JSON.parse(result.content);
-}
-```
+历史会随着对话增长并消耗更多上下文长度。若模型报告上下文过长，可通过页面的清空对话操作开始新会话。

--- a/package.json
+++ b/package.json
@@ -16,10 +16,6 @@
     "version": "node scripts/bump.cjs && git add src-tauri/Cargo.toml src-tauri/Cargo.lock"
   },
   "dependencies": {
-    "@langchain/core": "^0.3.64",
-    "@langchain/deepseek": "^0.1.0",
-    "@langchain/langgraph": "^0.3.10",
-    "@langchain/ollama": "^0.2.3",
     "@tauri-apps/api": "^2.6.2",
     "@tauri-apps/plugin-deep-link": "~2",
     "@tauri-apps/plugin-dialog": "~2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -29,7 +29,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "bytestring",
  "derive_more 2.0.1",
@@ -144,7 +144,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.1",
+ "socket2 0.6.5",
  "time",
  "tracing",
  "url",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -274,6 +274,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
 name = "ashpd"
@@ -470,7 +476,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -506,7 +512,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-lite",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "kv-log-macro",
  "log",
  "memchr",
@@ -515,6 +521,28 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -531,7 +559,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -593,6 +621,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "axum"
@@ -659,7 +710,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -740,6 +791,7 @@ dependencies = [
  "recorder",
  "regex",
  "reqwest 0.11.27",
+ "rig-core",
  "sanitize-filename",
  "scraper",
  "sentry",
@@ -763,7 +815,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-sql",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -790,7 +842,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -801,7 +853,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -827,9 +879,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -893,7 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17d4f95e880cfd28c4ca5a006cf7f6af52b4bcb7b5866f573b2faa126fb7affb"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -943,9 +995,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -974,7 +1026,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -1019,7 +1071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b4a6cae9efc04cc6cbb8faf338d2c497c165c83e74509cf4dbedea948bbf6e5"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1042,7 +1094,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1117,9 +1169,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1171,7 +1223,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1247,6 +1299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cooked-waker"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,7 +1374,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -1326,7 +1387,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1469,7 +1530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1479,7 +1540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1507,7 +1568,7 @@ dependencies = [
  "scroll_derive",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite 0.27.0",
  "tonic-build",
@@ -1537,7 +1598,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1548,7 +1609,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1624,7 +1685,7 @@ dependencies = [
  "deno_path_util",
  "deno_unsync",
  "futures",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "libc",
  "parking_lot",
  "percent-encoding",
@@ -1635,7 +1696,7 @@ dependencies = [
  "smallvec",
  "sourcemap",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "url",
  "v8",
@@ -1670,7 +1731,7 @@ checksum = "409f265785bd946d3006756955aaf40b0e4deb25752eae6a990afe54a31cfd83"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1679,15 +1740,15 @@ version = "0.231.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca530772bbcbc9ad389ad7bcd86623b2ec555f68a2d062d23cc008915cbe781"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "proc-macro-rules",
  "proc-macro2",
  "quote",
  "stringcase",
  "strum",
  "strum_macros",
- "syn 2.0.104",
- "thiserror 2.0.17",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1699,7 +1760,7 @@ dependencies = [
  "deno_error",
  "percent-encoding",
  "sys_traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "url",
 ]
 
@@ -1743,7 +1804,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1752,11 +1813,11 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1776,7 +1837,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1846,7 +1907,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.1",
  "libc",
  "objc2 0.6.1",
@@ -1860,7 +1921,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1892,7 +1953,7 @@ checksum = "788160fb30de9cdd857af31c6a2675904b16ece8fc2737b2c7127ba368c9d0f4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2031,7 +2092,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tower-layer",
@@ -2088,7 +2149,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2175,6 +2236,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
  "pin-project-lite",
 ]
 
@@ -2303,7 +2375,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2320,12 +2392,18 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fslock"
@@ -2355,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2370,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2380,15 +2458,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2408,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -2427,32 +2505,42 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers 0.4.0",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2462,7 +2550,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2636,9 +2723,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -2685,7 +2783,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2713,7 +2811,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2728,15 +2826,27 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2804,7 +2914,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2841,7 +2951,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2860,7 +2970,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2889,6 +2999,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -3130,7 +3246,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -3164,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3316,9 +3432,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3360,13 +3476,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3383,16 +3509,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-docker"
@@ -3478,7 +3594,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3490,7 +3606,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3498,10 +3614,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
@@ -3515,11 +3680,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3551,7 +3717,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -3580,7 +3746,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser 0.29.6",
  "html5ever 0.29.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
 
@@ -3640,9 +3806,9 @@ checksum = "775bf80d5878ab7c2b1080b5351a48b2f737d9f6f8b383574eebcc22be0dfccb"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -3696,7 +3862,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.5.14",
 ]
@@ -3754,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "value-bag",
 ]
@@ -3838,7 +4004,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3849,7 +4015,7 @@ checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3894,9 +4060,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -3941,14 +4107,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3968,7 +4134,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "windows-sys 0.59.0",
 ]
 
@@ -4012,8 +4178,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
- "jni-sys",
+ "bitflags 2.13.1",
+ "jni-sys 0.3.0",
  "log",
  "ndk-sys",
  "num_enum",
@@ -4033,7 +4199,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -4048,7 +4214,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4174,10 +4340,10 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4221,7 +4387,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.1",
  "libc",
  "objc2 0.6.1",
@@ -4240,7 +4406,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17614fdcd9b411e6ff1117dfb1d0150f908ba83a7df81b1f118005fe0a8ea15d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.1",
  "objc2-foundation 0.3.1",
 ]
@@ -4251,7 +4417,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291fbbf7d29287518e8686417cf7239c74700fd4b607623140a7d4a3c834329d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.1",
  "objc2-foundation 0.3.1",
 ]
@@ -4262,7 +4428,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.1",
 ]
@@ -4273,7 +4439,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2 0.6.1",
  "objc2-core-foundation",
@@ -4311,7 +4477,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -4323,7 +4489,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.1",
  "libc",
  "objc2 0.6.1",
@@ -4336,7 +4502,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.1",
  "objc2-core-foundation",
 ]
@@ -4347,7 +4513,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -4359,7 +4525,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -4372,7 +4538,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ffb6a0cd5f182dc964334388560b12a57f7b74b3e2dec5e2722aa2dfb2ccd5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.1",
  "objc2-foundation 0.3.1",
 ]
@@ -4383,7 +4549,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b1312ad7bc8a0e92adae17aa10f90aae1fb618832f9b993b022b591027daed"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-foundation 0.3.1",
@@ -4395,7 +4561,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91672909de8b1ce1c2252e95bbee8c1649c9ad9d14b9248b3d7b4c47903c47ad"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "block2 0.6.1",
  "objc2 0.6.1",
  "objc2-app-kit",
@@ -4414,9 +4580,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4442,7 +4608,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -4459,7 +4625,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4485,6 +4651,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -4630,9 +4805,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -4738,7 +4913,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4785,7 +4960,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4854,7 +5029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "quick-xml 0.38.0",
  "serde",
  "time",
@@ -4939,7 +5114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4963,11 +5138,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.22.27",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -5008,7 +5183,7 @@ checksum = "07c277e4e643ef00c1233393c673f655e3672cf7eb3ba08a00bdd0ea59139b5f"
 dependencies = [
  "proc-macro-rules-macros",
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5020,7 +5195,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5052,7 +5227,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5103,7 +5278,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -5115,6 +5290,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
@@ -5124,7 +5300,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5146,9 +5322,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -5158,6 +5334,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -5325,7 +5507,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "url",
  "urlencoding",
@@ -5347,7 +5529,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5369,7 +5551,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5389,14 +5571,14 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5406,9 +5588,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5423,9 +5605,9 @@ checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -5511,14 +5693,55 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http 0.6.6",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http 0.6.11",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -5544,6 +5767,55 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rig-core"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8731dd5532b3a12ce1613af73073fb2051ef750f50c504778c21d55ae933cac"
+dependencies = [
+ "as-any",
+ "async-stream",
+ "base64 0.22.1",
+ "bytes",
+ "eventsource-stream",
+ "fastrand",
+ "futures",
+ "futures-timer",
+ "glob",
+ "http 1.3.1",
+ "indexmap 2.14.0",
+ "mime",
+ "mime_guess",
+ "ordered-float",
+ "pin-project-lite",
+ "reqwest 0.13.4",
+ "rig-derive",
+ "schemars 1.0.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "rig-derive"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e98dde7a4e59e083e7396126ee4c83498c5bff605d126654e67815fa230a78"
+dependencies = [
+ "convert_case 0.11.0",
+ "indoc",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5617,7 +5889,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5630,7 +5902,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -5639,10 +5911,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5660,7 +5933,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -5683,11 +5956,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5740,7 +6041,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -5767,6 +6068,7 @@ checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -5780,7 +6082,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.104",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5824,7 +6138,7 @@ checksum = "22fc4f90c27b57691bbaf11d8ecc7cfbfe98a4da6dbe60226115d322aa80c06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5833,7 +6147,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5842,11 +6156,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5855,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5887,7 +6201,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5685b6ae43bfcf7d2e7dfcfb5d8e8f61b46442c902531e41a32a9a8bf0ee0fb6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cssparser 0.35.0",
  "derive_more 2.0.1",
  "fxhash",
@@ -5908,6 +6222,12 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sentry"
@@ -5997,7 +6317,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a63c02619733e917643fa91ec6744a18a1e48236cd876ce908a4c2b04f17bdf"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "log",
  "sentry-core",
 ]
@@ -6018,7 +6338,7 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2046f527fd4b75e0b6ab3bd656c67dce42072f828dc4d03c206d15dca74a93"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "sentry-backtrace",
  "sentry-core",
  "tracing-core",
@@ -6036,7 +6356,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "url",
  "uuid",
@@ -6080,7 +6400,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6091,21 +6411,21 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -6126,7 +6446,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6169,7 +6489,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "v8",
 ]
 
@@ -6183,7 +6503,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -6202,7 +6522,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6338,6 +6658,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6387,12 +6723,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6413,7 +6749,7 @@ dependencies = [
  "serde",
  "socketioxide-core",
  "socketioxide-parser-common",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -6431,7 +6767,7 @@ dependencies = [
  "futures-core",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6563,7 +6899,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.4",
  "hashlink",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -6572,7 +6908,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-stream",
@@ -6590,7 +6926,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6613,7 +6949,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.104",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
@@ -6626,7 +6962,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "crc 3.3.0",
@@ -6655,7 +6991,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "whoami",
@@ -6669,7 +7005,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "byteorder",
  "crc 3.3.0",
  "dotenvy",
@@ -6693,7 +7029,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "whoami",
@@ -6718,7 +7054,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "tracing",
  "url",
@@ -6817,7 +7153,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6850,9 +7186,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6882,7 +7229,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6911,7 +7258,7 @@ checksum = "181f22127402abcf8ee5c83ccd5b408933fec36a6095cf82cda545634692657e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6945,7 +7292,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -6989,7 +7336,7 @@ version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49c380ca75a231b87b6c9dd86948f035012e7171d1a7c40a9c2890489a7ffd8a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
@@ -6999,7 +7346,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "lazy_static",
  "libc",
  "log",
@@ -7030,7 +7377,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7062,7 +7409,7 @@ dependencies = [
  "heck 0.5.0",
  "http 1.3.1",
  "http-range",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -7085,7 +7432,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "tray-icon",
  "url",
@@ -7136,9 +7483,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.104",
+ "syn 2.0.119",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "url",
  "uuid",
@@ -7154,7 +7501,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -7189,7 +7536,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tracing",
  "url",
  "windows-registry",
@@ -7210,7 +7557,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "url",
 ]
 
@@ -7231,7 +7578,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "toml 0.8.23",
  "url",
 ]
@@ -7254,7 +7601,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
  "url",
  "urlpattern",
@@ -7274,7 +7621,7 @@ dependencies = [
  "serde_repr",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "url",
 ]
@@ -7294,7 +7641,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7314,7 +7661,7 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -7328,7 +7675,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin-deep-link",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
@@ -7341,14 +7688,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df059378695202fef1e274b8e7916fc3dffc44716ae4baf8c0226089b2f390ae"
 dependencies = [
  "futures-core",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_json",
  "sqlx",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "time",
  "tokio",
 ]
@@ -7363,14 +7710,14 @@ dependencies = [
  "dpi",
  "gtk",
  "http 1.3.1",
- "jni",
+ "jni 0.21.1",
  "objc2 0.6.1",
  "objc2-ui-kit",
  "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "url",
  "windows 0.61.3",
 ]
@@ -7383,7 +7730,7 @@ checksum = "902b5aa9035e16f342eb64f8bf06ccdc2808e411a2525ed1d07672fa4e780bad"
 dependencies = [
  "gtk",
  "http 1.3.1",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2 0.6.1",
  "objc2-app-kit",
@@ -7432,7 +7779,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "toml 0.8.23",
  "url",
  "urlpattern",
@@ -7447,7 +7794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d321dbc6f998d825ab3f0d62673e810c861aac2d0de2cc2c395328f1d113b4"
 dependencies = [
  "embed-resource",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "toml 0.8.23",
 ]
 
@@ -7458,7 +7805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "windows 0.61.3",
  "windows-version",
 ]
@@ -7507,11 +7854,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -7522,18 +7869,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7605,9 +7952,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -7615,7 +7962,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -7623,13 +7970,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7690,15 +8037,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.15"
+name = "tokio-tungstenite"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.28.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -7733,7 +8097,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 1.0.0",
  "toml_datetime 0.7.0",
@@ -7761,12 +8125,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -7779,7 +8152,7 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -7790,7 +8163,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -7799,12 +8172,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.1"
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "winnow 0.7.12",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -7828,7 +8213,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7853,7 +8238,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -7874,20 +8259,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -7922,7 +8307,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7936,10 +8321,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.22"
+name = "tracing-futures"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "tracing-core",
 ]
@@ -7962,7 +8359,7 @@ dependencies = [
  "once_cell",
  "png",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "windows-sys 0.59.0",
 ]
 
@@ -7985,7 +8382,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
@@ -8003,7 +8400,26 @@ dependencies = [
  "native-tls",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.3.1",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
@@ -8106,9 +8522,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -8121,9 +8537,9 @@ checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -8174,14 +8590,15 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8228,13 +8645,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "js-sys",
- "serde",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -8245,7 +8662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33995a1fee055ff743281cde33a41f0d618ee0bdbe8bdf6859e11864499c2595"
 dependencies = [
  "bindgen",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "fslock",
  "gzip-header",
  "home",
@@ -8262,9 +8679,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
 
 [[package]]
 name = "vcpkg"
@@ -8367,48 +8784,32 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8416,22 +8817,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -8450,13 +8851,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm_dep_analyzer"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a10e6b67c951a84de7029487e0e0a496860dae49f6699edd279d5ff35b8fbf54"
 dependencies = [
  "deno_error",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -8479,7 +8893,7 @@ version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "rustix 0.38.44",
  "wayland-backend",
  "wayland-scanner",
@@ -8491,7 +8905,7 @@ version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -8521,9 +8935,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8606,6 +9020,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.2",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
@@ -8635,7 +9058,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8644,7 +9067,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "windows 0.61.3",
  "windows-core 0.61.2",
 ]
@@ -8801,7 +9224,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8812,7 +9235,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8823,7 +9246,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8834,7 +9257,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9230,6 +9653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9261,7 +9693,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -9287,7 +9719,7 @@ dependencies = [
  "html5ever 0.29.1",
  "http 1.3.1",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "kuchikiki",
  "libc",
  "ndk",
@@ -9303,7 +9735,7 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.19",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
@@ -9374,7 +9806,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -9418,10 +9850,10 @@ version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -9456,7 +9888,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9476,7 +9908,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -9516,8 +9948,14 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"
@@ -9568,10 +10006,10 @@ version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.119",
  "zvariant_utils",
 ]
 
@@ -9585,6 +10023,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.104",
+ "syn 2.0.119",
  "winnow 0.7.12",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,6 +69,10 @@ sanitize-filename = "0.6.0"
 socketioxide = "0.17.2"
 scraper = "0.24.0"
 sentry = { version = "0.46.0", features = ["log", "logs"] }
+# Use Rig's core crate directly. The facade crate enables every provider and
+# vector-store integration by default, which would add unnecessary native
+# dependencies to the desktop application.
+rig-core = { version = "0.40.0", default-features = false, features = ["derive", "rustls"] }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/crates/recorder/src/platforms/bilibili.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili.rs
@@ -207,7 +207,7 @@ impl BiliRecorder {
 
                         log::info!(
                             "[{}]Update to a new stream: {:#?} => {:#?}",
-                            &self.room_id,
+                            self.room_id,
                             pre_live_stream,
                             stream
                         );
@@ -216,11 +216,11 @@ impl BiliRecorder {
                     }
                     Err(e) => {
                         if let crate::errors::RecorderError::FormatNotFound { format } = e {
-                            log::error!("[{}]Format {} not found", &self.room_id, format);
+                            log::error!("[{}]Format {} not found", self.room_id, format);
 
                             true
                         } else {
-                            log::error!("[{}]Fetch stream failed: {}", &self.room_id, e);
+                            log::error!("[{}]Fetch stream failed: {}", self.room_id, e);
 
                             true
                         }
@@ -228,7 +228,7 @@ impl BiliRecorder {
                 }
             }
             Err(e) => {
-                log::error!("[{}]Update room status failed: {}", &self.room_id, e);
+                log::error!("[{}]Update room status failed: {}", self.room_id, e);
                 // may encounter internet issues, not sure whether the stream is closed or started, just remain
                 pre_live_status
             }
@@ -241,7 +241,7 @@ impl BiliRecorder {
         let danmu_stream = DanmuStream::new(ProviderType::BiliBili, &cookies, &room_id).await;
         if danmu_stream.is_err() {
             let err = danmu_stream.err().unwrap();
-            log::error!("[{}]Failed to create danmu stream: {}", &self.room_id, err);
+            log::error!("[{}]Failed to create danmu stream: {}", self.room_id, err);
             return Err(crate::errors::RecorderError::DanmuStreamError(err));
         }
         let danmu_stream = danmu_stream.unwrap();
@@ -253,11 +253,11 @@ impl BiliRecorder {
                 start_res = &mut start_fut => {
                     match start_res {
                         Ok(_) => {
-                            log::info!("[{}]Danmu stream finished", &self.room_id);
+                            log::info!("[{}]Danmu stream finished", self.room_id);
                             return Ok(());
                         }
                         Err(err) => {
-                            log::error!("[{}]Danmu stream start error: {}", &self.room_id, err);
+                            log::error!("[{}]Danmu stream start error: {}", self.room_id, err);
                             return Err(crate::errors::RecorderError::DanmuStreamError(err));
                         }
                     }
@@ -280,11 +280,11 @@ impl BiliRecorder {
                             }
                         }
                         Ok(None) => {
-                            log::info!("[{}]Danmu stream closed", &self.room_id);
+                            log::info!("[{}]Danmu stream closed", self.room_id);
                             return Ok(());
                         }
                         Err(err) => {
-                            log::error!("[{}]Failed to receive danmu message: {}", &self.room_id, err);
+                            log::error!("[{}]Failed to receive danmu message: {}", self.room_id, err);
                             return Err(crate::errors::RecorderError::DanmuStreamError(err));
                         }
                     }

--- a/src-tauri/crates/recorder/src/platforms/douyin.rs
+++ b/src-tauri/crates/recorder/src/platforms/douyin.rs
@@ -148,7 +148,7 @@ impl DouyinRecorder {
                     // parse info.stream_data into DouyinStream
                     let stream_data = info.stream_data.clone();
                     let Ok(stream) = serde_json::from_str::<DouyinStream>(&stream_data) else {
-                        log::error!("Failed to parse stream data: {:#?}", &info);
+                        log::error!("Failed to parse stream data: {:#?}", info);
                         return false;
                     };
                     let Some(new_stream_url) = get_best_stream_url(&stream) else {
@@ -164,7 +164,7 @@ impl DouyinRecorder {
                 true
             }
             Err(e) => {
-                log::warn!("[{}]Update room status failed: {}", &self.room_id, e);
+                log::warn!("[{}]Update room status failed: {}", self.room_id, e);
                 pre_live_status
             }
         }

--- a/src-tauri/crates/recorder/src/platforms/huya/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/huya/mod.rs
@@ -77,7 +77,7 @@ impl HuyaRecorder {
                     // live status changed, reset current record flag
                     log::info!(
                         "[{}]Live status changed to {}, auto_start: {}",
-                        &self.room_id,
+                        self.room_id,
                         live_status,
                         self.enabled.load(atomic::Ordering::Relaxed)
                     );
@@ -116,7 +116,7 @@ impl HuyaRecorder {
                 true
             }
             Err(e) => {
-                log::warn!("[{}]Update room status failed: {}", &self.room_id, e);
+                log::warn!("[{}]Update room status failed: {}", self.room_id, e);
                 pre_live_status
             }
         }
@@ -164,7 +164,7 @@ impl HuyaRecorder {
             recorder: self.info().await,
         });
 
-        log::debug!("[{}]Stream URL: {}", &self.room_id, stream.hls_url);
+        log::debug!("[{}]Stream URL: {}", self.room_id, stream.hls_url);
 
         let hls_stream =
             construct_stream_from_variant(live_id, &stream.hls_url, Format::TS, Codec::Avc)
@@ -188,7 +188,7 @@ impl HuyaRecorder {
         let hls_recorder = hls_recorder.unwrap();
 
         if let Err(e) = hls_recorder.start().await {
-            log::error!("[{}]Failed to start hls recorder: {}", &self.room_id, e);
+            log::error!("[{}]Failed to start hls recorder: {}", self.room_id, e);
             return Err(e);
         }
 
@@ -210,7 +210,7 @@ impl crate::traits::RecorderTrait<HuyaExtra> for HuyaRecorder {
                             .store(true, atomic::Ordering::Relaxed);
                         let live_id = Utc::now().timestamp_millis().to_string();
                         if let Err(e) = self_clone.update_entries(&live_id).await {
-                            log::error!("[{}]Update entries error: {}", &self_clone.room_id, e);
+                            log::error!("[{}]Update entries error: {}", self_clone.room_id, e);
                         }
                     }
                     if self_clone.is_recording.load(atomic::Ordering::Relaxed) {
@@ -233,7 +233,7 @@ impl crate::traits::RecorderTrait<HuyaExtra> for HuyaRecorder {
                 ))
                 .await;
             }
-            log::info!("[{}]Recording thread quit.", &self_clone.room_id);
+            log::info!("[{}]Recording thread quit.", self_clone.room_id);
         }));
     }
 }

--- a/src-tauri/crates/recorder/src/platforms/kuaishou/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/kuaishou/api.rs
@@ -803,7 +803,7 @@ pub async fn get_stream_urls(
         });
     }
 
-    all_representations.sort_by(|a, b| b.bitrate.unwrap_or(0).cmp(&a.bitrate.unwrap_or(0)));
+    all_representations.sort_by_key(|item| std::cmp::Reverse(item.bitrate.unwrap_or(0)));
 
     // Remove duplicates based on URL
     let mut seen_urls = std::collections::HashSet::new();

--- a/src-tauri/crates/whisper-cpp-rs/build.rs
+++ b/src-tauri/crates/whisper-cpp-rs/build.rs
@@ -90,8 +90,8 @@ fn main() {
             if let Some(target) = macos_deployment_target() {
                 config.define("CMAKE_OSX_DEPLOYMENT_TARGET", &target);
                 config.define("GGML_METAL_MACOSX_VERSION_MIN", &target);
-                config.cflag(&format!("-mmacosx-version-min={target}"));
-                config.cxxflag(&format!("-mmacosx-version-min={target}"));
+                config.cflag(format!("-mmacosx-version-min={target}"));
+                config.cxxflag(format!("-mmacosx-version-min={target}"));
             }
 
             config.define("WHISPER_METAL", "ON");

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -1,0 +1,854 @@
+//! Server-side AI assistant powered by [Rig](https://github.com/0xPlaygrounds/rig).
+//!
+//! The browser supplies only a transient model configuration and conversation
+//! transcript.  Model requests and BSR tool calls happen in this process, so
+//! browser code never has to implement an agent loop or invoke privileged
+//! Tauri commands on the model's behalf.
+
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use rig_core::{
+    client::{CompletionClient, Nothing},
+    completion::{Chat, Message},
+    message::{AssistantContent, ToolCall, ToolFunction},
+    providers::{ollama, openai},
+    tool::Tool,
+    OneOrMany,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+#[cfg(feature = "gui")]
+use tauri::State as TauriState;
+
+use crate::{database::Database, recorder_manager::RecorderManager, state::State, state_type};
+
+const PROMPT: &str = r#"
+你是 BiliBili ShadowReplay（BSR）的虚拟助手小轴。你喜欢橘子，并适度使用 emoji。
+BSR 用 Recorder 表示监控的直播间，Archive 表示缓存的录播，Video/Clip 表示从 Archive 制作的视频。
+
+你可以用 bsr 工具读取和管理 BSR 数据。剪辑高光时，先读取 Archive、字幕和弹幕，再交叉验证字幕、弹幕密度和关键词；不要臆造时间点。所有时长尽量使用中文可读形式，结果优先以 Markdown 表格展示。
+
+只读工具会立即执行。删除、上传、修改配置、生成文件或启动外部操作等工具会返回 confirmation_required=true，此时你必须立即向用户清楚说明待执行的工具及参数，然后停止，不得重复调用该工具、继续调用其他工具或声称操作已完成。前端会让用户手动确认或拒绝；收到对应 tool result 后，再根据实际结果继续回复。每次只申请一个需要确认的操作。
+"#;
+
+static TOOL_CALL_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRequest {
+    pub provider: String,
+    pub endpoint: String,
+    pub api_key: Option<String>,
+    pub model: String,
+    /// Serialized UI messages. Keeping this wire type deliberately simple
+    /// avoids coupling the Rust backend to frontend message implementations.
+    #[serde(default)]
+    pub messages: Vec<AgentMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentMessage {
+    pub role: String,
+    pub content: String,
+    #[serde(default)]
+    pub tool_calls: Vec<AgentToolCall>,
+    pub tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AgentToolCall {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub args: Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentResponse {
+    pub content: String,
+    #[serde(default)]
+    pub tool_calls: Vec<ExecutedToolCall>,
+    pub error: Option<String>,
+}
+
+/// A tool invocation observed by the server-side Rig agent. Read-only calls are
+/// executed here; calls with `executed == false` are requests for explicit UI
+/// confirmation and must be executed at most once by the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutedToolCall {
+    pub id: String,
+    pub name: String,
+    pub args: Value,
+    pub executed: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Clone)]
+struct BsrTool {
+    db: Arc<Database>,
+    recorder_manager: Arc<RecorderManager>,
+    calls: Arc<Mutex<Vec<ExecutedToolCall>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BsrToolArgs {
+    action: String,
+    #[serde(default)]
+    args: Value,
+}
+
+#[derive(Debug)]
+struct BsrToolError(String);
+
+impl fmt::Display for BsrToolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for BsrToolError {}
+
+impl BsrTool {
+    fn tool_call_id() -> String {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let sequence = TOOL_CALL_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        format!("bsr-{timestamp}-{sequence}")
+    }
+
+    fn requires_confirmation(action: &str) -> bool {
+        matches!(
+            action,
+            "remove_account"
+                | "add_recorder"
+                | "remove_recorder"
+                | "delete_archive"
+                | "delete_archives"
+                | "delete_background_task"
+                | "get_video_cover"
+                | "delete_video"
+                | "get_video_typelist"
+                | "get_video_subtitle"
+                | "generate_video_subtitle"
+                | "encode_video_subtitle"
+                | "post_video_to_bilibili"
+                | "clip_range"
+                | "generic_ffmpeg_command"
+                | "open_clip"
+                | "list_folder"
+                | "generate_archive_subtitle"
+                | "extract_video_frames"
+                | "get_video_metadata"
+                | "merge_videos"
+                | "extract_video_audio"
+                | "get_archive_metadata"
+        )
+    }
+
+    fn action_schema(
+        action: &str,
+        description: &str,
+        properties: Value,
+        required: &[&str],
+    ) -> Value {
+        let mut args_schema = json!({
+            "type": "object",
+            "properties": properties,
+            "additionalProperties": false
+        });
+        if !required.is_empty() {
+            args_schema["required"] = json!(required);
+        }
+        json!({
+            "type": "object",
+            "description": description,
+            "properties": {
+                "action": { "const": action },
+                "args": args_schema
+            },
+            "required": ["action", "args"],
+            "additionalProperties": false
+        })
+    }
+
+    fn string_arg(args: &Value, name: &str) -> Result<String, BsrToolError> {
+        args.get(name)
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| BsrToolError(format!("Missing string argument: {name}")))
+    }
+
+    fn i64_arg(args: &Value, name: &str) -> Result<i64, BsrToolError> {
+        args.get(name)
+            .and_then(Value::as_i64)
+            .ok_or_else(|| BsrToolError(format!("Missing integer argument: {name}")))
+    }
+
+    fn f64_arg(args: &Value, name: &str) -> Result<f64, BsrToolError> {
+        args.get(name)
+            .and_then(Value::as_f64)
+            .ok_or_else(|| BsrToolError(format!("Missing number argument: {name}")))
+    }
+
+    async fn execute(&self, input: BsrToolArgs) -> Result<Value, BsrToolError> {
+        let args = &input.args;
+        match input.action.as_str() {
+            "get_accounts" => {
+                let accounts = self
+                    .db
+                    .get_accounts()
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                // Cookies must never be exposed to the LLM provider.
+                Ok(
+                    json!({ "accounts": accounts.into_iter().map(|mut account| { account.cookies = "********".into(); account }).collect::<Vec<_>>() }),
+                )
+            }
+            "get_recorder_list" => Ok(serde_json::to_value(
+                self.recorder_manager.get_recorder_list().await,
+            )
+            .unwrap_or(Value::Null)),
+            "get_recorder_info" => {
+                use recorder::platforms::PlatformType;
+                use std::str::FromStr;
+                let platform = PlatformType::from_str(&Self::string_arg(args, "platform")?)
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let room_id = Self::string_arg(args, "room_id")?;
+                let info = self
+                    .recorder_manager
+                    .get_recorder_info(platform, &room_id)
+                    .await
+                    .ok_or_else(|| BsrToolError("Recorder not found".into()))?;
+                Ok(serde_json::to_value(info).unwrap_or(Value::Null))
+            }
+            "get_archives" => {
+                let rows = self
+                    .recorder_manager
+                    .get_archives(
+                        &Self::string_arg(args, "room_id")?,
+                        Self::i64_arg(args, "offset")?,
+                        Self::i64_arg(args, "limit")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                Ok(json!({ "archives": rows }))
+            }
+            "get_archive" => {
+                let row = self
+                    .recorder_manager
+                    .get_archive(
+                        &Self::string_arg(args, "room_id")?,
+                        &Self::string_arg(args, "live_id")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                Ok(serde_json::to_value(row).unwrap_or(Value::Null))
+            }
+            "get_recent_record" => {
+                let rows = self
+                    .db
+                    .get_recent_record(
+                        &Self::string_arg(args, "room_id")?,
+                        Self::i64_arg(args, "offset")?,
+                        Self::i64_arg(args, "limit")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                Ok(json!({ "records": rows }))
+            }
+            "get_recent_record_all" => {
+                let rows = self
+                    .db
+                    .get_recent_record(
+                        "",
+                        Self::i64_arg(args, "offset")?,
+                        Self::i64_arg(args, "limit")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                Ok(json!({ "records": rows }))
+            }
+            "get_videos" => Ok(
+                json!({ "videos": self.db.get_videos(&Self::string_arg(args, "room_id")?).await.map_err(|e| BsrToolError(e.to_string()))? }),
+            ),
+            "get_all_videos" => Ok(
+                json!({ "videos": self.db.get_all_videos().await.map_err(|e| BsrToolError(e.to_string()))? }),
+            ),
+            "get_video" => Ok(
+                json!({ "video": self.db.get_video(Self::i64_arg(args, "id")?).await.map_err(|e| BsrToolError(e.to_string()))? }),
+            ),
+            "get_background_tasks" | "get_tasks" => Ok(
+                json!({ "tasks": self.db.get_tasks().await.map_err(|e| BsrToolError(e.to_string()))? }),
+            ),
+            "get_archive_subtitle" => {
+                use recorder::platforms::PlatformType;
+                use std::str::FromStr;
+                let platform = PlatformType::from_str(&Self::string_arg(args, "platform")?)
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let text = self
+                    .recorder_manager
+                    .get_archive_subtitle(
+                        platform,
+                        &Self::string_arg(args, "room_id")?,
+                        &Self::string_arg(args, "live_id")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                Ok(json!({ "subtitle": text }))
+            }
+            "get_danmu_record" => {
+                use recorder::platforms::PlatformType;
+                use std::str::FromStr;
+                let platform = PlatformType::from_str(&Self::string_arg(args, "platform")?)
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let rows = self
+                    .recorder_manager
+                    .load_danmus(
+                        platform,
+                        &Self::string_arg(args, "room_id")?,
+                        &Self::string_arg(args, "live_id")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let records = rows
+                    .into_iter()
+                    .map(|row| {
+                        json!({
+                            "ts": row.ts as f64 / 1000.0,
+                            "content": row.content,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                Ok(json!({ "danmu_record": records }))
+            }
+            "analyze_danmu_highlights" => {
+                use recorder::platforms::PlatformType;
+                use std::str::FromStr;
+                let platform = PlatformType::from_str(&Self::string_arg(args, "platform")?)
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let window = Self::f64_arg(args, "time_window")?;
+                if window <= 0.0 {
+                    return Err(BsrToolError("time_window must be positive".into()));
+                }
+                let minimum = Self::i64_arg(args, "min_density")?;
+                let minimum = usize::try_from(minimum).map_err(|_| {
+                    BsrToolError("min_density must be a non-negative integer".into())
+                })?;
+                let rows = self
+                    .recorder_manager
+                    .load_danmus(
+                        platform,
+                        &Self::string_arg(args, "room_id")?,
+                        &Self::string_arg(args, "live_id")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let max_ts = rows.iter().map(|row| row.ts).max().unwrap_or(0) as f64 / 1000.0;
+                let highlights = (0..(max_ts / window).ceil() as usize).filter_map(|index| {
+                    let start = index as f64 * window;
+                    let end = ((index + 1) as f64 * window).min(max_ts);
+                    let comments = rows.iter().filter(|row| (row.ts as f64 / 1000.0) >= start && (row.ts as f64 / 1000.0) < end).collect::<Vec<_>>();
+                    (comments.len() >= minimum).then(|| json!({
+                        "start_time": start, "end_time": end, "comment_count": comments.len(),
+                        "density": comments.len() as f64 / window,
+                        "sample_comments": comments.iter().take(5).map(|row| row.content.clone()).collect::<Vec<_>>()
+                    }))
+                }).collect::<Vec<_>>();
+                Ok(json!({ "highlights": highlights }))
+            }
+            "search_danmu_keywords" => {
+                use recorder::platforms::PlatformType;
+                use std::str::FromStr;
+                let platform = PlatformType::from_str(&Self::string_arg(args, "platform")?)
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let keywords = args
+                    .get("keywords")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| BsrToolError("Missing keywords".into()))?
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>();
+                let context = Self::f64_arg(args, "context_seconds")?;
+                let rows = self
+                    .recorder_manager
+                    .load_danmus(
+                        platform,
+                        &Self::string_arg(args, "room_id")?,
+                        &Self::string_arg(args, "live_id")?,
+                    )
+                    .await
+                    .map_err(|e| BsrToolError(e.to_string()))?;
+                let matches = rows.iter().flat_map(|row| keywords.iter().filter(move |keyword| row.content.contains(**keyword)).take(1).map(move |keyword| {
+                    let timestamp = row.ts as f64 / 1000.0;
+                    json!({ "timestamp": timestamp, "content": row.content, "keyword": keyword, "context_start": (timestamp - context).max(0.0), "context_end": timestamp + context })
+                })).collect::<Vec<_>>();
+                Ok(json!({ "matches": matches }))
+            }
+            other => Err(BsrToolError(format!("Unknown BSR action: {other}"))),
+        }
+    }
+}
+
+impl Tool for BsrTool {
+    const NAME: &'static str = "bsr";
+    type Error = BsrToolError;
+    type Args = BsrToolArgs;
+    type Output = Value;
+
+    fn description(&self) -> String {
+        "Read, analyse and manage BSR. Read-only actions execute immediately. Actions that change state, generate files, access local files through the browser, or start external operations return a confirmation request that the user must approve in the UI.".into()
+    }
+
+    fn parameters(&self) -> Value {
+        let platform = || json!({ "type": "string", "enum": ["bilibili", "douyin"] });
+        let string = || json!({ "type": "string" });
+        let integer = || json!({ "type": "integer" });
+        let number = || json!({ "type": "number" });
+        let boolean = || json!({ "type": "boolean" });
+        let transition = || {
+            json!({
+                "type": "string",
+                "enum": ["none", "fade", "dissolve", "wipeleft", "wiperight", "slideup", "slidedown"]
+            })
+        };
+        let actions = vec![
+            Self::action_schema(
+                "get_accounts",
+                "Get configured accounts with cookies redacted.",
+                json!({}),
+                &[],
+            ),
+            Self::action_schema(
+                "remove_account",
+                "Remove an account after user confirmation.",
+                json!({ "platform": platform(), "uid": integer() }),
+                &["platform", "uid"],
+            ),
+            Self::action_schema(
+                "add_recorder",
+                "Add a monitored live room after user confirmation.",
+                json!({ "platform": platform(), "room_id": string(), "extra": string() }),
+                &["platform", "room_id", "extra"],
+            ),
+            Self::action_schema(
+                "remove_recorder",
+                "Stop monitoring a live room after user confirmation.",
+                json!({ "platform": platform(), "room_id": string() }),
+                &["platform", "room_id"],
+            ),
+            Self::action_schema(
+                "get_recorder_list",
+                "List all monitored live rooms.",
+                json!({}),
+                &[],
+            ),
+            Self::action_schema(
+                "get_recorder_info",
+                "Get live-room information.",
+                json!({ "platform": platform(), "room_id": string() }),
+                &["platform", "room_id"],
+            ),
+            Self::action_schema(
+                "get_archives",
+                "List archives for a room.",
+                json!({ "room_id": string(), "offset": integer(), "limit": integer() }),
+                &["room_id", "offset", "limit"],
+            ),
+            Self::action_schema(
+                "get_archive",
+                "Get one archive.",
+                json!({ "room_id": string(), "live_id": string() }),
+                &["room_id", "live_id"],
+            ),
+            Self::action_schema(
+                "delete_archive",
+                "Delete one archive after user confirmation.",
+                json!({ "platform": platform(), "room_id": string(), "live_id": string() }),
+                &["platform", "room_id", "live_id"],
+            ),
+            Self::action_schema(
+                "delete_archives",
+                "Delete multiple archives after user confirmation.",
+                json!({ "platform": platform(), "room_id": string(), "live_ids": { "type": "array", "items": string() } }),
+                &["platform", "room_id", "live_ids"],
+            ),
+            Self::action_schema(
+                "get_background_tasks",
+                "List background tasks.",
+                json!({}),
+                &[],
+            ),
+            Self::action_schema(
+                "delete_background_task",
+                "Delete a background task after user confirmation.",
+                json!({ "id": string() }),
+                &["id"],
+            ),
+            Self::action_schema(
+                "get_videos",
+                "List videos for a room.",
+                json!({ "room_id": string() }),
+                &["room_id"],
+            ),
+            Self::action_schema(
+                "get_all_videos",
+                "List videos from all rooms.",
+                json!({}),
+                &[],
+            ),
+            Self::action_schema(
+                "get_video",
+                "Get one video.",
+                json!({ "id": integer() }),
+                &["id"],
+            ),
+            Self::action_schema(
+                "get_video_cover",
+                "Get a video cover after user confirmation because the result is handled locally.",
+                json!({ "id": integer() }),
+                &["id"],
+            ),
+            Self::action_schema(
+                "delete_video",
+                "Delete a video after user confirmation.",
+                json!({ "id": integer() }),
+                &["id"],
+            ),
+            Self::action_schema(
+                "get_video_typelist",
+                "Get Bilibili video categories after user confirmation.",
+                json!({}),
+                &[],
+            ),
+            Self::action_schema(
+                "get_video_subtitle",
+                "Get a generated video subtitle after user confirmation.",
+                json!({ "id": integer() }),
+                &["id"],
+            ),
+            Self::action_schema(
+                "generate_video_subtitle",
+                "Generate or overwrite a video subtitle after user confirmation.",
+                json!({ "id": integer() }),
+                &["id"],
+            ),
+            Self::action_schema(
+                "encode_video_subtitle",
+                "Burn subtitles into a video after user confirmation.",
+                json!({ "id": integer(), "srt_style": string() }),
+                &["id", "srt_style"],
+            ),
+            Self::action_schema(
+                "post_video_to_bilibili",
+                "Upload a video to Bilibili after user confirmation.",
+                json!({ "uid": integer(), "room_id": string(), "video_id": integer(), "title": string(), "desc": string(), "tag": string(), "tid": integer() }),
+                &["uid", "room_id", "video_id", "title", "desc", "tag", "tid"],
+            ),
+            Self::action_schema(
+                "get_danmu_record",
+                "Load danmu for an archive. Each ts value is seconds from the archive start.",
+                json!({ "platform": platform(), "room_id": string(), "live_id": string() }),
+                &["platform", "room_id", "live_id"],
+            ),
+            Self::action_schema(
+                "clip_range",
+                "Create a video from one or more archive ranges after user confirmation.",
+                json!({
+                    "reason": string(),
+                    "clip_range_params": {
+                        "type": "object",
+                        "properties": {
+                            "room_id": string(), "live_id": string(),
+                            "ranges": { "type": "array", "items": { "type": "object", "properties": { "start": number(), "end": number() }, "required": ["start", "end"], "additionalProperties": false } },
+                            "danmu": boolean(), "local_offset": number(), "title": string(), "note": string(), "cover": string(), "platform": platform(), "fix_encoding": boolean(), "transition": transition()
+                        },
+                        "required": ["room_id", "live_id", "ranges", "danmu", "local_offset", "title", "note", "cover", "platform", "fix_encoding"],
+                        "additionalProperties": false
+                    }
+                }),
+                &["reason", "clip_range_params"],
+            ),
+            Self::action_schema(
+                "get_recent_record",
+                "List recent archives for a room.",
+                json!({ "room_id": string(), "offset": integer(), "limit": integer() }),
+                &["room_id", "offset", "limit"],
+            ),
+            Self::action_schema(
+                "get_recent_record_all",
+                "List recent archives from all rooms.",
+                json!({ "offset": integer(), "limit": integer() }),
+                &["offset", "limit"],
+            ),
+            Self::action_schema(
+                "generic_ffmpeg_command",
+                "Run ffmpeg arguments after user confirmation.",
+                json!({ "args": { "type": "array", "items": string() } }),
+                &["args"],
+            ),
+            Self::action_schema(
+                "open_clip",
+                "Open a local video preview after user confirmation.",
+                json!({ "video_id": integer() }),
+                &["video_id"],
+            ),
+            Self::action_schema(
+                "list_folder",
+                "List a local folder after user confirmation.",
+                json!({ "path": string() }),
+                &["path"],
+            ),
+            Self::action_schema(
+                "get_archive_subtitle",
+                "Get an archive subtitle.",
+                json!({ "platform": platform(), "room_id": string(), "live_id": string() }),
+                &["platform", "room_id", "live_id"],
+            ),
+            Self::action_schema(
+                "generate_archive_subtitle",
+                "Generate or overwrite an archive subtitle after user confirmation.",
+                json!({ "platform": platform(), "room_id": string(), "live_id": string() }),
+                &["platform", "room_id", "live_id"],
+            ),
+            Self::action_schema(
+                "extract_video_frames",
+                "Extract local video frames after user confirmation.",
+                json!({ "video_id": integer(), "timestamps": { "type": "array", "items": number() }, "max_frames": integer() }),
+                &["video_id"],
+            ),
+            Self::action_schema(
+                "get_video_metadata",
+                "Inspect local video metadata after user confirmation.",
+                json!({ "video_id": integer() }),
+                &["video_id"],
+            ),
+            Self::action_schema(
+                "analyze_danmu_highlights",
+                "Find high-engagement time windows from danmu density.",
+                json!({ "platform": platform(), "room_id": string(), "live_id": string(), "time_window": number(), "min_density": integer() }),
+                &[
+                    "platform",
+                    "room_id",
+                    "live_id",
+                    "time_window",
+                    "min_density",
+                ],
+            ),
+            Self::action_schema(
+                "search_danmu_keywords",
+                "Find keyword matches and timestamps in danmu.",
+                json!({ "platform": platform(), "room_id": string(), "live_id": string(), "keywords": { "type": "array", "items": string() }, "context_seconds": number() }),
+                &[
+                    "platform",
+                    "room_id",
+                    "live_id",
+                    "keywords",
+                    "context_seconds",
+                ],
+            ),
+            Self::action_schema(
+                "merge_videos",
+                "Merge videos after user confirmation.",
+                json!({ "video_ids": { "type": "array", "items": integer() }, "output_title": string(), "output_note": string(), "transition": transition() }),
+                &["video_ids", "output_title", "output_note"],
+            ),
+            Self::action_schema(
+                "extract_video_audio",
+                "Extract audio from a video after user confirmation.",
+                json!({ "video_id": integer() }),
+                &["video_id"],
+            ),
+            Self::action_schema(
+                "get_archive_metadata",
+                "Inspect local archive metadata after user confirmation.",
+                json!({ "platform": platform(), "room_id": string(), "live_id": string() }),
+                &["platform", "room_id", "live_id"],
+            ),
+        ];
+        json!({
+            "type": "object",
+            "oneOf": actions
+        })
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // Rig owns the agent loop, so this is the one reliable boundary where
+        // every provider-triggered tool call can be captured for the UI.
+        let id = Self::tool_call_id();
+        let record_index = {
+            let mut calls = self.calls.lock().expect("tool call log mutex poisoned");
+            calls.push(ExecutedToolCall {
+                id: id.clone(),
+                name: args.action.clone(),
+                args: args.args.clone(),
+                executed: false,
+                error: None,
+            });
+            calls.len() - 1
+        };
+
+        if Self::requires_confirmation(&args.action) {
+            return Ok(json!({
+                "confirmation_required": true,
+                "tool_call_id": id,
+                "action": args.action,
+                "args": args.args,
+                "message": "Wait for the user to confirm or reject this operation in the BSR UI."
+            }));
+        }
+
+        let result = self.execute(args).await;
+        let mut calls = self.calls.lock().expect("tool call log mutex poisoned");
+        let record = &mut calls[record_index];
+        record.executed = true;
+        if let Err(error) = &result {
+            record.error = Some(error.to_string());
+        }
+        result
+    }
+}
+
+fn rig_message(message: &AgentMessage) -> Result<Message, String> {
+    match message.role.as_str() {
+        "user" => Ok(Message::user(message.content.clone())),
+        "assistant" => {
+            let mut content = Vec::new();
+            if !message.content.is_empty() {
+                content.push(AssistantContent::text(message.content.clone()));
+            }
+            content.extend(message.tool_calls.iter().map(|call| {
+                AssistantContent::ToolCall(ToolCall::new(
+                    call.id.clone(),
+                    ToolFunction::new(
+                        BsrTool::NAME.to_owned(),
+                        json!({ "action": call.name, "args": call.args }),
+                    ),
+                ))
+            }));
+            if content.is_empty() {
+                content.push(AssistantContent::text(""));
+            }
+            Ok(Message::Assistant {
+                id: None,
+                content: OneOrMany::many(content).expect("assistant content is not empty"),
+            })
+        }
+        "tool" => message
+            .tool_call_id
+            .as_ref()
+            .map(|id| Message::tool_result(id.clone(), message.content.clone()))
+            .ok_or_else(|| "Tool message is missing toolCallId".to_owned()),
+        "system" => Ok(Message::system(message.content.clone())),
+        role => Err(format!("Unsupported message role: {role}")),
+    }
+}
+
+fn prepare_chat(messages: &[AgentMessage]) -> Result<(Message, Vec<Message>), String> {
+    let mut history = messages
+        .iter()
+        .map(rig_message)
+        .collect::<Result<Vec<_>, _>>()?;
+    let prompt = history
+        .pop()
+        .ok_or_else(|| "Conversation must contain at least one message".to_owned())?;
+    Ok((prompt, history))
+}
+
+async fn openai_chat(
+    request: &AgentRequest,
+    tool: BsrTool,
+    prompt: Message,
+    mut history: Vec<Message>,
+) -> Result<String, String> {
+    let client = openai::Client::builder()
+        .api_key(request.api_key.as_deref().unwrap_or_default())
+        .base_url(&request.endpoint)
+        .build()
+        .map_err(|e| e.to_string())?
+        // OpenAI-compatible gateways commonly implement Chat Completions, not Responses.
+        .completions_api();
+    client
+        .agent(&request.model)
+        .preamble(PROMPT)
+        .tool(tool)
+        .default_max_turns(8)
+        .build()
+        .chat(prompt, &mut history)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn ollama_chat(
+    request: &AgentRequest,
+    tool: BsrTool,
+    prompt: Message,
+    mut history: Vec<Message>,
+) -> Result<String, String> {
+    let endpoint = if request.endpoint.trim().is_empty() {
+        "http://localhost:11434"
+    } else {
+        &request.endpoint
+    };
+    let client = ollama::Client::builder()
+        .api_key(Nothing)
+        .base_url(endpoint)
+        .build()
+        .map_err(|e| e.to_string())?;
+    client
+        .agent(&request.model)
+        .preamble(PROMPT)
+        .tool(tool)
+        .default_max_turns(8)
+        .build()
+        .chat(prompt, &mut history)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[cfg_attr(feature = "gui", tauri::command)]
+pub async fn agent_chat(
+    state: state_type!(),
+    request: AgentRequest,
+) -> Result<AgentResponse, String> {
+    if request.model.trim().is_empty() {
+        return Err("请选择模型".into());
+    }
+    let tool = BsrTool {
+        db: state.db.clone(),
+        recorder_manager: state.recorder_manager.clone(),
+        calls: Arc::new(Mutex::new(Vec::new())),
+    };
+    let calls = tool.calls.clone();
+    let (prompt, history) = prepare_chat(&request.messages)?;
+    let result = match request.provider.as_str() {
+        "ollama" => ollama_chat(&request, tool, prompt, history).await,
+        "openai" => openai_chat(&request, tool, prompt, history).await,
+        _ => return Err("Unsupported AI provider".into()),
+    };
+    let tool_calls = calls.lock().expect("tool call log mutex poisoned").clone();
+    match result {
+        Ok(content) => Ok(AgentResponse {
+            content,
+            tool_calls,
+            error: None,
+        }),
+        Err(error) => Ok(AgentResponse {
+            content: String::new(),
+            tool_calls,
+            error: Some(error),
+        }),
+    }
+}

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -17,7 +17,7 @@ use std::{
 use rig_core::{
     client::{CompletionClient, Nothing},
     completion::{Chat, Message},
-    message::{AssistantContent, ToolCall, ToolFunction},
+    message::{AssistantContent, ToolCall, ToolFunction, ToolResultContent, UserContent},
     providers::{ollama, openai},
     tool::Tool,
     OneOrMany,
@@ -106,6 +106,59 @@ struct BsrToolArgs {
     action: String,
     #[serde(default)]
     args: Value,
+}
+
+impl BsrToolArgs {
+    fn normalize(mut self) -> Result<Self, BsrToolError> {
+        if let Value::String(raw) = &self.args {
+            self.args = serde_json::from_str(raw)
+                .map_err(|error| BsrToolError(format!("Invalid JSON tool arguments: {error}")))?;
+        }
+        self.args = normalize_argument_keys(self.args);
+        Ok(self)
+    }
+}
+
+fn snake_case_key(key: &str) -> String {
+    let mut normalized = String::with_capacity(key.len());
+    for character in key.chars() {
+        if character.is_ascii_uppercase() {
+            if !normalized.is_empty() && !normalized.ends_with('_') {
+                normalized.push('_');
+            }
+            normalized.push(character.to_ascii_lowercase());
+        } else {
+            normalized.push(character);
+        }
+    }
+    normalized
+}
+
+fn normalize_argument_keys(value: Value) -> Value {
+    match value {
+        Value::Object(arguments) => {
+            let mut normalized = serde_json::Map::new();
+
+            for (key, value) in &arguments {
+                let canonical = snake_case_key(key);
+                if canonical == *key {
+                    normalized.insert(canonical, normalize_argument_keys(value.clone()));
+                }
+            }
+            for (key, value) in arguments {
+                let canonical = snake_case_key(&key);
+                normalized
+                    .entry(canonical)
+                    .or_insert_with(|| normalize_argument_keys(value));
+            }
+
+            Value::Object(normalized)
+        }
+        Value::Array(values) => {
+            Value::Array(values.into_iter().map(normalize_argument_keys).collect())
+        }
+        value => value,
+    }
 }
 
 #[derive(Debug)]
@@ -687,6 +740,7 @@ impl Tool for BsrTool {
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         // Rig owns the agent loop, so this is the one reliable boundary where
         // every provider-triggered tool call can be captured for the UI.
+        let args = args.normalize()?;
         let id = Self::tool_call_id();
         let record_index = {
             let mut calls = self.calls.lock().expect("tool call log mutex poisoned");
@@ -721,9 +775,9 @@ impl Tool for BsrTool {
     }
 }
 
-fn rig_message(message: &AgentMessage) -> Result<Message, String> {
+fn rig_messages(message: &AgentMessage) -> Result<Vec<Message>, String> {
     match message.role.as_str() {
-        "user" => Ok(Message::user(message.content.clone())),
+        "user" => Ok(vec![Message::user(message.content.clone())]),
         "assistant" => {
             let mut content = Vec::new();
             if !message.content.is_empty() {
@@ -741,17 +795,54 @@ fn rig_message(message: &AgentMessage) -> Result<Message, String> {
             if content.is_empty() {
                 content.push(AssistantContent::text(""));
             }
-            Ok(Message::Assistant {
+            Ok(vec![Message::Assistant {
                 id: None,
                 content: OneOrMany::many(content).expect("assistant content is not empty"),
-            })
+            }])
         }
-        "tool" => message
-            .tool_call_id
-            .as_ref()
-            .map(|id| Message::tool_result(id.clone(), message.content.clone()))
-            .ok_or_else(|| "Tool message is missing toolCallId".to_owned()),
-        "system" => Ok(Message::system(message.content.clone())),
+        "tool" => {
+            let id = message
+                .tool_call_id
+                .as_ref()
+                .ok_or_else(|| "Tool message is missing toolCallId".to_owned())?;
+            let parsed = ToolResultContent::from_tool_output(message.content.clone());
+            let mut text = Vec::new();
+            let mut images = Vec::new();
+
+            for content in parsed {
+                match content {
+                    ToolResultContent::Text(value) => text.push(value.text),
+                    ToolResultContent::Image(image) => images.push(image),
+                }
+            }
+
+            if images.is_empty() {
+                return Ok(vec![Message::tool_result(id.clone(), text.join("\n"))]);
+            }
+
+            // OpenAI Chat Completions requires tool results to remain text-only.
+            // Send the image parts in a following user message, while preserving
+            // the matching tool result so the assistant/tool protocol is valid.
+            let result_text = if text.is_empty() {
+                format!("The tool returned {} image(s).", images.len())
+            } else {
+                text.join("\n")
+            };
+            let mut image_content = Vec::with_capacity(images.len() + 1);
+            image_content.push(UserContent::text(
+                "These images are the visual output of the preceding tool result. Inspect them directly and use the timestamps in that result to identify each frame.",
+            ));
+            image_content.extend(images.into_iter().map(UserContent::Image));
+
+            Ok(vec![
+                Message::tool_result(id.clone(), result_text),
+                Message::User {
+                    content: OneOrMany::many(image_content)
+                        .expect("image tool result always has content"),
+                },
+            ])
+        }
+        "system" => Ok(vec![Message::system(message.content.clone())]),
         role => Err(format!("Unsupported message role: {role}")),
     }
 }
@@ -759,8 +850,11 @@ fn rig_message(message: &AgentMessage) -> Result<Message, String> {
 fn prepare_chat(messages: &[AgentMessage]) -> Result<(Message, Vec<Message>), String> {
     let mut history = messages
         .iter()
-        .map(rig_message)
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(rig_messages)
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
     let prompt = history
         .pop()
         .ok_or_else(|| "Conversation must contain at least one message".to_owned())?;
@@ -850,5 +944,146 @@ pub async fn agent_chat(
             tool_calls,
             error: Some(error),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig_core::message::{DocumentSourceKind, ImageMediaType};
+
+    fn tool_message(content: Value) -> AgentMessage {
+        AgentMessage {
+            role: "tool".into(),
+            content: content.to_string(),
+            tool_calls: Vec::new(),
+            tool_call_id: Some("tool-call-1".into()),
+        }
+    }
+
+    #[test]
+    fn stringified_tool_arguments_are_normalized() {
+        let args = BsrToolArgs {
+            action: "extract_video_frames".into(),
+            args: Value::String(r#"{"videoId":75,"timestamps":[120],"maxFrames":1}"#.into()),
+        }
+        .normalize()
+        .unwrap();
+
+        assert_eq!(args.args["video_id"], 75);
+        assert_eq!(args.args["timestamps"][0], 120);
+        assert_eq!(args.args["max_frames"], 1);
+    }
+
+    #[test]
+    fn nested_camel_case_tool_arguments_are_normalized() {
+        let args = BsrToolArgs {
+            action: "clip_range".into(),
+            args: json!({
+                "clipRangeParams": {
+                    "roomId": "123",
+                    "localOffset": 2,
+                    "fixEncoding": true
+                }
+            }),
+        }
+        .normalize()
+        .unwrap();
+
+        assert_eq!(args.args["clip_range_params"]["room_id"], "123");
+        assert_eq!(args.args["clip_range_params"]["local_offset"], 2);
+        assert_eq!(args.args["clip_range_params"]["fix_encoding"], true);
+    }
+
+    #[test]
+    fn plain_tool_results_remain_single_text_messages() {
+        let messages = rig_messages(&tool_message(json!({ "status": "ok" }))).unwrap();
+
+        assert_eq!(messages.len(), 1);
+        let Message::User { content } = &messages[0] else {
+            panic!("expected user tool-result message");
+        };
+        let UserContent::ToolResult(result) = content.first() else {
+            panic!("expected tool result content");
+        };
+        assert_eq!(result.id, "tool-call-1");
+        assert!(matches!(result.content.first(), ToolResultContent::Text(_)));
+    }
+
+    #[test]
+    fn image_tool_results_become_text_result_followed_by_images() {
+        let messages = rig_messages(&tool_message(json!({
+            "response": {
+                "tool": "extract_video_frames",
+                "frames": [{ "index": 0, "timestamp": 12.5 }]
+            },
+            "parts": [{
+                "type": "image",
+                "data": "base64-jpeg-data",
+                "mimeType": "image/jpeg"
+            }]
+        })))
+        .unwrap();
+
+        assert_eq!(messages.len(), 2);
+
+        let Message::User { content } = &messages[0] else {
+            panic!("expected text tool-result message");
+        };
+        let UserContent::ToolResult(result) = content.first() else {
+            panic!("expected tool result content");
+        };
+        assert_eq!(result.id, "tool-call-1");
+        assert!(matches!(result.content.first(), ToolResultContent::Text(_)));
+
+        let Message::User { content } = &messages[1] else {
+            panic!("expected following image message");
+        };
+        assert_eq!(content.len(), 2);
+        assert!(matches!(content.first(), UserContent::Text(_)));
+        let image = content
+            .iter()
+            .find_map(|content| match content {
+                UserContent::Image(image) => Some(image),
+                _ => None,
+            })
+            .expect("image content should be preserved");
+        assert_eq!(
+            image.data,
+            DocumentSourceKind::Base64("base64-jpeg-data".into())
+        );
+        assert_eq!(image.media_type, Some(ImageMediaType::JPEG));
+    }
+
+    #[test]
+    fn image_message_is_used_as_prompt_after_confirmed_tool_result() {
+        let assistant = AgentMessage {
+            role: "assistant".into(),
+            content: "".into(),
+            tool_calls: vec![AgentToolCall {
+                id: "tool-call-1".into(),
+                name: "extract_video_frames".into(),
+                args: json!({ "video_id": 1 }),
+            }],
+            tool_call_id: None,
+        };
+        let result = tool_message(json!({
+            "response": { "frames": [{ "index": 0, "timestamp": 1.0 }] },
+            "parts": [{
+                "type": "image",
+                "data": "frame-data",
+                "mimeType": "image/jpeg"
+            }]
+        }));
+
+        let (prompt, history) = prepare_chat(&[assistant, result]).unwrap();
+
+        assert_eq!(history.len(), 2);
+        let Message::User { content } = prompt else {
+            panic!("expected image user message to be the next model prompt");
+        };
+        assert!(content
+            .iter()
+            .any(|content| matches!(content, UserContent::Image(_))));
     }
 }

--- a/src-tauri/src/handlers/config.rs
+++ b/src-tauri/src/handlers/config.rs
@@ -315,6 +315,7 @@ pub async fn update_danmu_ass_options(
 }
 
 #[cfg_attr(feature = "gui", tauri::command)]
+#[cfg(feature = "gui")]
 pub async fn update_powerlive_key(state: state_type!(), powerlive_key: String) -> Result<(), ()> {
     state.config.write().await.powerlive_key = powerlive_key.clone();
     state.config.write().await.save();

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -6,6 +6,7 @@ pub mod recorder;
 pub mod task;
 pub mod utils;
 pub mod video;
+#[cfg(feature = "gui")]
 pub mod video_editing;
 
 use crate::database::account::AccountRow;

--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -512,7 +512,7 @@ async fn clip_range_inner(
             "生成新切片",
             &format!(
                 "生成了房间 {} 的切片，长度 {}s：{}",
-                &params.room_id, duration, filename
+                params.room_id, duration, filename
             ),
         )
         .await?;
@@ -525,7 +525,7 @@ async fn clip_range_inner(
             .title("BiliShadowReplay - 切片完成")
             .body(format!(
                 "生成了房间 {} 的切片: {}",
-                &params.room_id, filename
+                params.room_id, filename
             ))
             .show()
             .unwrap();

--- a/src-tauri/src/handlers/video_editing.rs
+++ b/src-tauri/src/handlers/video_editing.rs
@@ -63,6 +63,15 @@ fn get_ffprobe_path() -> PathBuf {
     path
 }
 
+fn resolve_video_path(output_dir: &Path, file: &str) -> PathBuf {
+    let path = PathBuf::from(file);
+    if path.is_absolute() {
+        path
+    } else {
+        output_dir.join(path)
+    }
+}
+
 /// Extract frames from a video at specific timestamps or evenly distributed
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn extract_video_frames(
@@ -78,9 +87,10 @@ pub async fn extract_video_frames(
         .await
         .map_err(|e| format!("Failed to get video: {}", e))?;
 
-    let video_path = PathBuf::from(&video.file);
+    let output_dir = PathBuf::from(&state.config.read().await.output);
+    let video_path = resolve_video_path(&output_dir, &video.file);
     if !video_path.exists() {
-        return Err("Video file not found".to_string());
+        return Err(format!("Video file not found: {}", video_path.display()));
     }
 
     // Get video duration
@@ -179,7 +189,8 @@ pub async fn get_video_metadata(
         .await
         .map_err(|e| format!("Failed to get video: {}", e))?;
 
-    let video_path = PathBuf::from(&video.file);
+    let output_dir = PathBuf::from(&state.config.read().await.output);
+    let video_path = resolve_video_path(&output_dir, &video.file);
     get_video_metadata_internal(&video_path).await
 }
 
@@ -441,6 +452,10 @@ pub async fn merge_videos(
 
     // Determine output path
     let output_dir = PathBuf::from(&state.config.read().await.output);
+    let video_paths = videos
+        .iter()
+        .map(|video| resolve_video_path(&output_dir, &video.file))
+        .collect::<Vec<_>>();
     let output_filename = format!(
         "merged_{}_{}.mp4",
         chrono::Local::now().format("%Y%m%d_%H%M%S"),
@@ -457,11 +472,14 @@ pub async fn merge_videos(
         let concat_file = std::env::temp_dir().join(format!("concat_{}.txt", uuid::Uuid::new_v4()));
         let mut concat_content = String::new();
 
-        for video in &videos {
+        for video_path in &video_paths {
             // Escape path for FFmpeg concat demuxer
             // Only escape backslashes and single quotes
             // Square brackets work fine inside single quotes
-            let path_str = video.file.replace('\\', "\\\\").replace('\'', "'\\''");
+            let path_str = video_path
+                .to_string_lossy()
+                .replace('\\', "\\\\")
+                .replace('\'', "'\\''");
             concat_content.push_str(&format!("file '{}'\n", path_str));
         }
 
@@ -583,8 +601,8 @@ pub async fn merge_videos(
         }
 
         // Add all input files
-        for video in &videos {
-            cmd.args(["-i", &video.file]);
+        for video_path in &video_paths {
+            cmd.arg("-i").arg(video_path);
         }
 
         // Add filter complex
@@ -667,13 +685,13 @@ pub async fn extract_video_audio(state: state_type!(), video_id: i64) -> Result<
         .await
         .map_err(|e| format!("Failed to get video: {}", e))?;
 
-    let video_path = PathBuf::from(&video.file);
+    let output_dir = PathBuf::from(&state.config.read().await.output);
+    let video_path = resolve_video_path(&output_dir, &video.file);
     if !video_path.exists() {
-        return Err("Video file not found".to_string());
+        return Err(format!("Video file not found: {}", video_path.display()));
     }
 
     // Determine output path
-    let output_dir = PathBuf::from(&state.config.read().await.output);
     let output_filename = format!(
         "audio_{}_{}.mp3",
         video.id,
@@ -764,4 +782,30 @@ pub async fn get_archive_metadata(
         "created_at": archive.created_at,
         "video_metadata": video_metadata,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_video_paths_are_resolved_from_output_directory() {
+        let output_dir = Path::new("/configured/output");
+        assert_eq!(
+            resolve_video_path(output_dir, "clip.mp4"),
+            output_dir.join("clip.mp4")
+        );
+    }
+
+    #[test]
+    fn absolute_video_paths_are_preserved() {
+        let video_path = std::env::temp_dir().join("clip.mp4");
+        assert_eq!(
+            resolve_video_path(
+                Path::new("/configured/output"),
+                video_path.to_str().unwrap()
+            ),
+            video_path
+        );
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod agent;
 mod audio_utils;
 mod config;
 mod constants;
@@ -726,6 +727,7 @@ fn setup_invoke_handlers(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<
         crate::handlers::video_editing::search_danmu_keywords,
         crate::handlers::video_editing::merge_videos,
         crate::handlers::video_editing::extract_video_audio,
+        crate::agent::agent_chat,
     ])
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+#[cfg(feature = "gui")]
 mod agent;
 mod audio_utils;
 mod config;
@@ -15,6 +16,7 @@ mod migration;
 mod progress;
 mod recorder_manager;
 mod state;
+#[cfg(feature = "gui")]
 mod static_server;
 mod subtitle_generator;
 mod task;
@@ -436,7 +438,7 @@ impl MigrationSource<'static> for MigrationList {
 async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Error>> {
     use std::path::PathBuf;
 
-    use crate::{constants::API_PORT, static_server::StaticServer, task::TaskManager};
+    use crate::task::TaskManager;
     use progress::progress_manager::ProgressManager;
     use progress::progress_reporter::EventEmitter;
 
@@ -494,11 +496,6 @@ async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Err
         webhook_poster.clone(),
     ));
 
-    // In headless/Docker, cache and output are served from the API server (API_PORT), so no
-    // separate static server is needed and only one port need be exposed. Use a dedicated
-    // constructor to make this intent explicit.
-    let static_server = Arc::new(StaticServer::headless(API_PORT));
-
     let _ = try_rebuild_archives(&db, config.read().await.cache.clone().into()).await;
     let _ = try_convert_live_covers(&db, config.read().await.cache.clone().into()).await;
     let _ = try_convert_clip_covers(&db, config.read().await.output.clone().into()).await;
@@ -511,7 +508,6 @@ async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Err
         webhook_poster,
         recorder_manager,
         task_manager,
-        static_server,
         progress_manager,
         readonly: args.readonly,
     })

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4,6 +4,7 @@ use tokio::sync::RwLock;
 use crate::config::Config;
 use crate::database::Database;
 use crate::recorder_manager::RecorderManager;
+#[cfg(feature = "gui")]
 use crate::static_server::StaticServer;
 use crate::task::TaskManager;
 use crate::webhook::poster::WebhookPoster;
@@ -18,6 +19,7 @@ pub struct State {
     pub webhook_poster: WebhookPoster,
     pub recorder_manager: Arc<RecorderManager>,
     pub task_manager: Arc<TaskManager>,
+    #[cfg(feature = "gui")]
     pub static_server: Arc<StaticServer>,
     #[cfg(not(feature = "headless"))]
     pub app_handle: tauri::AppHandle,

--- a/src-tauri/src/static_server/mod.rs
+++ b/src-tauri/src/static_server/mod.rs
@@ -12,19 +12,6 @@ pub struct StaticServer {
     pub port: u16,
 }
 
-impl StaticServer {
-    /// Create a StaticServer instance for environments where the actual static
-    /// files are served by the API server (e.g. headless/Docker). The handle is
-    /// a no-op task used only to satisfy the existing interface.
-    #[cfg(feature = "headless")]
-    pub fn headless(port: u16) -> Self {
-        Self {
-            handle: tokio::spawn(async {}),
-            port,
-        }
-    }
-}
-
 pub async fn start_static_server(
     config: Arc<RwLock<Config>>,
 ) -> Result<StaticServer, Box<dyn std::error::Error>> {

--- a/src-tauri/src/subtitle_generator/whisper_cpp.rs
+++ b/src-tauri/src/subtitle_generator/whisper_cpp.rs
@@ -145,19 +145,6 @@ impl SubtitleGenerator for WhisperCPP {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::progress::progress_reporter::ProgressReporterTrait;
-
-    #[derive(Clone)]
-    struct TestReporter;
-    #[async_trait]
-    impl ProgressReporterTrait for TestReporter {
-        async fn update(&self, msg: &str) {
-            println!("  [{msg}]");
-        }
-        async fn finish(&self, success: bool, msg: &str) {
-            println!("  finish({success}): {msg}");
-        }
-    }
 
     /// Run whisper on test audio and validate output.
     async fn run_whisper_test(max_len: i32) -> Vec<srtparse::Item> {

--- a/src/lib/agent/agent.ts
+++ b/src/lib/agent/agent.ts
@@ -2,9 +2,9 @@ import { invoke } from "../invoker";
 import {
   isAssistantMessage,
   isToolMessage,
+  normalizeToolCalls,
   type AssistantMessage,
   type ChatMessage,
-  type ToolCall,
 } from "./messages";
 
 export interface AgentConfig {
@@ -16,7 +16,7 @@ export interface AgentConfig {
 
 interface AgentChatResponse {
   content: string;
-  toolCalls?: ToolCall[];
+  toolCalls?: unknown;
   error?: string | null;
 }
 
@@ -97,7 +97,7 @@ export async function agentChat(
       ? `❌ **LLM API 错误**\n\n${response.error}`
       : response.content,
     timestamp: new Date().toISOString(),
-    toolCalls: response.toolCalls ?? [],
+    toolCalls: normalizeToolCalls(response.toolCalls),
     isError: Boolean(response.error),
   };
 }

--- a/src/lib/agent/agent.ts
+++ b/src/lib/agent/agent.ts
@@ -1,202 +1,103 @@
-import { createReactAgent } from "@langchain/langgraph/prebuilt";
-import { MemorySaver } from "@langchain/langgraph/web";
-import { ChatOpenAI } from "@langchain/openai";
-import { ChatOllama } from "@langchain/ollama";
-import { tools } from "./tools";
-
-const PROMPT = `
-你是一位虚拟助手，昵称叫小轴，喜欢的水果是橘子，你习惯使用 emoji 来表示你的情绪。你拥有许多来自 BiliBili ShadowReplay（简称 BSR，是一个缓存直播并进行实时编辑投稿的工具）的工具可以使用，请根据用户的需求使用工具来管理 BSR。
-
-## 基础概念
-在 BSR 中，Recorder 指代正在被 BSR 监控的直播间；Archive 指代已经缓存的录播，也可能是正在进行的直播；Video/Clip 指代用户从 Archive 中区间选择生成的视频。
-BSR 中可以监控多个直播间，直播间只有一个对应的主播，一个直播间可以有多个录播，一个录播可以有多个视频切片。
-用户提到的"直播"可能是广义的，也可能是狭义的，广义的直播包括录播，狭义的直播指正在进行的直播。
-
-## 视频编辑与制作标准操作流程 (SOP)
-
-你现在具备专业的视频编辑能力。当用户要求你编辑或制作视频时，请严格遵循以下 SOP：
-
-### 场景 1: 从直播/录播中剪辑精彩片段
-
-**步骤 1: 信息收集 (Information Gathering)**
-- 使用 get_recorder_list 获取所有监控的直播间（如果用户没有指定）
-- 使用 get_archives 或 get_recent_record 获取可用的录播列表
-- 使用 get_archive 获取目标录播的详细信息（标题、时长、创建时间）
-- 使用 get_archive_metadata 获取技术信息（文件大小、视频质量）
-
-**步骤 2: 内容分析 (Content Analysis)**
-必须执行以下分析来做出数据驱动的剪辑决策：
-
-a) 字幕生成与分析（必须）：
-   - 使用 get_archive_subtitle 尝试获取字幕
-   - 如果字幕不存在，使用 generate_archive_subtitle 生成字幕
-   - 分析字幕内容，寻找：
-     * 有趣的对话和笑点
-     * 技术操作和精彩表现
-     * 情绪高涨的时刻
-     * 观众可能感兴趣的话题
-   - 记录所有潜在精彩时刻的时间戳
-
-b) 弹幕密度分析（必须）：
-   - 使用 analyze_danmu_highlights 分析弹幕密度
-   - 参数建议：time_window=30（30秒窗口），min_density=10（至少10条弹幕）
-   - 高弹幕密度 = 高观众互动 = 可能的精彩时刻
-   - 记录所有高密度时间段
-
-c) 关键词搜索（必须）：
-   - 使用 search_danmu_keywords 搜索精彩内容指示词
-   - 推荐关键词：["精彩", "666", "牛", "笑死", "哈哈", "卧槽", "绝了", "高光"]
-   - 参数建议：context_seconds=10（前后各10秒上下文）
-   - 关键词出现 = 观众认可的精彩时刻
-
-d) 交叉验证：
-   - 将字幕分析、弹幕密度、关键词搜索的结果进行交叉对比
-   - 找出三者重合或两者重合的时间段，这些是最有价值的片段
-
-**步骤 3: 决策制定 (Decision Making)**
-基于分析结果，确定剪辑时间点：
-- 优先选择：字幕有趣 + 弹幕密度高 + 关键词出现的时间段（三重验证）
-- 次优选择：字幕有趣 + 弹幕密度高 或 字幕有趣 + 关键词出现（双重验证）
-- 保底选择：弹幕密度高 + 关键词出现的时间段
-- 每个片段建议长度：30秒 - 3分钟（根据内容调整）
-- 片段前后各留 2-5 秒缓冲，避免剪辑过于突兀
-- 确保片段有完整的上下文（对话完整、操作完整）
-
-**步骤 4: 视觉验证 (Visual Verification - 可选)**
-如果需要确认画面内容：
-- 使用 extract_video_frames 提取关键时间点的帧
-- 参数：timestamps=[确定的时间点数组]
-- 检查画面是否符合预期（避免黑屏、加载画面等）
-
-**步骤 5: 执行剪辑 (Execution)**
-使用 clip_range 工具：
-- 支持单个或多个片段（通过 ranges 数组传入多个时间段）
-- 提供清晰的 reason 说明为什么选择这些时间段
-- 设置 danmu=false（除非用户明确要求弹幕）
-- 设置 fix_encoding=false（除非视频有编码问题）
-- 多个片段时可选择转场效果（transition）：'none'(直接切换), 'fade'(淡入淡出), 'dissolve'(溶解), 'wipeleft'(左擦除), 'wiperight'(右擦除), 'slideup'(上滑), 'slidedown'(下滑)
-- 默认为 'none'，根据内容风格选择合适的转场
-
-**步骤 6: 后期处理 (Post-Production - 可选)**
-根据用户需求：
-- 使用 merge_videos 将多个已有视频合并成合集
-  * 可选择转场效果：'none'(直接切换), 'fade'(淡入淡出), 'dissolve'(溶解), 'wipeleft'(左擦除), 'wiperight'(右擦除), 'slideup'(上滑), 'slidedown'(下滑)
-  * 默认为 'none'，根据内容风格选择合适的转场
-- 使用 extract_video_audio 提取音频（如果需要单独的音频文件）
-
-**步骤 7: 结果报告 (Reporting)**
-向用户报告：
-- 字幕分析结果（发现了哪些有趣内容）
-- 分析了多少条弹幕
-- 发现了多少个高光时刻
-- 最终剪辑了几个片段，每个片段的时间范围和选择原因
-- 使用 markdown 表格清晰展示结果，包含：
-  * 片段编号
-  * 时间范围（开始-结束）
-  * 时长
-  * 选择原因（字幕内容 + 弹幕密度 + 关键词）
-  * 精彩程度评分（基于三重验证结果）
-
-### 场景 2: 编辑已有视频
-
-**步骤 1: 获取视频信息**
-- 使用 get_videos 或 get_all_videos 列出可用视频
-- 使用 get_video 获取目标视频详情
-- 使用 get_video_metadata 获取技术参数
-
-**步骤 2: 分析视频内容**
-- 使用 extract_video_frames 提取关键帧查看内容
-- 使用 get_video_subtitle 获取字幕（如果有）
-
-**步骤 3: 执行编辑操作**
-- 合并视频：使用 merge_videos（可选择转场效果：fade/dissolve/wipeleft/wiperight/slideup/slidedown）
-- 提取音频：使用 extract_video_audio
-- 重新剪辑：需要先找到原始 archive，然后按场景1流程操作
-
-### 场景 3: 制作视频合集
-
-**步骤 1: 收集素材**
-- 使用 get_all_videos 获取所有可用视频
-- 根据主题、时间、主播等筛选相关视频
-
-**步骤 2: 排序规划**
-- 确定视频播放顺序（时间顺序、精彩程度、主题相关性等）
-- 考虑总时长（建议合集不超过10分钟）
-
-**步骤 3: 执行合并**
-- 使用 merge_videos 按顺序合并
-- 根据内容风格选择合适的转场效果（娱乐向推荐 fade/dissolve，快节奏推荐 wipe/slide，严肃内容推荐 none）
-- 提供有意义的标题和说明
-
-## 关键原则
-
-1. **数据驱动决策**：永远基于弹幕分析和关键词搜索做剪辑决策，不要凭空猜测
-2. **效率优先**：clip_range 支持多个 ranges，一次调用即可剪辑多个片段
-3. **用户体验**：剪辑片段要有上下文，避免过于突兀
-4. **透明沟通**：向用户解释你的分析过程和决策依据
-5. **时间格式**：所有时间都用人类可读格式（如 "1分40秒" 而不是 "100秒"）
-6. **表格展示**：使用 markdown 表格展示分析结果，清晰易读
-
-## 工具使用优先级
-
-剪辑精彩片段时的工具调用顺序：
-1. get_archive (必须) → 了解基本信息
-2. get_archive_subtitle (必须) → 获取字幕，如果不存在则调用 generate_archive_subtitle
-3. generate_archive_subtitle (条件必须) → 如果字幕不存在，必须生成
-4. analyze_danmu_highlights (必须) → 找出高互动时刻
-5. search_danmu_keywords (必须) → 验证精彩内容
-6. extract_video_frames (可选) → 视觉验证
-7. clip_range (推荐) → 执行剪辑，支持单个或多个 ranges，可选择转场效果（transition: none/fade/dissolve/wipeleft/wiperight/slideup/slidedown）
-8. merge_videos (可选) → 合并已有视频，可选择转场效果（transition: none/fade/dissolve/wipeleft/wiperight/slideup/slidedown）
-
-## 通用规则
-当用户询问最近的直播时，你不仅应该返回正在进行的直播，还应该返回已经缓存的录播。
-当涉及到时间（多少秒）时，尽量转换成人类可读的格式，比如 100 秒转换成 1 分 40 秒。
-If user not provide room id but a streamer name, you should use the tool get_recorder_list to get the room id of the streamer.
-You should always try to use markdown table to show the data in tool response.
-You MUST avoid using images in your response unless you are analyzing video frames.
-Before you response, you should always treat previous messages as outdated.
-`;
+import { invoke } from "../invoker";
+import {
+  isAssistantMessage,
+  isToolMessage,
+  type AssistantMessage,
+  type ChatMessage,
+  type ToolCall,
+} from "./messages";
 
 export interface AgentConfig {
-  provider: 'openai' | 'ollama';
+  provider: "openai" | "ollama";
   apiKey?: string;
   baseURL?: string;
   model?: string;
 }
 
-function createAgent(config: AgentConfig) {
-  let agentModel: ChatOpenAI | ChatOllama;
-
-  if (config.provider === 'ollama') {
-    agentModel = new ChatOllama({
-      baseUrl: config.baseURL || 'http://localhost:11434',
-      model: config.model || 'llama2',
-    });
-  } else {
-    agentModel = new ChatOpenAI({
-      apiKey: config.apiKey,
-      configuration: {
-        baseURL: config.baseURL,
-      },
-      model: config.model,
-    });
-  }
-
-  const agentModelWithTools = agentModel.bindTools(tools, {
-    parallel_tool_calls: false,
-  });
-
-  const agentCheckpointer = new MemorySaver();
-  const agent = createReactAgent({
-    llm: agentModelWithTools,
-    checkpointSaver: agentCheckpointer,
-    interruptBefore: ["tools"],
-    prompt: PROMPT,
-    tools: tools,
-  });
-
-  return agent;
+interface AgentChatResponse {
+  content: string;
+  toolCalls?: ToolCall[];
+  error?: string | null;
 }
 
-export default createAgent;
+function contentText(message: ChatMessage): string {
+  return typeof message.content === "string"
+    ? message.content
+    : JSON.stringify(message.content);
+}
+
+/**
+ * Sends the complete visible conversation to the stateless Rust agent.
+ * Read-only tool traces are display-only; pending calls and their results are
+ * retained as protocol messages so the model can continue after confirmation.
+ */
+export async function agentChat(
+  config: AgentConfig,
+  conversation: ChatMessage[],
+): Promise<AssistantMessage> {
+  const toolResultIds = new Set(
+    conversation.filter(isToolMessage).map((message) => message.toolCallId),
+  );
+  const protocolToolCallIds = new Set(
+    conversation.flatMap((message) =>
+      isAssistantMessage(message)
+        ? message.toolCalls
+            .filter(
+              (call) => call.executed === false || toolResultIds.has(call.id),
+            )
+            .map((call) => call.id)
+        : [],
+    ),
+  );
+
+  const messages = conversation
+    .filter((message) => {
+      if (isToolMessage(message)) {
+        return protocolToolCallIds.has(message.toolCallId);
+      }
+      return !(
+        isAssistantMessage(message) &&
+        message.isError === true &&
+        !message.toolCalls.some((call) => call.executed === false)
+      );
+    })
+    .map((message) => {
+      if (message.kind === "human") {
+        return { role: "user", content: message.content };
+      }
+      if (message.kind === "tool") {
+        return {
+          role: "tool",
+          content: contentText(message),
+          toolCallId: message.toolCallId,
+        };
+      }
+      return {
+        role: "assistant",
+        content: message.isError ? "" : contentText(message),
+        toolCalls: message.toolCalls
+          .filter((call) => protocolToolCallIds.has(call.id))
+          .map(({ id, name, args }) => ({ id, name, args })),
+      };
+    });
+
+  const response = await invoke<AgentChatResponse>("agent_chat", {
+    request: {
+      provider: config.provider,
+      endpoint: config.baseURL || "",
+      apiKey: config.apiKey,
+      model: config.model || (config.provider === "ollama" ? "llama2" : ""),
+      messages,
+    },
+  });
+
+  return {
+    kind: "assistant",
+    content: response.error
+      ? `❌ **LLM API 错误**\n\n${response.error}`
+      : response.content,
+    timestamp: new Date().toISOString(),
+    toolCalls: response.toolCalls ?? [],
+    isError: Boolean(response.error),
+  };
+}

--- a/src/lib/agent/messages.ts
+++ b/src/lib/agent/messages.ts
@@ -1,0 +1,158 @@
+export type MessageContent = string | unknown[];
+
+export interface ToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  executed: boolean;
+  error?: string | null;
+}
+
+export interface HumanMessage {
+  kind: "human";
+  content: string;
+  timestamp: string;
+}
+
+export interface AssistantMessage {
+  kind: "assistant";
+  content: MessageContent;
+  timestamp: string;
+  toolCalls: ToolCall[];
+  isError?: boolean;
+}
+
+export interface ToolMessage {
+  kind: "tool";
+  content: MessageContent;
+  timestamp: string;
+  name: string;
+  toolCallId: string;
+  status: "success" | "error";
+  resolution: "confirmed" | "rejected";
+}
+
+export type ChatMessage = HumanMessage | AssistantMessage | ToolMessage;
+
+export function isAssistantMessage(
+  message: ChatMessage,
+): message is AssistantMessage {
+  return message.kind === "assistant";
+}
+
+export function isToolMessage(message: ChatMessage): message is ToolMessage {
+  return message.kind === "tool";
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function messageContent(value: unknown): MessageContent {
+  if (typeof value === "string" || Array.isArray(value)) return value;
+  return value == null ? "" : JSON.stringify(value);
+}
+
+function timestamp(value: unknown): string {
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function toolCalls(value: unknown): ToolCall[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((raw): ToolCall[] => {
+    if (!isRecord(raw) || !raw.id || !raw.name) return [];
+    return [{
+      id: String(raw.id),
+      name: String(raw.name),
+      args: isRecord(raw.args) ? raw.args : {},
+      executed: raw.executed !== false,
+      error: raw.error == null ? null : String(raw.error),
+    }];
+  });
+}
+
+function wasRejected(content: MessageContent): boolean {
+  if (typeof content !== "string") return false;
+  try {
+    const value = JSON.parse(content);
+    return isRecord(value) && value.rejected === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reads both the current message shape and the former persisted format.
+ * Legacy fields are normalized here and never leak into the application.
+ */
+export function deserializeMessages(stored: unknown): ChatMessage[] {
+  if (!Array.isArray(stored)) return [];
+
+  return stored.flatMap((raw): ChatMessage[] => {
+    if (!isRecord(raw)) return [];
+
+    const fields = isRecord(raw.kwargs) ? raw.kwargs : raw;
+    const legacyId = Array.isArray(raw.id) ? raw.id.join("/") : String(raw.id ?? "");
+    const kind = raw.kind ??
+      (legacyId.includes("HumanMessage")
+        ? "human"
+        : legacyId.includes("AIMessage")
+          ? "assistant"
+          : legacyId.includes("ToolMessage")
+            ? "tool"
+            : undefined);
+    const additional = isRecord(fields.additional_kwargs)
+      ? fields.additional_kwargs
+      : isRecord(raw.additional_kwargs)
+        ? raw.additional_kwargs
+        : {};
+    const savedTimestamp = fields.timestamp ?? raw.timestamp ?? additional.timestamp;
+
+    if (kind === "human") {
+      const content = messageContent(fields.content ?? raw.content);
+      return [{
+        kind: "human",
+        content: typeof content === "string" ? content : JSON.stringify(content),
+        timestamp: timestamp(savedTimestamp),
+      }];
+    }
+
+    if (kind === "assistant") {
+      return [{
+        kind: "assistant",
+        content: messageContent(fields.content ?? raw.content),
+        timestamp: timestamp(savedTimestamp),
+        toolCalls: toolCalls(
+          fields.toolCalls ?? raw.toolCalls ?? fields.tool_calls ?? raw.tool_calls,
+        ),
+        isError: fields.isError === true || raw.isError === true || additional.isError === true,
+      }];
+    }
+
+    if (kind === "tool") {
+      const toolCallId = fields.toolCallId ?? raw.toolCallId ??
+        fields.tool_call_id ?? raw.tool_call_id;
+      if (!toolCallId) return [];
+      const content = messageContent(fields.content ?? raw.content);
+      const resolution = fields.resolution ?? raw.resolution;
+      return [{
+        kind: "tool",
+        content,
+        timestamp: timestamp(savedTimestamp),
+        name: String(fields.name ?? raw.name ?? "未知工具"),
+        toolCallId: String(toolCallId),
+        status: fields.status === "error" || raw.status === "error" ? "error" : "success",
+        resolution: resolution === "rejected" || wasRejected(content)
+          ? "rejected"
+          : "confirmed",
+      }];
+    }
+
+    return [];
+  });
+}

--- a/src/lib/agent/messages.ts
+++ b/src/lib/agent/messages.ts
@@ -34,6 +34,126 @@ export interface ToolMessage {
 
 export type ChatMessage = HumanMessage | AssistantMessage | ToolMessage;
 
+export interface MessageTextPart {
+  kind: "text";
+  text: string;
+  format: "markdown" | "json";
+}
+
+export interface MessageImagePart {
+  kind: "image";
+  src: string;
+  alt: string;
+}
+
+export type MessageDisplayPart = MessageTextPart | MessageImagePart;
+
+function imageDisplayPart(value: unknown): MessageImagePart | null {
+  if (!isRecord(value)) return null;
+
+  const type = typeof value.type === "string" ? value.type.toLowerCase() : "";
+  const mimeType = typeof value.mimeType === "string"
+    ? value.mimeType
+    : typeof value.mime_type === "string"
+      ? value.mime_type
+      : "";
+  const imageUrl = isRecord(value.image_url)
+    ? value.image_url.url
+    : value.image_url;
+  const source = typeof value.data === "string"
+    ? value.data
+    : typeof value.image_base64 === "string"
+      ? value.image_base64
+      : typeof imageUrl === "string"
+        ? imageUrl
+        : null;
+
+  if (!source) return null;
+  const isImage = type === "image" || type === "image_url" ||
+    typeof value.image_base64 === "string" ||
+    mimeType.startsWith("image/") || source.startsWith("data:image/");
+  if (!isImage) return null;
+
+  const safeMimeType = /^image\/[a-z0-9.+-]+$/i.test(mimeType)
+    ? mimeType
+    : "image/jpeg";
+  const src = source.startsWith("data:") || /^(https?:|blob:)/.test(source)
+    ? source
+    : `data:${safeMimeType};base64,${source}`;
+
+  return {
+    kind: "image",
+    src,
+    alt: typeof value.alt === "string" ? value.alt : "消息图片",
+  };
+}
+
+function displayPartsFromValue(value: unknown): MessageDisplayPart[] {
+  if (typeof value === "string") {
+    return [{ kind: "text", text: value, format: "markdown" }];
+  }
+  if (Array.isArray(value)) return value.flatMap(displayPartsFromValue);
+
+  const image = imageDisplayPart(value);
+  if (image) return [image];
+  const structured = structuredImageParts(value);
+  if (structured) return structured;
+
+  if (isRecord(value) && value.type === "text" && typeof value.text === "string") {
+    return [{ kind: "text", text: value.text, format: "markdown" }];
+  }
+
+  return [{
+    kind: "text",
+    text: JSON.stringify(value, null, 2) ?? String(value),
+    format: "json",
+  }];
+}
+
+function structuredImageParts(value: unknown): MessageDisplayPart[] | null {
+  if (!isRecord(value) || !Array.isArray(value.parts)) return null;
+
+  const parts = value.parts.flatMap(displayPartsFromValue);
+  if (!parts.some((part) => part.kind === "image")) return null;
+
+  const summary = Object.fromEntries(
+    Object.entries(value).filter(([key]) => key !== "parts"),
+  );
+  if (Object.keys(summary).length === 0) return parts;
+
+  return [{
+    kind: "text",
+    text: JSON.stringify(summary, null, 2),
+    format: "json",
+  }, ...parts];
+}
+
+export function messageContentToDisplayParts(
+  content: MessageContent,
+): MessageDisplayPart[] {
+  if (Array.isArray(content)) return content.flatMap(displayPartsFromValue);
+
+  try {
+    const structured = structuredImageParts(JSON.parse(content));
+    if (structured) return structured;
+  } catch {
+    // Ordinary message text is not expected to be valid JSON.
+  }
+
+  return [{ kind: "text", text: content, format: "markdown" }];
+}
+
+export function messageContentToMarkdown(content: MessageContent): string {
+  return messageContentToDisplayParts(content)
+    .map((part) => {
+      if (part.kind === "image") return `![${part.alt}](${part.src})`;
+      return part.format === "json"
+        ? `\`\`\`json\n${part.text}\n\`\`\``
+        : part.text;
+    })
+    .join("\n\n");
+}
+
 export function isAssistantMessage(
   message: ChatMessage,
 ): message is AssistantMessage {

--- a/src/lib/agent/messages.ts
+++ b/src/lib/agent/messages.ts
@@ -48,6 +48,42 @@ function isRecord(value: unknown): value is Record<string, any> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+export function normalizeToolArguments(value: unknown): Record<string, unknown> {
+  let parsed = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  if (!isRecord(parsed)) return {};
+
+  return normalizeArgumentValue(parsed) as Record<string, unknown>;
+}
+
+function snakeCaseKey(key: string): string {
+  return key.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function normalizeArgumentValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeArgumentValue);
+  if (!isRecord(value)) return value;
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value)) {
+    const canonical = snakeCaseKey(key);
+    if (canonical === key) normalized[canonical] = normalizeArgumentValue(item);
+  }
+  for (const [key, item] of Object.entries(value)) {
+    const canonical = snakeCaseKey(key);
+    if (!(canonical in normalized)) {
+      normalized[canonical] = normalizeArgumentValue(item);
+    }
+  }
+  return normalized;
+}
+
 function messageContent(value: unknown): MessageContent {
   if (typeof value === "string" || Array.isArray(value)) return value;
   return value == null ? "" : JSON.stringify(value);
@@ -61,7 +97,7 @@ function timestamp(value: unknown): string {
   return new Date().toISOString();
 }
 
-function toolCalls(value: unknown): ToolCall[] {
+export function normalizeToolCalls(value: unknown): ToolCall[] {
   if (!Array.isArray(value)) return [];
 
   return value.flatMap((raw): ToolCall[] => {
@@ -69,7 +105,7 @@ function toolCalls(value: unknown): ToolCall[] {
     return [{
       id: String(raw.id),
       name: String(raw.name),
-      args: isRecord(raw.args) ? raw.args : {},
+      args: normalizeToolArguments(raw.args),
       executed: raw.executed !== false,
       error: raw.error == null ? null : String(raw.error),
     }];
@@ -127,7 +163,7 @@ export function deserializeMessages(stored: unknown): ChatMessage[] {
         kind: "assistant",
         content: messageContent(fields.content ?? raw.content),
         timestamp: timestamp(savedTimestamp),
-        toolCalls: toolCalls(
+        toolCalls: normalizeToolCalls(
           fields.toolCalls ?? raw.toolCalls ?? fields.tool_calls ?? raw.tool_calls,
         ),
         isError: fields.isError === true || raw.isError === true || additional.isError === true,

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -4,9 +4,15 @@ import {
   generateEventId,
   type ClipRangeParams,
 } from "../interface";
+import { normalizeToolArguments } from "./messages";
 
 type ToolArguments = Record<string, unknown>;
 type ToolExecutor = (args: ToolArguments) => Promise<unknown>;
+
+interface ExtractedVideoFrame {
+  timestamp: number;
+  image_base64: string;
+}
 
 function executor<T extends ToolArguments>(
   implementation: (args: T) => Promise<unknown>,
@@ -152,11 +158,33 @@ const confirmedToolExecutors: Record<string, ToolExecutor> = {
       video_id: number;
       timestamps?: number[];
       max_frames?: number;
-    }) => invoke("extract_video_frames", {
-      videoId: video_id,
-      timestamps: timestamps ?? [],
-      maxFrames: max_frames ?? 10,
-    }),
+    }) => {
+      const frames = await invoke<ExtractedVideoFrame[]>(
+        "extract_video_frames",
+        {
+          videoId: video_id,
+          timestamps: timestamps ?? [],
+          maxFrames: max_frames ?? 10,
+        },
+      );
+
+      // Rig recognizes this response/parts shape as a multimodal tool result.
+      // The Rust bridge keeps the response as the tool result required by the
+      // provider protocol and sends the parts as a following image message.
+      return {
+        response: {
+          tool: "extract_video_frames",
+          video_id,
+          frame_count: frames.length,
+          frames: frames.map(({ timestamp }, index) => ({ index, timestamp })),
+        },
+        parts: frames.map(({ image_base64 }) => ({
+          type: "image",
+          data: image_base64,
+          mimeType: "image/jpeg",
+        })),
+      };
+    },
   ),
 
   get_video_metadata: executor(
@@ -198,11 +226,11 @@ const confirmedToolExecutors: Record<string, ToolExecutor> = {
 
 export async function invokeToolByName(
   name: string,
-  args: ToolArguments,
+  args: unknown,
 ): Promise<unknown> {
   const selectedTool = confirmedToolExecutors[name];
   if (!selectedTool) {
     throw new Error(`Tool ${name} is not available for frontend confirmation`);
   }
-  return selectedTool(args);
+  return selectedTool(normalizeToolArguments(args));
 }

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1,1116 +1,208 @@
-import { tool } from "@langchain/core/tools";
-import { z } from "zod";
 import { invoke } from "../invoker";
 import {
   default_profile,
   generateEventId,
   type ClipRangeParams,
-  type Profile,
 } from "../interface";
 
-const platform_list = ["bilibili", "douyin"];
+type ToolArguments = Record<string, unknown>;
+type ToolExecutor = (args: ToolArguments) => Promise<unknown>;
 
-// @ts-ignore
-const get_accounts = tool(
-  async () => {
-    const result = (await invoke("get_accounts")) as any;
-    // hide cookies in result
-    return {
-      accounts: result.accounts.map((a: any) => {
-        return {
-          ...a,
-          cookies: "********",
-        };
-      }),
-    };
-  },
-  {
-    name: "get_accounts",
-    description: "Get all available accounts",
-    schema: z.object({}),
-  }
-);
+function executor<T extends ToolArguments>(
+  implementation: (args: T) => Promise<unknown>,
+): ToolExecutor {
+  return (args) => implementation(args as T);
+}
 
-// @ts-ignore
-const remove_account = tool(
-  async ({ platform, uid }: { platform: string; uid: number }) => {
-    const result = await invoke("remove_account", {
-      platform,
-      uid,
-    });
-    return result;
-  },
-  {
-    name: "remove_account",
-    description: "Remove an account",
-    schema: z.object({
-      platform: z
-        .string()
-        .describe(
-          `The platform of the account. Can be ${platform_list.join(", ")}`
-        ),
-      uid: z.number().describe("The uid of the account"),
-    }),
-  }
-);
+const confirmedToolExecutors: Record<string, ToolExecutor> = {
+  remove_account: executor(
+    async ({ platform, uid }: { platform: string; uid: number }) =>
+      invoke("remove_account", { platform, uid }),
+  ),
 
-// @ts-ignore
-const add_recorder = tool(
-  async ({
-    platform,
-    room_id,
-    extra,
-  }: {
-    platform: string;
-    room_id: string;
-    extra: string;
-  }) => {
-    const result = await invoke("add_recorder", {
-      platform,
-      roomId: room_id,
-      extra,
-    });
-    return result;
-  },
-  {
-    name: "add_recorder",
-    description: "Add a recorder",
-    schema: z.object({
-      platform: z
-        .string()
-        .describe(
-          `The platform of the recorder. Can be ${platform_list.join(", ")}`
-        ),
-      room_id: z.string().describe("The room id of the recorder"),
-      extra: z
-        .string()
-        .describe(
-          "The extra of the recorder, should be empty for bilibili, and the sec_user_id for douyin"
-        ),
-    }),
-  }
-);
+  add_recorder: executor(
+    async ({ platform, room_id, extra }: {
+      platform: string;
+      room_id: string;
+      extra: string;
+    }) => invoke("add_recorder", { platform, roomId: room_id, extra }),
+  ),
 
-// @ts-ignore
-const remove_recorder = tool(
-  async ({ platform, room_id }: { platform: string; room_id: string }) => {
-    const result = await invoke("remove_recorder", {
-      platform,
-      roomId: room_id,
-    });
-    return result;
-  },
-  {
-    name: "remove_recorder",
-    description: "Remove a recorder",
-    schema: z.object({
-      platform: z
-        .string()
-        .describe(
-          `The platform of the recorder. Can be ${platform_list.join(", ")}`
-        ),
-      room_id: z.string().describe("The room id of the recorder"),
-    }),
-  }
-);
+  remove_recorder: executor(
+    async ({ platform, room_id }: { platform: string; room_id: string }) =>
+      invoke("remove_recorder", { platform, roomId: room_id }),
+  ),
 
-// @ts-ignore
-const get_recorder_list = tool(
-  async () => {
-    const result = await invoke("get_recorder_list");
-    return result;
-  },
-  {
-    name: "get_recorder_list",
-    description: "Get the list of all available recorders",
-    schema: z.object({}),
-  }
-);
-
-// @ts-ignore
-const get_recorder_info = tool(
-  async ({ platform, room_id }: { platform: string; room_id: string }) => {
-    const result = await invoke("get_room_info", { platform, roomId: room_id });
-    return result;
-  },
-  {
-    name: "get_recorder_info",
-    description: "Get the info of a recorder",
-    schema: z.object({
-      platform: z.string().describe("The platform of the room"),
-      room_id: z.string().describe("The room id of the room"),
-    }),
-  }
-);
-
-// @ts-ignore
-const get_archives = tool(
-  async ({
-    room_id,
-    offset,
-    limit,
-  }: {
-    room_id: string;
-    offset: number;
-    limit: number;
-  }) => {
-    const archives = (await invoke("get_archives", {
-      roomId: room_id,
-      offset,
-      limit,
-    })) as any[];
-    // hide cover in result
-    return {
-      archives: archives.map((a: any) => {
-        return {
-          ...a,
-          cover: null,
-          created_at: new Date(a.created_at).toLocaleString(),
-        };
-      }),
-    };
-  },
-  {
-    name: "get_archives",
-    description: "Get the list of all archives of a recorder",
-    schema: z.object({
-      room_id: z.string().describe("The room id of the recorder"),
-      offset: z.number().describe("The offset of the archives"),
-      limit: z.number().describe("The limit of the archives"),
-    }),
-  }
-);
-
-// @ts-ignore
-const get_archive = tool(
-  async ({ room_id, live_id }: { room_id: string; live_id: string }) => {
-    const result = (await invoke("get_archive", {
-      roomId: room_id,
-      liveId: live_id,
-    })) as any;
-    // hide cover in result, convert utc datetime to local datetime
-    return {
-      ...result,
-      cover: null,
-      created_at: new Date(result.created_at).toLocaleString(),
-    };
-  },
-  {
-    name: "get_archive",
-    description: "Get the info of a archive",
-    schema: z.object({
-      room_id: z.string().describe("The room id of the recorder"),
-      live_id: z.string().describe("The live id of the archive"),
-    }),
-  }
-);
-
-// @ts-ignore
-const delete_archive = tool(
-  async ({
-    platform,
-    room_id,
-    live_id,
-  }: {
-    platform: string;
-    room_id: string;
-    live_id: string;
-  }) => {
-    const result = await invoke("delete_archive", {
+  delete_archive: executor(
+    async ({ platform, room_id, live_id }: {
+      platform: string;
+      room_id: string;
+      live_id: string;
+    }) => invoke("delete_archive", {
       platform,
       roomId: room_id,
       liveId: live_id,
-    });
-    return result;
-  },
-  {
-    name: "delete_archive",
-    description: "Delete an archive",
-    schema: z.object({
-      platform: z
-        .string()
-        .describe(
-          `The platform of the recorder. Can be ${platform_list.join(", ")}`
-        ),
-      room_id: z.string().describe("The room id of the recorder"),
-      live_id: z.string().describe("The live id of the archive"),
     }),
-  }
-);
+  ),
 
-// @ts-ignore
-const delete_archives = tool(
-  async ({
-    platform,
-    room_id,
-    live_ids,
-  }: {
-    platform: string;
-    room_id: string;
-    live_ids: string[];
-  }) => {
-    const result = await invoke("delete_archives", {
+  delete_archives: executor(
+    async ({ platform, room_id, live_ids }: {
+      platform: string;
+      room_id: string;
+      live_ids: string[];
+    }) => invoke("delete_archives", {
       platform,
       roomId: room_id,
       liveIds: live_ids,
-    });
-    return result;
-  },
-  {
-    name: "delete_archives",
-    description: "Delete multiple archives",
-    schema: z.object({
-      platform: z
-        .string()
-        .describe(
-          `The platform of the recorder. Can be ${platform_list.join(", ")}`
-        ),
-      room_id: z.string().describe("The room id of the recorder"),
-      live_ids: z.array(z.string()).describe("The live ids of the archives"),
     }),
-  }
-);
+  ),
 
-// @ts-ignore
-const get_background_tasks = tool(
-  async () => {
-    const result = (await invoke("get_tasks")) as any[];
-    return {
-      tasks: result.map((t: any) => {
-        return {
-          ...t,
-          created_at: new Date(t.created_at).toLocaleString(),
-        };
-      }),
-    };
-  },
-  {
-    name: "get_background_tasks",
-    description: "Get the list of all background tasks",
-    schema: z.object({}),
-  }
-);
+  delete_background_task: executor(
+    async ({ id }: { id: string }) => invoke("delete_task", { id }),
+  ),
 
-// @ts-ignore
-const delete_background_task = tool(
-  async ({ id }: { id: string }) => {
-    const result = await invoke("delete_task", { id });
-    return result;
-  },
-  {
-    name: "delete_background_task",
-    description: "Delete a background task",
-    schema: z.object({
-      id: z.string().describe("The id of the task"),
-    }),
-  }
-);
+  get_video_cover: executor(async ({ id }: { id: number }) => ({
+    cover: await invoke("get_video_cover", { id }),
+  })),
 
-// @ts-ignore
-const get_videos = tool(
-  async ({ room_id }: { room_id: string }) => {
-    const result = (await invoke("get_videos", { roomId: room_id })) as any[];
-    return {
-      videos: result.map((v: any) => {
-        return {
-          ...v,
-          created_at: new Date(v.created_at).toLocaleString(),
-        };
-      }),
-    };
-  },
-  {
-    name: "get_videos",
-    description: "Get the list of all videos of a room",
-    schema: z.object({
-      room_id: z.string().describe("The room id of the room"),
-    }),
-  }
-);
+  delete_video: executor(
+    async ({ id }: { id: number }) => invoke("delete_video", { id }),
+  ),
 
-// @ts-ignore
-const get_all_videos = tool(
-  async () => {
-    const result = (await invoke("get_all_videos")) as any[];
-    return {
-      videos: result.map((v: any) => {
-        return {
-          ...v,
-          created_at: new Date(v.created_at).toLocaleString(),
-        };
-      }),
-    };
-  },
-  {
-    name: "get_all_videos",
-    description: "Get the list of all videos from all rooms",
-    schema: z.object({}),
-  }
-);
+  get_video_typelist: async () => invoke("get_video_typelist"),
 
-// @ts-ignore
-const get_video = tool(
-  async ({ id }: { id: number }) => {
-    const result = (await invoke("get_video", { id })) as any;
-    return {
-      video: {
-        ...result,
-        created_at: new Date(result.created_at).toLocaleString(),
-      },
-    };
-  },
-  {
-    name: "get_video",
-    description: "Get the info of a video",
-    schema: z.object({
-      id: z.number().describe("The id of the video"),
-    }),
-  }
-);
+  get_video_subtitle: executor(
+    async ({ id }: { id: number }) => invoke("get_video_subtitle", { id }),
+  ),
 
-// @ts-ignore
-const get_video_cover = tool(
-  async ({ id }: { id: number }) => {
-    const result = await invoke("get_video_cover", { id });
-    return {
-      cover: result,
-    };
-  },
-  {
-    name: "get_video_cover",
-    description: "Get the cover of a video in base64 format",
-    schema: z.object({
-      id: z.number().describe("The id of the video"),
-    }),
-  }
-);
+  generate_video_subtitle: executor(
+    async ({ id }: { id: number }) => invoke("generate_video_subtitle", { id }),
+  ),
 
-// @ts-ignore
-const delete_video = tool(
-  async ({ id }: { id: number }) => {
-    const result = await invoke("delete_video", { id });
-    return result;
-  },
-  {
-    name: "delete_video",
-    description: "Delete a video",
-    schema: z.object({
-      id: z.number().describe("The id of the video"),
-    }),
-  }
-);
+  encode_video_subtitle: executor(
+    async ({ id, srt_style }: { id: number; srt_style: string }) =>
+      invoke("encode_video_subtitle", { id, srtStyle: srt_style }),
+  ),
 
-// @ts-ignore
-const get_video_typelist = tool(
-  async () => {
-    const result = await invoke("get_video_typelist");
-    return result;
-  },
-  {
-    name: "get_video_typelist",
-    description:
-      "Get the list of all video types（视频分区） that can be selected on bilibili platform",
-    schema: z.object({}),
-  }
-);
-
-// @ts-ignore
-const get_video_subtitle = tool(
-  async ({ id }: { id: number }) => {
-    const result = await invoke("get_video_subtitle", { id });
-    return result;
-  },
-  {
-    name: "get_video_subtitle",
-    description:
-      "Get the subtitle of a video, if empty, you can use generate_video_subtitle to generate the subtitle",
-    schema: z.object({
-      id: z.number().describe("The id of the video"),
-    }),
-  }
-);
-
-// @ts-ignore
-const generate_video_subtitle = tool(
-  async ({ id }: { id: number }) => {
-    const result = await invoke("generate_video_subtitle", { id });
-    return result;
-  },
-  {
-    name: "generate_video_subtitle",
-    description: "Generate the subtitle of a video",
-    schema: z.object({
-      id: z.number().describe("The id of the video"),
-    }),
-  }
-);
-
-// @ts-ignore
-const encode_video_subtitle = tool(
-  async ({ id, srt_style }: { id: number; srt_style: string }) => {
-    const result = await invoke("encode_video_subtitle", {
-      id,
-      srtStyle: srt_style,
-    });
-    return result;
-  },
-  {
-    name: "encode_video_subtitle",
-    description: "Encode the subtitle of a video",
-    schema: z.object({
-      id: z.number().describe("The id of the video"),
-      srt_style: z
-        .string()
-        .describe(
-          "The style of the subtitle, it is used for ffmpeg -vf force_style, it must be a valid srt style"
-        ),
-    }),
-  }
-);
-
-// @ts-ignore
-const post_video_to_bilibili = tool(
-  async ({
-    uid,
-    room_id,
-    video_id,
-    title,
-    desc,
-    tag,
-    tid,
-  }: {
-    uid: number;
-    room_id: string;
-    video_id: number;
-    title: string;
-    desc: string;
-    tag: string;
-    tid: number;
-  }) => {
-    // invoke("upload_procedure", {
-    //   uid: uid_selected,
-    //   eventId: event_id,
-    //   roomId: roomId,
-    //   videoId: video.id,
-    //   cover: video.cover,
-    //   profile: profile,
-    // })
-    const event_id = generateEventId();
-    let profile = default_profile();
-    profile.title = title;
-    profile.desc = desc;
-    profile.tag = tag;
-    profile.tid = tid;
-    const result = await invoke("upload_procedure", {
-      uid,
-      eventId: event_id,
-      roomId: room_id,
-      videoId: video_id,
-      profile,
-    });
-    return result;
-  },
-  {
-    name: "post_video_to_bilibili",
-    description: "Post a video to bilibili",
-    schema: z.object({
-      uid: z
-        .number()
-        .describe(
-          "The uid of the user, it should be one of the uid in the bilibili accounts"
-        ),
-      room_id: z.string().describe("The room id of the room"),
-      video_id: z.number().describe("The id of the video"),
-      title: z.string().describe("The title of the video"),
-      desc: z.string().describe("The description of the video"),
-      tag: z
-        .string()
-        .describe(
-          "The tag of the video, multiple tags should be separated by comma"
-        ),
-      tid: z
-        .number()
-        .describe(
-          "The tid of the video, it is the id of the video type, you can use get_video_typelist to get the list of all video types"
-        ),
-    }),
-  }
-);
-
-// @ts-ignore
-const get_danmu_record = tool(
-  async ({
-    platform,
-    room_id,
-    live_id,
-  }: {
-    platform: string;
-    room_id: string;
-    live_id: string;
-  }) => {
-    const result = (await invoke("get_danmu_record", {
-      platform,
-      roomId: room_id,
-      liveId: live_id,
-    })) as any[];
-    // remove ts from result
-    return {
-      danmu_record: result.map((r: any) => {
-        return {
-          ...r,
-          ts: (r.ts / 1000).toFixed(1),
-        };
-      }),
-    };
-  },
-  {
-    name: "get_danmu_record",
-    description:
-      "Get the danmu record of a live, entry ts is relative to the live start time in seconds",
-    schema: z.object({
-      platform: z.string().describe("The platform of the room"),
-      room_id: z.string().describe("The room id of the room"),
-      live_id: z.string().describe("The live id of the live"),
-    }),
-  }
-);
-
-// @ts-ignore
-const clip_range = tool(
-  async ({
-    reason,
-    clip_range_params,
-  }: {
-    reason: string;
-    clip_range_params: Omit<ClipRangeParams, 'ranges'> & {
-      ranges: Array<{ start: number; end: number }>;
-    };
-  }) => {
-    const event_id = generateEventId();
-    const backendParams: ClipRangeParams = {
-      ...clip_range_params,
-    };
-
-    const result = await invoke("clip_range", {
-      eventId: event_id,
-      params: backendParams,
-    });
-    return result;
-  },
-  {
-    name: "clip_range",
-    description:
-      "Clip one or more ranges from a live stream to generate a video. When multiple ranges are provided, they are concatenated into a single video with an optional transition effect. You must provide a reason for your decision on params.",
-    schema: z.object({
-      reason: z
-        .string()
-        .describe(
-          "The reason for the clip range, it will be shown to the user. You must offer a summary of the clip range content and why you choose this clip range."
-        ),
-      clip_range_params: z.object({
-        room_id: z.string().describe("The room id of the room"),
-        live_id: z.string().describe("The live id of the live"),
-        ranges: z
-          .array(
-            z.object({
-              start: z
-                .number()
-                .describe(
-                  "The start time in SECONDS of the clip that relative to the live start time"
-                ),
-              end: z
-                .number()
-                .describe(
-                  "The end time in SECONDS of the clip that relative to the live start time"
-                ),
-            })
-          )
-          .describe("Array of time ranges to clip. Supports single or multiple ranges."),
-        danmu: z
-          .boolean()
-          .describe(
-            "Whether to encode danmu, encode danmu will take a lot of time, so it is recommended to set it to false"
-          ),
-        local_offset: z
-          .number()
-          .describe(
-            "The offset for danmu timestamp, it is used to correct the timestamp of danmu"
-          ),
-        title: z.string().describe("The title of the clip"),
-        note: z.string().describe("The note of the clip"),
-        cover: z.string().describe("Must be empty"),
-        platform: z.string().describe("The platform of the clip"),
-        fix_encoding: z
-          .boolean()
-          .describe(
-            "Whether to fix the encoding of the clip, it will take a lot of time, so it is recommended to set it to false"
-          ),
-        transition: z
-          .enum(["none", "fade", "dissolve", "wipeleft", "wiperight", "slideup", "slidedown"])
-          .optional()
-          .describe(
-            "Transition effect between clips when multiple ranges are provided. Default: 'none' (direct cut)."
-          ),
-      }),
-    }),
-  }
-);
-
-// @ts-ignore
-const get_recent_record = tool(
-  async ({
-    room_id,
-    offset,
-    limit,
-  }: {
-    room_id: string;
-    offset: number;
-    limit: number;
-  }) => {
-    const records = (await invoke("get_recent_record", {
-      roomId: room_id,
-      offset,
-      limit,
-    })) as any[];
-    return {
-      records: records.map((r: any) => {
-        return {
-          ...r,
-          cover: null,
-          created_at: new Date(r.created_at).toLocaleString(),
-        };
-      }),
-    };
-  },
-  {
-    name: "get_recent_record",
-    description: "Get the list of recent records that bsr has recorded",
-    schema: z.object({
-      room_id: z.string().describe("The room id of the room"),
-      offset: z.number().describe("The offset of the records"),
-      limit: z.number().describe("The limit of the records"),
-    }),
-  }
-);
-
-// @ts-ignore
-const get_recent_record_all = tool(
-  async ({ offset, limit }: { offset: number; limit: number }) => {
-    const records = (await invoke("get_recent_record", {
-      roomId: 0,
-      offset,
-      limit,
-    })) as any[];
-    return {
-      records: records.map((r: any) => {
-        return {
-          ...r,
-          cover: null,
-          created_at: new Date(r.created_at).toLocaleString(),
-        };
-      }),
-    };
-  },
-  {
-    name: "get_recent_record_all",
-    description: "Get the list of recent records from all rooms",
-    schema: z.object({
-      offset: z.number().describe("The offset of the records"),
-      limit: z.number().describe("The limit of the records"),
-    }),
-  }
-);
-
-// @ts-ignore
-const generic_ffmpeg_command = tool(
-  async ({ args }: { args: string[] }) => {
-    const result = await invoke("generic_ffmpeg_command", { args });
-    return result;
-  },
-  {
-    name: "generic_ffmpeg_command",
-    description: "Run a generic ffmpeg command",
-    schema: z.object({
-      args: z.array(z.string()).describe("The arguments of the ffmpeg command"),
-    }),
-  }
-);
-
-// @ts-ignore
-const open_clip = tool(
-  async ({ video_id }: { video_id: number }) => {
-    const result = await invoke("open_clip", { videoId: video_id });
-    return result;
-  },
-  {
-    name: "open_clip",
-    description: "Open a video preview window",
-    schema: z.object({
-      video_id: z.number().describe("The id of the video"),
-    }),
-  }
-);
-
-// @ts-ignore
-const list_folder = tool(
-  async ({ path }: { path: string }) => {
-    const result = await invoke("list_folder", { path });
-    return result;
-  },
-  {
-    name: "list_folder",
-    description: "List the files in a folder",
-    schema: z.object({
-      path: z.string().describe("The path of the folder"),
-    }),
-  }
-);
-
-// @ts-ignore
-const get_archive_subtitle = tool(
-  async ({
-    platform,
-    room_id,
-    live_id,
-  }: {
-    platform: string;
-    room_id: string;
-    live_id: string;
-  }) => {
-    try {
-      const result = await invoke("get_archive_subtitle", {
-        platform,
+  post_video_to_bilibili: executor(
+    async ({ uid, room_id, video_id, title, desc, tag, tid }: {
+      uid: number;
+      room_id: string;
+      video_id: number;
+      title: string;
+      desc: string;
+      tag: string;
+      tid: number;
+    }) => {
+      const profile = default_profile();
+      profile.title = title;
+      profile.desc = desc;
+      profile.tag = tag;
+      profile.tid = tid;
+      return invoke("upload_procedure", {
+        uid,
+        eventId: generateEventId(),
         roomId: room_id,
-        liveId: live_id,
+        videoId: video_id,
+        profile,
       });
-      return result;
-    } catch (error) {
-      // If subtitle doesn't exist, return a helpful message instead of throwing
-      if (error.toString().includes("Subtitle not found")) {
-        return {
-          error: "subtitle_not_found",
-          message: "该录播还没有生成字幕，可以使用 generate_archive_subtitle 工具生成字幕",
-          platform,
-          room_id,
-          live_id,
-        };
-      }
-      throw error;
-    }
-  },
-  {
-    name: "get_archive_subtitle",
-    description:
-      "Get the subtitle of a archive, it may not be generated yet, you can use generate_archive_subtitle to generate the subtitle",
-    schema: z.object({
-      platform: z.string().describe("The platform of the archive"),
-      room_id: z.string().describe("The room id of the archive"),
-      live_id: z.string().describe("The live id of the archive"),
-    }),
-  }
-);
+    },
+  ),
 
-// @ts-ignore
-const generate_archive_subtitle = tool(
-  async ({
-    platform,
-    room_id,
-    live_id,
-  }: {
-    platform: string;
-    room_id: string;
-    live_id: string;
-  }) => {
-    const result = await invoke("generate_archive_subtitle", {
+  clip_range: executor(
+    async ({ clip_range_params }: {
+      reason: string;
+      clip_range_params: Omit<ClipRangeParams, "ranges"> & {
+        ranges: Array<{ start: number; end: number }>;
+      };
+    }) => invoke("clip_range", {
+      eventId: generateEventId(),
+      params: { ...clip_range_params } as ClipRangeParams,
+    }),
+  ),
+
+  generic_ffmpeg_command: executor(
+    async ({ args }: { args: string[] }) =>
+      invoke("generic_ffmpeg_command", { args }),
+  ),
+
+  open_clip: executor(
+    async ({ video_id }: { video_id: number }) =>
+      invoke("open_clip", { videoId: video_id }),
+  ),
+
+  list_folder: executor(
+    async ({ path }: { path: string }) => invoke("list_folder", { path }),
+  ),
+
+  generate_archive_subtitle: executor(
+    async ({ platform, room_id, live_id }: {
+      platform: string;
+      room_id: string;
+      live_id: string;
+    }) => invoke("generate_archive_subtitle", {
       platform,
       roomId: room_id,
       liveId: live_id,
-    });
-    return result;
-  },
-  {
-    name: "generate_archive_subtitle",
-    description:
-      "Generate the subtitle of a archive, it may take a long time, you should not call this tool unless user ask you to generate the subtitle. It can be used to overwrite the subtitle of a archive",
-    schema: z.object({
-      platform: z.string().describe("The platform of the archive"),
-      room_id: z.string().describe("The room id of the archive"),
-      live_id: z.string().describe("The live id of the archive"),
     }),
-  }
-);
+  ),
 
-// @ts-ignore
-const extract_video_frames = tool(
-  async ({
-    video_id,
-    timestamps,
-    max_frames,
-  }: {
-    video_id: number;
-    timestamps?: number[];
-    max_frames?: number;
-  }) => {
-    const result = await invoke("extract_video_frames", {
+  extract_video_frames: executor(
+    async ({ video_id, timestamps, max_frames }: {
+      video_id: number;
+      timestamps?: number[];
+      max_frames?: number;
+    }) => invoke("extract_video_frames", {
       videoId: video_id,
-      timestamps: timestamps || [],
-      maxFrames: max_frames || 10,
-    });
-    return result;
-  },
-  {
-    name: "extract_video_frames",
-    description:
-      "Extract frames from a video at specific timestamps or evenly distributed. Returns base64 encoded images for visual analysis. Use this to 'see' video content.",
-    schema: z.object({
-      video_id: z.number().describe("The id of the video"),
-      timestamps: z
-        .array(z.number())
-        .optional()
-        .describe(
-          "Specific timestamps in seconds to extract frames. If not provided, frames will be evenly distributed"
-        ),
-      max_frames: z
-        .number()
-        .optional()
-        .describe("Maximum number of frames to extract (default: 10)"),
+      timestamps: timestamps ?? [],
+      maxFrames: max_frames ?? 10,
     }),
-  }
-);
+  ),
 
-// @ts-ignore
-const get_video_metadata = tool(
-  async ({ video_id }: { video_id: number }) => {
-    const result = await invoke("get_video_metadata", { videoId: video_id });
-    return result;
-  },
-  {
-    name: "get_video_metadata",
-    description:
-      "Get detailed metadata of a video including duration, resolution, codec, bitrate, fps, and file size",
-    schema: z.object({
-      video_id: z.number().describe("The id of the video"),
-    }),
-  }
-);
+  get_video_metadata: executor(
+    async ({ video_id }: { video_id: number }) =>
+      invoke("get_video_metadata", { videoId: video_id }),
+  ),
 
-// @ts-ignore
-const analyze_danmu_highlights = tool(
-  async ({
-    platform,
-    room_id,
-    live_id,
-    time_window,
-    min_density,
-  }: {
-    platform: string;
-    room_id: string;
-    live_id: string;
-    time_window: number;
-    min_density: number;
-  }) => {
-    const result = await invoke("analyze_danmu_highlights", {
-      platform,
-      roomId: room_id,
-      liveId: live_id,
-      timeWindow: time_window,
-      minDensity: min_density,
-    });
-    return result;
-  },
-  {
-    name: "analyze_danmu_highlights",
-    description:
-      "Analyze danmu (comments) to find highlight moments based on comment density and keywords. Returns time ranges with high engagement that are good candidates for clipping.",
-    schema: z.object({
-      platform: z.string().describe("The platform of the live"),
-      room_id: z.string().describe("The room id of the live"),
-      live_id: z.string().describe("The live id of the live"),
-      time_window: z
-        .number()
-        .describe(
-          "Time window in seconds to analyze comment density (e.g., 30 for 30-second windows)"
-        ),
-      min_density: z
-        .number()
-        .describe(
-          "Minimum comments per time window to consider as highlight (e.g., 10)"
-        ),
-    }),
-  }
-);
-
-// @ts-ignore
-const search_danmu_keywords = tool(
-  async ({
-    platform,
-    room_id,
-    live_id,
-    keywords,
-    context_seconds,
-  }: {
-    platform: string;
-    room_id: string;
-    live_id: string;
-    keywords: string[];
-    context_seconds: number;
-  }) => {
-    const result = await invoke("search_danmu_keywords", {
-      platform,
-      roomId: room_id,
-      liveId: live_id,
-      keywords,
-      contextSeconds: context_seconds,
-    });
-    return result;
-  },
-  {
-    name: "search_danmu_keywords",
-    description:
-      "Search for specific keywords in danmu and return timestamps with context. Useful for finding specific moments mentioned by viewers (e.g., '精彩', '666', '笑死').",
-    schema: z.object({
-      platform: z.string().describe("The platform of the live"),
-      room_id: z.string().describe("The room id of the live"),
-      live_id: z.string().describe("The live id of the live"),
-      keywords: z
-        .array(z.string())
-        .describe("Keywords to search for in danmu content"),
-      context_seconds: z
-        .number()
-        .describe(
-          "Seconds of context to include before and after keyword match (e.g., 10)"
-        ),
-    }),
-  }
-);
-
-// @ts-ignore
-const merge_videos = tool(
-  async ({
-    video_ids,
-    output_title,
-    output_note,
-    transition,
-  }: {
-    video_ids: number[];
-    output_title: string;
-    output_note: string;
-    transition?: string;
-  }) => {
-    const result = await invoke("merge_videos", {
+  merge_videos: executor(
+    async ({ video_ids, output_title, output_note, transition }: {
+      video_ids: number[];
+      output_title: string;
+      output_note: string;
+      transition?: string;
+    }) => invoke("merge_videos", {
       videoIds: video_ids,
       outputTitle: output_title,
       outputNote: output_note,
-      transition: transition || "none",
-    });
-    return result;
-  },
-  {
-    name: "merge_videos",
-    description:
-      "Merge multiple videos into a single video. Videos will be concatenated in the order provided with optional transitions between clips. Useful for creating compilations or combining multiple clips.",
-    schema: z.object({
-      video_ids: z
-        .array(z.number())
-        .describe("Array of video IDs to merge, in order"),
-      output_title: z.string().describe("Title for the merged video"),
-      output_note: z.string().describe("Note for the merged video"),
-      transition: z
-        .enum(["none", "fade", "dissolve", "wipeleft", "wiperight", "slideup", "slidedown"])
-        .optional()
-        .describe(
-          "Transition effect between clips. Options: 'none' (直接切换), 'fade' (淡入淡出), 'dissolve' (溶解), 'wipeleft' (左擦除), 'wiperight' (右擦除), 'slideup' (上滑), 'slidedown' (下滑). Default: 'none'"
-        ),
+      transition: transition ?? "none",
     }),
-  }
-);
+  ),
 
-// @ts-ignore
-const extract_video_audio = tool(
-  async ({ video_id }: { video_id: number }) => {
-    const result = await invoke("extract_video_audio", { videoId: video_id });
-    return result;
-  },
-  {
-    name: "extract_video_audio",
-    description:
-      "Extract audio from a video as a separate audio file. Useful for audio analysis or creating audio-only content.",
-    schema: z.object({
-      video_id: z.number().describe("The id of the video"),
-    }),
-  }
-);
+  extract_video_audio: executor(
+    async ({ video_id }: { video_id: number }) =>
+      invoke("extract_video_audio", { videoId: video_id }),
+  ),
 
-// @ts-ignore
-const get_archive_metadata = tool(
-  async ({
-    platform,
-    room_id,
-    live_id,
-  }: {
-    platform: string;
-    room_id: string;
-    live_id: string;
-  }) => {
-    const result = await invoke("get_archive_metadata", {
+  get_archive_metadata: executor(
+    async ({ platform, room_id, live_id }: {
+      platform: string;
+      room_id: string;
+      live_id: string;
+    }) => invoke("get_archive_metadata", {
       platform,
       roomId: room_id,
       liveId: live_id,
-    });
-    return result;
-  },
-  {
-    name: "get_archive_metadata",
-    description:
-      "Get detailed metadata of an archive including duration, file size, video quality, and recording time",
-    schema: z.object({
-      platform: z.string().describe("The platform of the archive"),
-      room_id: z.string().describe("The room id of the archive"),
-      live_id: z.string().describe("The live id of the archive"),
     }),
+  ),
+};
+
+export async function invokeToolByName(
+  name: string,
+  args: ToolArguments,
+): Promise<unknown> {
+  const selectedTool = confirmedToolExecutors[name];
+  if (!selectedTool) {
+    throw new Error(`Tool ${name} is not available for frontend confirmation`);
   }
-);
-
-const tools = [
-  get_accounts,
-  remove_account,
-  add_recorder,
-  remove_recorder,
-  get_recorder_list,
-  get_recorder_info,
-  get_archives,
-  get_archive,
-  delete_archive,
-  delete_archives,
-  get_background_tasks,
-  delete_background_task,
-  get_videos,
-  get_all_videos,
-  get_video,
-  get_video_cover,
-  delete_video,
-  get_video_typelist,
-  get_video_subtitle,
-  generate_video_subtitle,
-  encode_video_subtitle,
-  post_video_to_bilibili,
-  clip_range,
-  get_danmu_record,
-  get_recent_record,
-  get_recent_record_all,
-  generic_ffmpeg_command,
-  open_clip,
-  list_folder,
-  get_archive_subtitle,
-  generate_archive_subtitle,
-  // New video editing tools
-  extract_video_frames,
-  get_video_metadata,
-  analyze_danmu_highlights,
-  search_danmu_keywords,
-  merge_videos,
-  extract_video_audio,
-  get_archive_metadata,
-];
-
-export { tools };
+  return selectedTool(args);
+}

--- a/src/lib/components/AIMessage.svelte
+++ b/src/lib/components/AIMessage.svelte
@@ -5,28 +5,21 @@
     X,
     AlertTriangle,
   } from "lucide-svelte";
-  import { AIMessage } from "@langchain/core/messages";
+  import type { AssistantMessage, ToolCall } from "../agent/messages";
   import { marked } from "marked";
 
-  export let message: AIMessage;
+  export let message: AssistantMessage;
   export let formatTime: (date: Date) => string;
-  export let onToolCallConfirm: ((toolCall: any) => void) | undefined =
-    undefined;
-  export let onToolCallReject: ((toolCall: any) => void) | undefined =
-    undefined;
-  export let toolCallState: 'confirmed' | 'rejected' | 'none' = 'none';
-  export let isSensitiveToolCall: boolean = false;
+  export let onToolCallConfirm: ((toolCall: ToolCall) => void) | undefined;
+  export let onToolCallReject: ((toolCall: ToolCall) => void) | undefined;
+  export let getToolCallState: (
+    toolCallId: string,
+  ) => 'confirmed' | 'rejected' | 'none' = () => 'none';
+  export let confirmationDisabled = false;
 
-  // 检查是否被内容过滤
-  $: isContentFiltered = message.response_metadata?.finish_reason === "content_filter";
+  $: isError = message.isError === true;
 
-  // 检查是否是错误消息
-  $: isError = message.additional_kwargs?.isError === true;
-
-  // 获取消息时间戳，如果没有则使用当前时间
-  $: messageTime = message.additional_kwargs?.timestamp
-    ? new Date(message.additional_kwargs.timestamp as string)
-    : new Date();
+  $: messageTime = new Date(message.timestamp);
 
   // 将 Markdown 转换为 HTML
   $: htmlContent = marked(
@@ -44,18 +37,20 @@
     (message.content.includes('|') || message.content.includes('---') ||
      message.content.includes('|--') || message.content.includes('| -'));
 
-  // 处理工具调用确认
-  function handleToolCallConfirm(toolCall: any) {
-    if (onToolCallConfirm) {
-      onToolCallConfirm(toolCall);
-    }
+  function isExecutedToolCall(toolCall: ToolCall): boolean {
+    return toolCall.executed === true;
   }
 
-  // 处理工具调用拒绝
-  function handleToolCallReject(toolCall: any) {
-    if (onToolCallReject) {
-      onToolCallReject(toolCall);
-    }
+  function isPendingToolCall(toolCall: ToolCall): boolean {
+    return toolCall.executed === false;
+  }
+
+  function toolCallFailed(toolCall: ToolCall): boolean {
+    return Boolean(toolCall.error);
+  }
+
+  function toolCallError(toolCall: ToolCall): string {
+    return String(toolCall.error || "未知错误");
   }
 </script>
 
@@ -94,21 +89,6 @@
         class:dark:border-red-700={isError}
         class:dark:bg-red-900={isError}
       >
-        <!-- 内容过滤警告 -->
-        {#if isContentFiltered}
-          <div class="mb-3 p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 rounded-lg">
-            <div class="flex items-center space-x-2">
-              <AlertTriangle class="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
-              <span class="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-                内容被过滤
-              </span>
-            </div>
-            <p class="text-xs text-yellow-700 dark:text-yellow-300 mt-1">
-              由于内容安全策略，部分回复内容可能已被过滤。请尝试重新表述您的问题。
-            </p>
-          </div>
-        {/if}
-
         <div
           class="text-gray-900 dark:text-white text-sm leading-relaxed prose prose-sm max-w-none [&_.prose]:bg-transparent [&_.prose_*]:bg-transparent [&_p]:bg-transparent [&_div]:bg-transparent [&_span]:bg-transparent [&_code]:bg-gray-100 dark:bg-gray-700 [&_pre]:bg-gray-100 dark:bg-gray-700 [&_blockquote]:bg-transparent [&_ul]:bg-transparent [&_ol]:bg-transparent [&_li]:bg-transparent [&_h1]:bg-transparent [&_h2]:bg-transparent [&_h3]:bg-transparent [&_h4]:bg-transparent [&_h5]:bg-transparent [&_h6]:bg-transparent [&_p]:m-0 [&_p]:p-0 [&_div]:m-0 [&_div]:p-0 [&_ul]:m-0 [&_ul]:p-0 [&_ol]:m-0 [&_ol]:p-0 [&_li]:m-0 [&_li]:p-0 [&_li]:mb-0 [&_li]:mt-0 [&_h1]:m-0 [&_h1]:p-0 [&_h2]:m-0 [&_h2]:p-0 [&_h3]:m-0 [&_h3]:p-0 [&_h4]:m-0 [&_h4]:p-0 [&_h5]:m-0 [&_h5]:p-0 [&_h6]:m-0 [&_h6]:p-0 [&_blockquote]:m-0 [&_blockquote]:p-0"
         >
@@ -121,9 +101,9 @@
           {/if}
         </div>
 
-        {#if message.tool_calls && message.tool_calls.length > 0}
+        {#if message.toolCalls.length > 0}
           <div class="space-y-2 mt-3">
-            {#each message.tool_calls as tool_call}
+            {#each message.toolCalls as toolCall}
               <div
                 class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-3"
               >
@@ -154,11 +134,11 @@
                   <span
                     class="text-sm font-medium text-blue-700 dark:text-blue-300"
                   >
-                    工具调用: {tool_call.name}
+                    工具调用: {toolCall.name}
                   </span>
                 </div>
 
-                {#if tool_call.args && Object.keys(tool_call.args).length > 0}
+                {#if Object.keys(toolCall.args).length > 0}
                   <div class="mb-2">
                     <div
                       class="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1"
@@ -168,7 +148,7 @@
                     <div class="bg-gray-50 dark:bg-gray-800 rounded p-2">
                       <pre
                         class="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words">{JSON.stringify(
-                          tool_call.args,
+                          toolCall.args,
                           null,
                           2
                         )}</pre>
@@ -176,9 +156,9 @@
                   </div>
                 {/if}
 
-                {#if tool_call.id}
+                {#if toolCall.id}
                   <div class="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                    ID: {tool_call.id}
+                    ID: {toolCall.id}
                   </div>
                 {/if}
 
@@ -186,38 +166,50 @@
                 <div
                   class="flex items-center justify-between mt-3 pt-2 border-t border-blue-200 dark:border-blue-700"
                 >
-                  {#if tool_call.id && toolCallState === 'confirmed'}
+                  {#if isExecutedToolCall(toolCall)}
+                    {#if toolCallFailed(toolCall)}
+                      <div class="space-y-1 text-red-600 dark:text-red-400">
+                        <div class="flex items-center space-x-2">
+                          <AlertTriangle class="w-4 h-4" />
+                          <span class="text-sm font-medium">调用失败</span>
+                        </div>
+                        <div class="text-xs break-words">{toolCallError(toolCall)}</div>
+                      </div>
+                    {:else}
+                      <div class="flex items-center space-x-2 text-green-600 dark:text-green-400">
+                        <Check class="w-4 h-4" />
+                        <span class="text-sm font-medium">已完成</span>
+                      </div>
+                    {/if}
+                  {:else if getToolCallState(toolCall.id) === 'confirmed'}
                     <!-- 显示状态 -->
                       <div class="flex items-center space-x-2 text-green-600 dark:text-green-400">
                         <Check class="w-4 h-4" />
                         <span class="text-sm font-medium">已确认</span>
                       </div>
-                  {:else if toolCallState === 'rejected'}
+                  {:else if getToolCallState(toolCall.id) === 'rejected'}
                       <div class="flex items-center space-x-2 text-red-600 dark:text-red-400">
                         <X class="w-4 h-4" />
                         <span class="text-sm font-medium">已拒绝</span>
                       </div>
-                  {:else if onToolCallConfirm || onToolCallReject}
-                    <!-- 显示操作按钮 -->
+                  {:else if isPendingToolCall(toolCall)}
                     <div class="flex items-center space-x-2 w-full">
-                      {#if isSensitiveToolCall && onToolCallReject}
-                        <button
-                          on:click={() => handleToolCallReject(tool_call)}
-                          class="flex items-center space-x-1 px-4 py-2 bg-red-500 hover:bg-red-600 active:bg-red-700 text-white text-xs font-medium rounded-lg shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
-                        >
-                          <X class="w-3 h-3" />
-                          <span>拒绝</span>
-                        </button>
-                      {/if}
-                      {#if onToolCallConfirm}
-                        <button
-                          on:click={() => handleToolCallConfirm(tool_call)}
-                          class="flex items-center space-x-1 px-4 py-2 bg-blue-500 hover:bg-blue-600 active:bg-blue-700 text-white text-xs font-medium rounded-lg shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 flex-1"
-                        >
-                          <Check class="w-3 h-3" />
-                          <span>{isSensitiveToolCall ? '确认' : '执行'}</span>
-                        </button>
-                      {/if}
+                      <button
+                        on:click={() => onToolCallReject?.(toolCall)}
+                        disabled={confirmationDisabled}
+                        class="flex items-center space-x-1 px-4 py-2 bg-red-500 hover:bg-red-600 active:bg-red-700 text-white text-xs font-medium rounded-lg shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        <X class="w-3 h-3" />
+                        <span>拒绝</span>
+                      </button>
+                      <button
+                        on:click={() => onToolCallConfirm?.(toolCall)}
+                        disabled={confirmationDisabled}
+                        class="flex items-center justify-center space-x-1 px-4 py-2 bg-blue-500 hover:bg-blue-600 active:bg-blue-700 text-white text-xs font-medium rounded-lg shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed flex-1"
+                      >
+                        <Check class="w-3 h-3" />
+                        <span>确认执行</span>
+                      </button>
                     </div>
                   {/if}
                 </div>

--- a/src/lib/components/AIMessage.svelte
+++ b/src/lib/components/AIMessage.svelte
@@ -5,8 +5,14 @@
     X,
     AlertTriangle,
   } from "lucide-svelte";
-  import type { AssistantMessage, ToolCall } from "../agent/messages";
+  import {
+    messageContentToDisplayParts,
+    messageContentToMarkdown,
+    type AssistantMessage,
+    type ToolCall,
+  } from "../agent/messages";
   import { marked } from "marked";
+  import CopyMarkdownButton from "./CopyMarkdownButton.svelte";
 
   export let message: AssistantMessage;
   export let formatTime: (date: Date) => string;
@@ -20,22 +26,21 @@
   $: isError = message.isError === true;
 
   $: messageTime = new Date(message.timestamp);
+  $: contentParts = messageContentToDisplayParts(message.content);
 
-  // 将 Markdown 转换为 HTML
-  $: htmlContent = marked(
-    typeof message.content === "string"
-      ? message.content
-      : Array.isArray(message.content)
-        ? message.content
-            .map((c) => (typeof c === "string" ? c : JSON.stringify(c)))
-            .join("\n")
-        : JSON.stringify(message.content)
+  function markdownContent(): string {
+    return messageContentToMarkdown(message.content);
+  }
+
+  function containsTable(content: string): boolean {
+    return content.includes('|') || content.includes('---') ||
+      content.includes('|--') || content.includes('| -');
+  }
+
+  $: hasTable = contentParts.some(
+    (part) => part.kind === "text" &&
+      part.format === "markdown" && containsTable(part.text),
   );
-
-  // 检查消息是否包含表格
-  $: hasTable = message.content && typeof message.content === 'string' &&
-    (message.content.includes('|') || message.content.includes('---') ||
-     message.content.includes('|--') || message.content.includes('| -'));
 
   function isExecutedToolCall(toolCall: ToolCall): boolean {
     return toolCall.executed === true;
@@ -76,6 +81,7 @@
         <span class="text-xs text-gray-500 dark:text-gray-400">
           {formatTime(messageTime)}
         </span>
+        <CopyMarkdownButton content={markdownContent} />
       </div>
 
       <div
@@ -92,13 +98,24 @@
         <div
           class="text-gray-900 dark:text-white text-sm leading-relaxed prose prose-sm max-w-none [&_.prose]:bg-transparent [&_.prose_*]:bg-transparent [&_p]:bg-transparent [&_div]:bg-transparent [&_span]:bg-transparent [&_code]:bg-gray-100 dark:bg-gray-700 [&_pre]:bg-gray-100 dark:bg-gray-700 [&_blockquote]:bg-transparent [&_ul]:bg-transparent [&_ol]:bg-transparent [&_li]:bg-transparent [&_h1]:bg-transparent [&_h2]:bg-transparent [&_h3]:bg-transparent [&_h4]:bg-transparent [&_h5]:bg-transparent [&_h6]:bg-transparent [&_p]:m-0 [&_p]:p-0 [&_div]:m-0 [&_div]:p-0 [&_ul]:m-0 [&_ul]:p-0 [&_ol]:m-0 [&_ol]:p-0 [&_li]:m-0 [&_li]:p-0 [&_li]:mb-0 [&_li]:mt-0 [&_h1]:m-0 [&_h1]:p-0 [&_h2]:m-0 [&_h2]:p-0 [&_h3]:m-0 [&_h3]:p-0 [&_h4]:m-0 [&_h4]:p-0 [&_h5]:m-0 [&_h5]:p-0 [&_h6]:m-0 [&_h6]:p-0 [&_blockquote]:m-0 [&_blockquote]:p-0"
         >
-          {#if hasTable}
-            <div class="table-container">
-              {@html htmlContent}
-            </div>
-          {:else}
-            {@html htmlContent}
-          {/if}
+          <div class="space-y-3">
+            {#each contentParts as part}
+              {#if part.kind === "image"}
+                <img
+                  src={part.src}
+                  alt={part.alt}
+                  loading="lazy"
+                  class="max-h-[28rem] max-w-full rounded-lg border border-gray-200 object-contain dark:border-gray-600"
+                />
+              {:else if part.format === "json"}
+                <pre class="overflow-x-auto whitespace-pre-wrap break-words rounded-lg p-3 text-xs">{part.text}</pre>
+              {:else}
+                <div class:table-container={containsTable(part.text)}>
+                  {@html marked(part.text)}
+                </div>
+              {/if}
+            {/each}
+          </div>
         </div>
 
         {#if message.toolCalls.length > 0}

--- a/src/lib/components/CopyMarkdownButton.svelte
+++ b/src/lib/components/CopyMarkdownButton.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { onDestroy } from "svelte";
+  import { Check, Copy } from "lucide-svelte";
+
+  export let content: string | (() => string);
+
+  let copied = false;
+  let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+  async function copyMarkdown() {
+    try {
+      const markdown = typeof content === "function" ? content() : content;
+      await navigator.clipboard.writeText(markdown);
+      copied = true;
+      if (resetTimer) clearTimeout(resetTimer);
+      resetTimer = setTimeout(() => {
+        copied = false;
+      }, 1500);
+    } catch (error) {
+      console.error("Failed to copy message:", error);
+    }
+  }
+
+  onDestroy(() => {
+    if (resetTimer) clearTimeout(resetTimer);
+  });
+</script>
+
+<button
+  type="button"
+  on:click={copyMarkdown}
+  class="inline-flex h-6 w-6 items-center justify-center rounded text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+  aria-label={copied ? "已复制 Markdown" : "复制为 Markdown"}
+  title={copied ? "已复制" : "复制为 Markdown"}
+>
+  {#if copied}
+    <Check class="h-3.5 w-3.5 text-green-500" />
+  {:else}
+    <Copy class="h-3.5 w-3.5" />
+  {/if}
+</button>

--- a/src/lib/components/HumanMessage.svelte
+++ b/src/lib/components/HumanMessage.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { User } from "lucide-svelte";
   import type { HumanMessage } from "../agent/messages";
+  import CopyMarkdownButton from "./CopyMarkdownButton.svelte";
 
   export let message: HumanMessage;
   export let formatTime: (date: Date) => string;
@@ -18,6 +19,7 @@
         <span class="text-xs text-gray-500 dark:text-gray-400">
           {formatTime(messageTime)}
         </span>
+        <CopyMarkdownButton content={message.content} />
       </div>
 
       <div

--- a/src/lib/components/HumanMessage.svelte
+++ b/src/lib/components/HumanMessage.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
   import { User } from "lucide-svelte";
-  import { HumanMessage } from "@langchain/core/messages";
+  import type { HumanMessage } from "../agent/messages";
 
   export let message: HumanMessage;
   export let formatTime: (date: Date) => string;
 
-  // 获取消息时间戳，如果没有则使用当前时间
-  $: messageTime = message.additional_kwargs?.timestamp
-    ? new Date(message.additional_kwargs.timestamp as string | number)
-    : new Date();
+  $: messageTime = new Date(message.timestamp);
 </script>
 
 <div class="flex justify-end">

--- a/src/lib/components/ToolMessage.svelte
+++ b/src/lib/components/ToolMessage.svelte
@@ -6,7 +6,7 @@
     ChevronDown,
     ChevronRight,
   } from "lucide-svelte";
-  import { ToolMessage } from "@langchain/core/messages";
+  import type { ToolMessage } from "../agent/messages";
 
   export let message: ToolMessage;
   export let formatTime: (date: Date) => string;
@@ -14,14 +14,11 @@
   // 折叠状态 - 默认折叠
   let isExpanded = false;
 
-  // 获取消息时间戳，如果没有则使用当前时间
-  $: messageTime = message.additional_kwargs?.timestamp
-    ? new Date(message.additional_kwargs.timestamp as string | number)
-    : new Date();
+  $: messageTime = new Date(message.timestamp);
 
   // 获取状态图标和颜色
   function getStatusInfo() {
-    if (message.status === "success" || !message.status) {
+    if (message.status === "success") {
       return {
         icon: CheckCircle,
         color: "text-green-500",
@@ -39,8 +36,7 @@
   }
 
   // 格式化工具调用ID
-  function formatToolCallId(id: string | undefined): string {
-    if (!id) return "";
+  function formatToolCallId(id: string): string {
     return id.length > 8 ? id.slice(-8) : id;
   }
 
@@ -85,13 +81,11 @@
               <span
                 class="text-sm font-medium text-gray-700 dark:text-gray-300"
               >
-                {message.name || "未知工具"}
+                {message.name}
               </span>
-              {#if message.tool_call_id}
-                <span class="text-xs text-gray-500 dark:text-gray-400">
-                  (ID: {formatToolCallId(message.tool_call_id)})
-                </span>
-              {/if}
+              <span class="text-xs text-gray-500 dark:text-gray-400">
+                (ID: {formatToolCallId(message.toolCallId)})
+              </span>
             </div>
           </div>
 
@@ -125,11 +119,9 @@
           </div>
 
           <!-- 状态信息 -->
-          {#if message.status}
-            <div class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-              状态: {message.status}
-            </div>
-          {/if}
+          <div class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            状态: {message.status}
+          </div>
         </div>
       </div>
     </div>

--- a/src/lib/components/ToolMessage.svelte
+++ b/src/lib/components/ToolMessage.svelte
@@ -6,7 +6,12 @@
     ChevronDown,
     ChevronRight,
   } from "lucide-svelte";
-  import type { ToolMessage } from "../agent/messages";
+  import {
+    messageContentToDisplayParts,
+    messageContentToMarkdown,
+    type ToolMessage,
+  } from "../agent/messages";
+  import CopyMarkdownButton from "./CopyMarkdownButton.svelte";
 
   export let message: ToolMessage;
   export let formatTime: (date: Date) => string;
@@ -15,6 +20,11 @@
   let isExpanded = false;
 
   $: messageTime = new Date(message.timestamp);
+  $: contentParts = messageContentToDisplayParts(message.content);
+
+  function markdownContent(): string {
+    return messageContentToMarkdown(message.content);
+  }
 
   // 获取状态图标和颜色
   function getStatusInfo() {
@@ -65,6 +75,7 @@
         <span class="text-xs text-gray-500 dark:text-gray-400">
           {formatTime(messageTime)}
         </span>
+        <CopyMarkdownButton content={markdownContent} />
       </div>
 
       <div
@@ -110,9 +121,26 @@
                 class="bg-gray-50 dark:bg-gray-700 rounded-lg p-3 border border-gray-200 dark:border-gray-600"
               >
                 <div
-                  class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed"
+                  class="space-y-3 text-sm text-gray-700 dark:text-gray-300 leading-relaxed"
                 >
-                  {message.content || "无响应内容"}
+                  {#if contentParts.length === 0}
+                    无响应内容
+                  {:else}
+                    {#each contentParts as part}
+                      {#if part.kind === "image"}
+                        <img
+                          src={part.src}
+                          alt={part.alt}
+                          loading="lazy"
+                          class="max-h-[28rem] max-w-full rounded-lg border border-gray-200 object-contain dark:border-gray-600"
+                        />
+                      {:else if part.format === "json"}
+                        <pre class="overflow-x-auto whitespace-pre-wrap break-words text-xs">{part.text}</pre>
+                      {:else}
+                        <div class="whitespace-pre-wrap break-words">{part.text}</div>
+                      {/if}
+                    {/each}
+                  {/if}
                 </div>
               </div>
             {/if}

--- a/src/lib/components/ai/SettingsModal.svelte
+++ b/src/lib/components/ai/SettingsModal.svelte
@@ -35,9 +35,9 @@
       <div class="p-6 space-y-5 max-h-[calc(100vh-200px)] overflow-y-auto">
         <!-- Provider Selection -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+          <div class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
             选择 AI 提供商
-          </label>
+          </div>
           <div class="grid grid-cols-2 gap-3">
             <button
               type="button"

--- a/src/page/AI.svelte
+++ b/src/page/AI.svelte
@@ -1,25 +1,31 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { Settings, Send, Sparkles, Trash2, Zap, MessageSquare, Bot } from "lucide-svelte";
-  import createAgent, { type AgentConfig } from "../lib/agent/agent";
-  import { tools } from "../lib/agent/tools";
+  import { Settings, Send, Sparkles, Trash2, Zap, Bot } from "lucide-svelte";
   import {
-    HumanMessage,
-    AIMessage,
-    ToolMessage,
-  } from "@langchain/core/messages";
+    agentChat,
+    type AgentConfig,
+  } from "../lib/agent/agent";
+  import { invokeToolByName } from "../lib/agent/tools";
+  import {
+    deserializeMessages,
+    isAssistantMessage,
+    isToolMessage,
+    type ChatMessage,
+    type ToolCall,
+    type ToolMessage,
+  } from "../lib/agent/messages";
   import HumanMessageComponent from "../lib/components/HumanMessage.svelte";
   import AIMessageComponent from "../lib/components/AIMessage.svelte";
   import ProcessingMessageComponent from "../lib/components/ProcessingMessage.svelte";
   import ToolMessageComponent from "../lib/components/ToolMessage.svelte";
   import SettingsModal from "../lib/components/ai/SettingsModal.svelte";
 
-  let messages: any[] = [];
+  let messages: ChatMessage[] = [];
   let inputMessage = "";
   let isProcessing = false;
   let messageContainer: HTMLElement;
   let inputAreaHeight = 0;
-  let agent = null;
+  let agentConfig: AgentConfig | null = null;
 
   // 设置相关状态
   let showSettings = false;
@@ -31,8 +37,8 @@
     model: ""
   };
 
-  let availableModels = [];
-  const toolCallStates = new Map<string, 'confirmed' | 'rejected' | 'none'>();
+  let availableModels: Array<{ value: string; label: string }> = [];
+  type ToolCallState = 'confirmed' | 'rejected' | 'none';
 
   // 预设提示词
   const presetPrompts = [
@@ -47,31 +53,28 @@
   function openSettings() { showSettings = true; }
   function closeSettings() { showSettings = false; }
 
+  function buildAgentConfig(): AgentConfig | null {
+    if (settings.provider === 'ollama') {
+      if (!settings.endpoint && !settings.model) return null;
+      return {
+        provider: 'ollama',
+        baseURL: settings.endpoint || 'http://localhost:11434',
+        model: settings.model.trim() || 'llama2',
+      };
+    }
+    if (!settings.api_key || !settings.endpoint || !settings.model.trim()) return null;
+    return {
+      provider: 'openai',
+      apiKey: settings.api_key,
+      baseURL: settings.endpoint,
+      model: settings.model.trim(),
+    };
+  }
+
   async function saveSettings() {
     localStorage.setItem('ai_settings', JSON.stringify(settings));
-    if (settings.provider === 'ollama') {
-      if (settings.endpoint || settings.model) {
-        agent = createAgent({
-          provider: 'ollama',
-          baseURL: settings.endpoint || 'http://localhost:11434',
-          model: settings.model || 'llama2',
-        });
-      } else {
-        agent = null;
-      }
-    } else {
-      if (settings.api_key && settings.endpoint) {
-        agent = createAgent({
-          provider: 'openai',
-          apiKey: settings.api_key,
-          baseURL: settings.endpoint,
-          model: settings.model || undefined,
-        });
-        await loadModels();
-      } else {
-        agent = null;
-      }
-    }
+    agentConfig = buildAgentConfig();
+    if (settings.provider === 'openai') await loadModels();
     closeSettings();
   }
 
@@ -108,35 +111,51 @@
 
   function loadSettings() {
     const savedSettings = localStorage.getItem('ai_settings');
-    if (savedSettings) {
+    if (!savedSettings) return;
+    try {
       settings = { ...settings, ...JSON.parse(savedSettings) };
-      if (settings.provider === 'ollama') {
-        if (settings.endpoint || settings.model) {
-          agent = createAgent({
-            provider: 'ollama',
-            baseURL: settings.endpoint || 'http://localhost:11434',
-            model: settings.model || 'llama2',
-          });
-        }
-      } else {
-        if (settings.api_key && settings.endpoint) {
-          agent = createAgent({
-            provider: 'openai',
-            apiKey: settings.api_key,
-            baseURL: settings.endpoint,
-            model: settings.model || undefined,
-          });
-          loadModels();
-        }
-      }
+      agentConfig = buildAgentConfig();
+      if (settings.provider === 'openai') loadModels();
+    } catch (error) {
+      console.error('Failed to load AI settings:', error);
     }
   }
 
-  function getToolCallState(message: any): 'confirmed' | 'rejected' | 'none' {
-    if (message.tool_calls && message.tool_calls.length > 0) {
-      return toolCallStates.get(message.tool_calls[0]?.id) || 'none';
+  function getToolCallState(toolCallId: string): ToolCallState {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (isToolMessage(message) && message.toolCallId === toolCallId) {
+        return message.resolution;
+      }
     }
     return 'none';
+  }
+
+  function hasUnresolvedPendingToolCalls(): boolean {
+    return messages.some(
+      (message) =>
+        isAssistantMessage(message) &&
+        message.toolCalls.some(
+          (toolCall) =>
+            toolCall.executed === false &&
+            getToolCallState(toolCall.id) === 'none',
+        ),
+    );
+  }
+
+  $: hasPendingToolCalls = hasUnresolvedPendingToolCalls();
+
+  function persistConversation() {
+    try {
+      localStorage.setItem('messages', JSON.stringify(messages));
+    } catch (error) {
+      console.error('Failed to persist AI conversation:', error);
+    }
+  }
+
+  function toolResultContent(result: unknown): string {
+    if (typeof result === 'string') return result;
+    return JSON.stringify(result) ?? String(result);
   }
 
   function scrollToBottom() {
@@ -145,15 +164,9 @@
     }
   }
 
-  function formatTime(timestamp: string): string {
+  function formatTime(timestamp: string | Date): string {
     const date = new Date(timestamp);
     return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
-  }
-
-  function isSensitiveToolCall(message: any): boolean {
-    if (!message.tool_calls || message.tool_calls.length === 0) return false;
-    const sensitiveTools = ['delete_recorder', 'delete_archive', 'delete_video'];
-    return message.tool_calls.some((toolCall: any) => sensitiveTools.includes(toolCall.name));
   }
 
   async function handlePresetPrompt(prompt: string) {
@@ -162,247 +175,139 @@
   }
 
   async function sendMessage() {
-    if (!inputMessage.trim() || isProcessing || !agent) return;
-    const userMessage = new HumanMessage({ content: inputMessage });
-    userMessage.additional_kwargs = { ...userMessage.additional_kwargs, timestamp: new Date().toISOString() };
-    messages = [...messages, userMessage];
+    if (!inputMessage.trim() || isProcessing || hasPendingToolCalls || !agentConfig) return;
+    messages = [...messages, {
+      kind: 'human',
+      content: inputMessage,
+      timestamp: new Date().toISOString(),
+    }];
     inputMessage = "";
     isProcessing = true;
     scrollToBottom();
     try {
-      await continueAgentFlow([userMessage]);
+      await continueAgentFlow();
     } finally {
       isProcessing = false;
       scrollToBottom();
     }
   }
 
-  // Define tool whitelist - tools that auto-execute without user confirmation
-  const autoExecuteTools = new Set([
-    'get_accounts',
-    'get_recorder_list',
-    'get_recorder_info',
-    'get_archives',
-    'get_archive',
-    'get_background_tasks',
-    'get_videos',
-    'get_all_videos',
-    'get_video',
-    'get_video_cover',
-    'get_video_typelist',
-    'get_video_subtitle',
-    'get_danmu_record',
-    'get_recent_record',
-    'get_recent_record_all',
-    'get_archive_subtitle',
-    'get_video_metadata',
-    'get_archive_metadata',
-  ]);
-
-  async function continueAgentFlow(newMessages: any[]) {
-    const config = { configurable: { thread_id: "1" } };
-
+  async function continueAgentFlow() {
+    if (!agentConfig) return;
     try {
-      const stream = await agent.stream({ messages: newMessages }, config);
-
-      let lastAIMessage = null;
-      for await (const chunk of stream) {
-        if (chunk.agent) {
-          const agentMessages = chunk.agent.messages;
-          for (const msg of agentMessages) {
-            if (msg instanceof AIMessage) {
-              msg.additional_kwargs = { ...msg.additional_kwargs, timestamp: new Date().toISOString() };
-              messages = [...messages, msg];
-              lastAIMessage = msg;
-              scrollToBottom();
-            }
-          }
-        }
-      }
-
-    localStorage.setItem('messages', JSON.stringify(messages));
-    const toolCallStatesObj = Object.fromEntries(toolCallStates);
-    localStorage.setItem('toolCallStates', JSON.stringify(toolCallStatesObj));
-
-    // After stream ends, check if we need to auto-execute whitelisted tools
-    if (lastAIMessage?.tool_calls && lastAIMessage.tool_calls.length > 0) {
-      const autoExecutableTools = lastAIMessage.tool_calls.filter(
-        (toolCall: any) => autoExecuteTools.has(toolCall.name)
-      );
-
-      // If all tool calls are whitelisted, auto-execute them
-      if (autoExecutableTools.length === lastAIMessage.tool_calls.length) {
-        const toolResults: any[] = [];
-
-        for (const toolCall of autoExecutableTools) {
-          // Mark as confirmed
-          toolCallStates.set(toolCall.id, 'confirmed');
-
-          // Execute tool
-          const tool = tools.find(t => t.name === toolCall.name);
-          if (!tool) {
-            console.error(`Tool ${toolCall.name} not found`);
-            const errorDetails = {
-              error: true,
-              message: `Tool ${toolCall.name} not found`,
-              tool: toolCall.name,
-            };
-            const errorMessage = new ToolMessage({
-              name: toolCall.name,
-              content: JSON.stringify(errorDetails),
-              tool_call_id: toolCall.id || `tool_${Date.now()}`,
-            });
-            errorMessage.additional_kwargs = { ...errorMessage.additional_kwargs, timestamp: new Date().toISOString() };
-            toolResults.push(errorMessage);
-            continue;
-          }
-
-          try {
-            const result = await tool.invoke(toolCall.args);
-            const resultMessage = new ToolMessage({
-              name: toolCall.name,
-              content: typeof result === 'string' ? result : JSON.stringify(result),
-              tool_call_id: toolCall.id || `tool_${Date.now()}`,
-            });
-            resultMessage.additional_kwargs = { ...resultMessage.additional_kwargs, timestamp: new Date().toISOString() };
-            toolResults.push(resultMessage);
-          } catch (error) {
-            console.error(`Error executing tool ${toolCall.name}:`, error);
-            const errorDetails = {
-              error: true,
-              message: error.message || String(error),
-              tool: toolCall.name,
-              args: toolCall.args,
-            };
-            const errorMessage = new ToolMessage({
-              name: toolCall.name,
-              content: JSON.stringify(errorDetails),
-              tool_call_id: toolCall.id || `tool_${Date.now()}`,
-            });
-            errorMessage.additional_kwargs = { ...errorMessage.additional_kwargs, timestamp: new Date().toISOString() };
-            toolResults.push(errorMessage);
-          }
-        }
-
-        // Add all tool results to messages
-        messages = [...messages, ...toolResults];
-        scrollToBottom();
-
-        // Continue agent flow with all tool results
-        await continueAgentFlow(toolResults);
-      }
-    }
+      const response = await agentChat(agentConfig, messages);
+      messages = [...messages, response];
+      persistConversation();
+      scrollToBottom();
     } catch (error) {
       console.error('LLM API Error:', error);
-
-      // Create error message to display to user
-      const errorMessage = new AIMessage({
-        content: `❌ **LLM API 错误**\n\n${error.message || String(error)}\n\n请检查：\n- API 端点是否正确\n- API 密钥是否有效\n- 网络连接是否正常\n- 模型名称是否正确`,
-      });
-      errorMessage.additional_kwargs = {
-        ...errorMessage.additional_kwargs,
+      const message = error instanceof Error ? error.message : String(error);
+      messages = [...messages, {
+        kind: 'assistant',
+        content: `❌ **LLM API 错误**\n\n${message}\n\n请检查：\n- API 端点是否正确\n- API 密钥是否有效\n- 网络连接是否正常\n- 模型名称是否正确`,
         timestamp: new Date().toISOString(),
-        isError: true
-      };
-      messages = [...messages, errorMessage];
+        toolCalls: [],
+        isError: true,
+      }];
+      persistConversation();
       scrollToBottom();
     }
   }
 
-  async function handleToolCallConfirm(toolCall: any) {
+  async function handleToolCallConfirm(toolCall: ToolCall) {
+    if (
+      isProcessing ||
+      toolCall.executed !== false ||
+      !toolCall.id ||
+      getToolCallState(toolCall.id) !== 'none'
+    ) return;
+
     isProcessing = true;
+    let resultMessage: ToolMessage;
     try {
-      // 立即更新状态为 confirmed
-      toolCallStates.set(toolCall.id, 'confirmed');
-      messages = [...messages]; // 触发响应式更新
-      scrollToBottom();
-
-      const tool = tools.find(t => t.name === toolCall.name);
-      if (!tool) {
-        throw new Error(`Tool ${toolCall.name} not found`);
-      }
-
-      let resultMessage: ToolMessage;
-      try {
-        const result = await tool.invoke(toolCall.args);
-        resultMessage = new ToolMessage({
-          name: toolCall.name,
-          content: typeof result === 'string' ? result : JSON.stringify(result),
-          tool_call_id: toolCall.id || `tool_${Date.now()}`,
-        });
-      } catch (error) {
-        // Wrap error as tool result instead of throwing
-        console.error(`Error executing tool ${toolCall.name}:`, error);
-        const errorDetails = {
+      const result = await invokeToolByName(toolCall.name, toolCall.args);
+      resultMessage = {
+        kind: 'tool',
+        name: toolCall.name,
+        content: toolResultContent(result),
+        timestamp: new Date().toISOString(),
+        toolCallId: toolCall.id,
+        status: 'success',
+        resolution: 'confirmed',
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Error executing tool ${toolCall.name}:`, error);
+      resultMessage = {
+        kind: 'tool',
+        name: toolCall.name,
+        content: JSON.stringify({
           error: true,
-          message: error.message || String(error),
+          message,
           tool: toolCall.name,
           args: toolCall.args,
-        };
-        resultMessage = new ToolMessage({
-          name: toolCall.name,
-          content: JSON.stringify(errorDetails),
-          tool_call_id: toolCall.id || `tool_${Date.now()}`,
-        });
+        }),
+        timestamp: new Date().toISOString(),
+        toolCallId: toolCall.id,
+        status: 'error',
+        resolution: 'confirmed',
+      };
+    }
+
+    messages = [...messages, resultMessage];
+    persistConversation();
+    scrollToBottom();
+
+    try {
+      if (!hasUnresolvedPendingToolCalls()) {
+        await continueAgentFlow();
       }
-
-      resultMessage.additional_kwargs = { ...resultMessage.additional_kwargs, timestamp: new Date().toISOString() };
-
-      // 添加工具结果消息到对话中
-      messages = [...messages, resultMessage];
-      scrollToBottom();
-
-      await continueAgentFlow([resultMessage]);
     } finally {
       isProcessing = false;
       scrollToBottom();
     }
   }
 
-  async function handleToolCallReject(toolCall: any) {
-    // 立即更新状态为 rejected
-    toolCallStates.set(toolCall.id, 'rejected');
-    messages = [...messages]; // 触发响应式更新
-    scrollToBottom();
+  async function handleToolCallReject(toolCall: ToolCall) {
+    if (
+      isProcessing ||
+      toolCall.executed !== false ||
+      !toolCall.id ||
+      getToolCallState(toolCall.id) !== 'none'
+    ) return;
 
-    const resultMessage = new ToolMessage({
+    isProcessing = true;
+    const resultMessage: ToolMessage = {
+      kind: 'tool',
       name: toolCall.name,
-      content: "用户选择拒绝执行工具",
-      tool_call_id: toolCall.id || `tool_${Date.now()}`,
-    });
-    resultMessage.additional_kwargs = { ...resultMessage.additional_kwargs, timestamp: new Date().toISOString() };
-
-    // 添加拒绝消息到对话中
+      content: JSON.stringify({
+        rejected: true,
+        message: '用户拒绝执行该工具调用',
+        tool: toolCall.name,
+        args: toolCall.args,
+      }),
+      timestamp: new Date().toISOString(),
+      toolCallId: toolCall.id,
+      status: 'error',
+      resolution: 'rejected',
+    };
     messages = [...messages, resultMessage];
+    persistConversation();
     scrollToBottom();
 
-    await continueAgentFlow([resultMessage]);
-    scrollToBottom();
+    try {
+      if (!hasUnresolvedPendingToolCalls()) {
+        await continueAgentFlow();
+      }
+    } finally {
+      isProcessing = false;
+      scrollToBottom();
+    }
   }
 
-  async function clearConversation() {
+  function clearConversation() {
     messages = [];
-    toolCallStates.clear();
     localStorage.removeItem('messages');
-    localStorage.removeItem('toolCallStates');
-    if (settings.provider === 'ollama') {
-      if (settings.endpoint || settings.model) {
-        agent = createAgent({
-          provider: 'ollama',
-          baseURL: settings.endpoint || 'http://localhost:11434',
-          model: settings.model || 'llama2',
-        });
-      }
-    } else {
-      if (settings.api_key && settings.endpoint) {
-        agent = createAgent({
-          provider: 'openai',
-          apiKey: settings.api_key,
-          baseURL: settings.endpoint,
-          model: settings.model || undefined,
-        });
-      }
-    }
     scrollToBottom();
   }
 
@@ -413,38 +318,15 @@
     }
   }
 
-  onMount(async () => {
+  onMount(() => {
     loadSettings();
-    const previousMessages = JSON.parse(localStorage.getItem('messages') || '[]');
-    messages = previousMessages.map((message: any) => {
-      if (message.id.includes('HumanMessage')) {
-        const msg = new HumanMessage(message.kwargs);
-        if (message.additional_kwargs?.timestamp) {
-          msg.additional_kwargs = { ...msg.additional_kwargs, timestamp: message.additional_kwargs.timestamp };
-        }
-        return msg;
-      } else if (message.id.includes('AIMessage')) {
-        const msg = new AIMessage(message.kwargs);
-        if (message.additional_kwargs?.timestamp) {
-          msg.additional_kwargs = { ...msg.additional_kwargs, timestamp: message.additional_kwargs.timestamp };
-        }
-        return msg;
-      } else if (message.id.includes('ToolMessage')) {
-        const msg = new ToolMessage(message.kwargs);
-        if (message.additional_kwargs?.timestamp) {
-          msg.additional_kwargs = { ...msg.additional_kwargs, timestamp: message.additional_kwargs.timestamp };
-        }
-        return msg;
-      }
-    });
-    toolCallStates.clear();
-    const toolCallStatesString = localStorage.getItem('toolCallStates');
-    if (toolCallStatesString) {
-      const toolCallStatesObj = JSON.parse(toolCallStatesString);
-      for (const [key, value] of Object.entries(toolCallStatesObj)) {
-        toolCallStates.set(key, value as 'confirmed' | 'rejected' | 'none');
-      }
+    try {
+      const previousMessages = JSON.parse(localStorage.getItem('messages') || '[]');
+      messages = deserializeMessages(previousMessages);
+    } catch (error) {
+      console.error('Failed to load AI conversation:', error);
     }
+    localStorage.removeItem('toolCallStates'); // Remove the obsolete parallel state store.
     scrollToBottom();
   });
 </script>
@@ -455,7 +337,7 @@
     <!-- Messages Area -->
     <div class="flex-1 overflow-y-auto" bind:this={messageContainer}>
       <div class="max-w-4xl mx-auto px-6 py-8" style="padding-bottom: {inputAreaHeight + 16}px;">
-        {#if !agent}
+        {#if !agentConfig}
           <!-- Welcome State -->
           <div class="flex items-center justify-center min-h-[500px]">
             <div class="max-w-md text-center space-y-6">
@@ -522,18 +404,18 @@
           <!-- Messages -->
           <div class="space-y-6">
             {#each messages as message, index (index)}
-              {#if message instanceof HumanMessage}
+              {#if message.kind === 'human'}
                 <HumanMessageComponent {message} {formatTime} />
-              {:else if message instanceof AIMessage}
+              {:else if message.kind === 'assistant'}
                 <AIMessageComponent
                   {message}
                   {formatTime}
+                  {getToolCallState}
                   onToolCallConfirm={handleToolCallConfirm}
                   onToolCallReject={handleToolCallReject}
-                  toolCallState={getToolCallState(message)}
-                  isSensitiveToolCall={isSensitiveToolCall(message)}
+                  confirmationDisabled={isProcessing}
                 />
-              {:else if message instanceof ToolMessage}
+              {:else}
                 <ToolMessageComponent {message} {formatTime} />
               {/if}
             {/each}
@@ -557,10 +439,10 @@
             <textarea
               bind:value={inputMessage}
               on:keypress={handleKeyPress}
-              placeholder={!agent ? "请先配置 AI 模型..." : "输入您的消息..."}
+              placeholder={!agentConfig ? "请先配置 AI 模型..." : hasPendingToolCalls ? "请先确认或拒绝待执行的工具调用..." : "输入您的消息..."}
               class="w-full px-4 pt-3 pb-3 border-0 bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-0 resize-none min-h-[52px] max-h-[200px] text-[15px] leading-relaxed disabled:opacity-50 disabled:cursor-not-allowed"
               rows="1"
-              disabled={isProcessing || !agent}
+              disabled={isProcessing || hasPendingToolCalls || !agentConfig}
             ></textarea>
           </div>
 
@@ -574,7 +456,7 @@
                 title="点击配置模型"
               >
                 <Bot class="w-3.5 h-3.5" />
-                {#if agent}
+                {#if agentConfig}
                   <span>{settings.provider === 'ollama' ? 'Ollama' : 'OpenAI'} · {settings.model || '未设置模型'}</span>
                 {:else}
                   <span>未配置模型</span>
@@ -584,7 +466,7 @@
               <button
                 class="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 on:click={clearConversation}
-                disabled={!agent}
+                disabled={!agentConfig}
                 title="清空对话"
               >
                 <Trash2 class="w-3.5 h-3.5" />
@@ -598,7 +480,7 @@
               {/if}
               <button
                 class="px-3 py-1.5 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center space-x-1.5 text-sm font-medium"
-                disabled={!inputMessage.trim() || isProcessing || !agent}
+                disabled={!inputMessage.trim() || isProcessing || hasPendingToolCalls || !agentConfig}
                 on:click={sendMessage}
               >
                 <Send class="w-3.5 h-3.5" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,11 +198,6 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz#15e19737d946559289b915e5dad3b4c28407735e"
   integrity sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==
 
-"@cfworker/json-schema@^4.0.2":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@cfworker/json-schema/-/json-schema-4.1.1.tgz#4a2a3947ee9fa7b7c24be981422831b8674c3be6"
-  integrity sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==
-
 "@chevrotain/cst-dts-gen@11.0.3":
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz#5e0863cc57dc45e204ccfee6303225d15d9d4783"
@@ -581,75 +576,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@langchain/core@^0.3.64":
-  version "0.3.66"
-  resolved "https://registry.yarnpkg.com/@langchain/core/-/core-0.3.66.tgz#cd20687f29a07148436cd8b72b88c66d076c500c"
-  integrity sha512-d3SgSDOlgOjdIbReIXVQl9HaQzKqO/5+E+o3kJwoKXLGP9dxi7+lMyaII7yv7G8/aUxMWLwFES9zc1jFoeJEZw==
-  dependencies:
-    "@cfworker/json-schema" "^4.0.2"
-    ansi-styles "^5.0.0"
-    camelcase "6"
-    decamelize "1.2.0"
-    js-tiktoken "^1.0.12"
-    langsmith "^0.3.46"
-    mustache "^4.2.0"
-    p-queue "^6.6.2"
-    p-retry "4"
-    uuid "^10.0.0"
-    zod "^3.25.32"
-    zod-to-json-schema "^3.22.3"
-
-"@langchain/deepseek@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@langchain/deepseek/-/deepseek-0.1.0.tgz#19b703bf6df6e51b01291c3e46fec63c5da94fed"
-  integrity sha512-5VzaG/oi2oSfBt+JUdXWjavZcmOzjk14+N5sCFnbrY6xeAjHrtBq7VeBcBJcHqkrjafxADK1aVGV0hpbhiFyJg==
-  dependencies:
-    "@langchain/openai" "^0.6.0"
-
-"@langchain/langgraph-checkpoint@~0.0.18":
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-0.0.18.tgz#2f7a9cdeda948ccc8d312ba9463810709d71d0b8"
-  integrity sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==
-  dependencies:
-    uuid "^10.0.0"
-
-"@langchain/langgraph-sdk@~0.0.98":
-  version "0.0.99"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.99.tgz#9077fe42d8be1a49fd9b5ed6aa02d2194eddc736"
-  integrity sha512-KSG0CixrKwBGAxXavkGUaoP+Px5BC+oZuSo8XmC9zVifPKui/JQi4Pgx2xcG611zEtdk0xRD8cG+gttdS8gPYg==
-  dependencies:
-    "@types/json-schema" "^7.0.15"
-    p-queue "^6.6.2"
-    p-retry "4"
-    uuid "^9.0.0"
-
-"@langchain/langgraph@^0.3.10":
-  version "0.3.10"
-  resolved "https://registry.yarnpkg.com/@langchain/langgraph/-/langgraph-0.3.10.tgz#9e16a995be0461f770fd9e20de1d905d04b2bed9"
-  integrity sha512-EVvvnsqmcNLTgKtxdVGDdWt7UxT6a+mVuo42VLDs2U62kejSnT7Jr4y+x1cEcijIRx15xGyyBiMBuWYiAL6drQ==
-  dependencies:
-    "@langchain/langgraph-checkpoint" "~0.0.18"
-    "@langchain/langgraph-sdk" "~0.0.98"
-    uuid "^10.0.0"
-    zod "^3.25.32"
-
-"@langchain/ollama@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@langchain/ollama/-/ollama-0.2.3.tgz#4868e66db4fc480f08c42fc652274abbab0416f0"
-  integrity sha512-1Obe45jgQspqLMBVlayQbGdywFmri8DgmGRdzNu0li56cG5RReYlRCFVDZBRMMvF9JhsP5eXRyfyivtKfITHWQ==
-  dependencies:
-    ollama "^0.5.12"
-    uuid "^10.0.0"
-
-"@langchain/openai@^0.6.0":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@langchain/openai/-/openai-0.6.2.tgz#fb68fa7305ef419e772a56c29146810c0923513d"
-  integrity sha512-OjdSfGENdz4tR9TPN4KTat7vJIE6cgt7vT0z69qU1J1aHCs9MyNwqdaQFF++LVlZAae9aTpyCyqeODyge42oKw==
-  dependencies:
-    js-tiktoken "^1.0.12"
-    openai "^5.3.0"
-    zod "^3.25.32"
 
 "@mermaid-js/mermaid-mindmap@^9.3.0":
   version "9.3.0"
@@ -1301,11 +1227,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/json-schema@^7.0.15":
-  version "7.0.15"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
-  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
-
 "@types/linkify-it@^5":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-5.0.0.tgz#21413001973106cda1c3a9b91eedd4ccd5469d76"
@@ -1362,11 +1283,6 @@
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
-"@types/retry@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
-  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
-
 "@types/trusted-types@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
@@ -1376,11 +1292,6 @@
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
   integrity sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==
-
-"@types/uuid@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
-  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
 
 "@types/web-bluetooth@^0.0.21":
   version "0.0.21"
@@ -1581,17 +1492,12 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
   integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
-
-ansi-styles@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
-  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-styles@^6.1.0:
   version "6.2.1"
@@ -1651,11 +1557,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
@@ -1708,11 +1609,6 @@ camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-camelcase@6:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
-  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
-
 camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -1727,14 +1623,6 @@ ccount@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
-
-chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 character-entities-html4@^2.0.0:
   version "2.1.0"
@@ -1835,13 +1723,6 @@ confbox@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.2.2.tgz#8652f53961c74d9e081784beed78555974a9c110"
   integrity sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==
-
-console-table-printer@^2.12.1:
-  version "2.14.6"
-  resolved "https://registry.yarnpkg.com/console-table-printer/-/console-table-printer-2.14.6.tgz#edfe0bf311fa2701922ed509443145ab51e06436"
-  integrity sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==
-  dependencies:
-    simple-wcswidth "^1.0.1"
 
 copy-anything@^3.0.2:
   version "3.0.5"
@@ -2205,7 +2086,7 @@ debug@~4.3.1, debug@~4.3.2:
   dependencies:
     ms "^2.1.3"
 
-decamelize@1.2.0, decamelize@^1.2.0:
+decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
@@ -2384,11 +2265,6 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-eventemitter3@^4.0.4:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
-  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
-
 exsolve@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/exsolve/-/exsolve-1.0.7.tgz#3b74e4c7ca5c5f9a19c3626ca857309fa99f9e9e"
@@ -2552,11 +2428,6 @@ hachure-fill@^0.5.2:
   resolved "https://registry.yarnpkg.com/hachure-fill/-/hachure-fill-0.5.2.tgz#d19bc4cc8750a5962b47fb1300557a85fcf934cc"
   integrity sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
 
-has-flag@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
-  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
 hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
@@ -2693,13 +2564,6 @@ jiti@^1.21.6:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
-js-tiktoken@^1.0.12:
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/js-tiktoken/-/js-tiktoken-1.0.20.tgz#fa2733bf147acaf1bdcf9ab8a878e79c581c95f2"
-  integrity sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==
-  dependencies:
-    base64-js "^1.5.1"
-
 katex@^0.16.22:
   version "0.16.22"
   resolved "https://registry.yarnpkg.com/katex/-/katex-0.16.22.tgz#d2b3d66464b1e6d69e6463b28a86ced5a02c5ccd"
@@ -2732,19 +2596,6 @@ langium@3.3.1:
     vscode-languageserver "~9.0.1"
     vscode-languageserver-textdocument "~1.0.11"
     vscode-uri "~3.0.8"
-
-langsmith@^0.3.46:
-  version "0.3.46"
-  resolved "https://registry.yarnpkg.com/langsmith/-/langsmith-0.3.46.tgz#6d369f2c91aa771f49a5f7c4e4e67c12763cf737"
-  integrity sha512-Hhi4/cMjhWIGpu0DW5eQrXBbeeKQWPYYQyJCYzhFjod+xinMry4i8QR0gxrrgjGOgfMuU6nyK79YqjGTEPVbDA==
-  dependencies:
-    "@types/uuid" "^10.0.0"
-    chalk "^4.1.2"
-    console-table-printer "^2.12.1"
-    p-queue "^6.6.2"
-    p-retry "4"
-    semver "^7.6.3"
-    uuid "^10.0.0"
 
 layout-base@^1.0.0:
   version "1.0.2"
@@ -2981,11 +2832,6 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mustache@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
-  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
-
 mz@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
@@ -3030,13 +2876,6 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
-ollama@^0.5.12:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/ollama/-/ollama-0.5.16.tgz#cb695b4aab6f6c07236a04b3aee40160f4f9e892"
-  integrity sha512-OEbxxOIUZtdZgOaTPAULo051F5y+Z1vosxEYOoABPnQKeW7i4O8tJNlxCB+xioyoorVqgjkdj+TA1f1Hy2ug/w==
-  dependencies:
-    whatwg-fetch "^3.6.20"
-
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3053,16 +2892,6 @@ oniguruma-to-es@^3.1.0:
     regex "^6.0.1"
     regex-recursion "^6.0.2"
 
-openai@^5.3.0:
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/openai/-/openai-5.10.1.tgz#4535a9603f4d03b2392bb2ca41a618a80fdcfacd"
-  integrity sha512-fq6xVfv1/gpLbsj8fArEt3b6B9jBxdhAK+VJ+bDvbUvNd+KTLlA3bnDeYZaBsGH9LUhJ1M1yXfp9sEyBLMx6eA==
-
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -3076,29 +2905,6 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
-
-p-queue@^6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
-  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
-  dependencies:
-    eventemitter3 "^4.0.4"
-    p-timeout "^3.2.0"
-
-p-retry@4:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
-  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
-  dependencies:
-    "@types/retry" "0.12.0"
-    retry "^0.13.1"
-
-p-timeout@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -3353,11 +3159,6 @@ resolve@^1.1.7, resolve@^1.22.1, resolve@^1.22.8:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-retry@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
-
 reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
@@ -3460,11 +3261,6 @@ sander@^0.5.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-semver@^7.6.3:
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
-  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
-
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -3500,11 +3296,6 @@ signal-exit@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
-
-simple-wcswidth@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz#66722f37629d5203f9b47c5477b1225b85d6525b"
-  integrity sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==
 
 socket.io-client@^4.8.1:
   version "4.8.1"
@@ -3636,13 +3427,6 @@ superjson@^2.2.2:
   integrity sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==
   dependencies:
     copy-anything "^3.0.2"
-
-supports-color@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
-  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
-  dependencies:
-    has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -3916,20 +3700,10 @@ util-deprecate@^1.0.2:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
-
 uuid@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
-
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -4061,11 +3835,6 @@ wavesurfer.js@^7.11.0:
   resolved "https://registry.yarnpkg.com/wavesurfer.js/-/wavesurfer.js-7.11.0.tgz#989b7d2044db0538abc5a37eb730b9a53bb40903"
   integrity sha512-LOGdIBIKv/roYuQYClhoqhwbIdQL1GfobLnS2vx0heoLD9lu57OUHWE2DIsCNXBvCsmmbkUvJq9W8bPLPbikGw==
 
-whatwg-fetch@^3.6.20:
-  version "3.6.20"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz#580ce6d791facec91d37c72890995a0b48d31c70"
-  integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
-
 which-module@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
@@ -4159,16 +3928,6 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
-
-zod-to-json-schema@^3.22.3:
-  version "3.24.6"
-  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz#5920f020c4d2647edfbb954fa036082b92c9e12d"
-  integrity sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==
-
-zod@^3.25.32:
-  version "3.25.76"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
-  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
 zwitch@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
## Summary

- migrate the AI agent runtime from the frontend LangChain implementation to a stateless Rust Rig backend while preserving full conversation history
- expose tool-call traces and require manual confirmation for mutating tools
- add multimodal video-frame extraction so models can inspect extracted frames correctly
- improve chat rendering with Markdown copy actions and inline Base64 image display
- remove obsolete LangChain dependencies and update the agent documentation

## Testing

- `npm run check`
- `npm run build`

## Summary by Sourcery

Migrate the AI assistant from a frontend LangChain-based implementation to a stateless Rust Rig agent, updating the Svelte UI, tool wiring, and documentation accordingly.

Enhancements:
- Introduce a Rust-based Rig agent that orchestrates BSR tools and maintains tool-call traces, with a new Tauri command for chat handling.
- Refactor the frontend AI page to use a simple agentChat API and a new message model, adding persistence, tool confirmation flow, and improved error handling.
- Add multimodal support for video-frame extraction and display, plus inline Markdown copy buttons and better rendering of tool and assistant messages.
- Normalize and centralize tool invocation in the frontend, enforcing manual confirmation for mutating operations and exposing structured tool-call metadata.
- Improve video path resolution in Rust video-editing handlers to correctly handle relative vs absolute paths and add tests.
- Update architecture and agent documentation to describe the new Rust Rig-based AI agent and remove outdated LangChain-specific guidance.

Build:
- Remove LangChain-related JavaScript dependencies from the frontend build and add the rig-core crate to the Rust backend.

Tests:
- Add Rust unit tests for video path resolution and agent message/tool argument handling, including image-tool result wiring.