### PR TITLE
fix: optimize NVENC encoder parameters to reduce bitrate

### DIFF
--- a/src-tauri/src/ffmpeg/hwaccel.rs
+++ b/src-tauri/src/ffmpeg/hwaccel.rs
@@ -98,7 +98,7 @@ pub fn apply_x264_quality_args(command: &mut tokio::process::Command, encoder: &
 pub fn quality_args_for_encoder(encoder: &str) -> &'static [&'static str] {
     match encoder {
         VAAPI_ENCODER => &["-qp", "20"],
-        NVENC_ENCODER => &["-preset", "p5", "-rc", "vbr", "-cq", "20", "-b:v", "0"],
+        NVENC_ENCODER => &["-preset", "p5", "-rc", "vbr", "-cq", "23", "-b:v", "8000k"],
         VIDEOTOOLBOX_ENCODER => &["-q:v", "65"],
         QSV_ENCODER => &["-preset", "medium", "-global_quality", "20"],
         AMF_ENCODER => &[
@@ -406,7 +406,7 @@ mod tests {
 
         assert_eq!(
             args,
-            &["-preset", "p5", "-rc", "vbr", "-cq", "20", "-b:v", "0"]
+            &["-preset", "p5", "-rc", "vbr", "-cq", "23", "-b:v", "8000k"]
         );
         assert!(!args.contains(&"-crf"));
     }


### PR DESCRIPTION
## Problem
When generating clips with danmaku overlay, the output bitrate was extremely high (~35 Mbps), resulting in unnecessarily large file sizes.

## Root Cause
The NVENC encoder was configured with:
- CQ (Constant Quality) = 20 (very high quality)
- Target bitrate = 0 (no limit)

This caused the encoder to use extremely high bitrate to maintain the quality target, especially with complex danmaku overlays.

## Solution
Adjusted NVENC encoder parameters:
- Changed CQ from 20 to 23 (still high quality, more reasonable)
- Set target bitrate to 8000k (8 Mbps limit)

## Expected Results
- Bitrate reduced from ~35 Mbps to ~8 Mbps (77% reduction)
- File size reduced by approximately 75%
- Visual quality remains excellent for danmaku clips

## Summary by Sourcery

Adjust NVENC hardware encoder configuration to reduce output bitrate and file size while maintaining visual quality.

Bug Fixes:
- Limit NVENC bitrate and relax constant quality settings to prevent excessively high bitrates for clips with danmaku overlays.

Enhancements:
- Standardize NVENC encoder defaults around a capped variable bitrate profile for more reasonable output sizes.

Tests:
- Update NVENC encoder argument test expectations to match the new bitrate and quality configuration.