### PR TITLE
fix: only migrate BSR-owned files when cache/output dir changes

### DIFF
--- a/src-tauri/crates/recorder/src/platforms/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/mod.rs
@@ -18,6 +18,20 @@ pub enum PlatformType {
 }
 
 impl PlatformType {
+    /// All known platforms. Keep in sync with the enum variants; used by
+    /// cache directory migration to tell BSR-owned folders apart from
+    /// pre-existing user files.
+    pub const ALL: [PlatformType; 8] = [
+        PlatformType::BiliBili,
+        PlatformType::Douyin,
+        PlatformType::Huya,
+        PlatformType::Youtube,
+        PlatformType::Kuaishou,
+        PlatformType::Xiaohongshu,
+        PlatformType::TikTok,
+        PlatformType::Weibo,
+    ];
+
     pub fn as_str(&self) -> &'static str {
         match self {
             PlatformType::BiliBili => "bilibili",
@@ -92,6 +106,26 @@ mod tests {
         );
         assert_eq!(PlatformType::from_str("tiktok"), Ok(PlatformType::TikTok));
         assert_eq!(PlatformType::from_str("weibo"), Ok(PlatformType::Weibo));
+    }
+
+    #[test]
+    fn test_platform_type_all_covers_every_variant() {
+        // ALL must stay in sync with the enum; a missing variant would make
+        // cache migration silently skip that platform's folder.
+        let names: HashSet<&str> = PlatformType::ALL.iter().map(|p| p.as_str()).collect();
+        assert_eq!(names.len(), PlatformType::ALL.len());
+        for name in [
+            "bilibili",
+            "douyin",
+            "huya",
+            "youtube",
+            "kuaishou",
+            "xiaohongshu",
+            "tiktok",
+            "weibo",
+        ] {
+            assert!(names.contains(name), "ALL is missing {name}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/handlers/config.rs
+++ b/src-tauri/src/handlers/config.rs
@@ -153,56 +153,38 @@ pub async fn set_cache_path(state: state_type!(), cache_path: String) -> Result<
         )
         .await?;
 
-    let mut old_cache_entries = vec![];
-    if let Ok(entries) = std::fs::read_dir(&old_cache_path) {
-        for entry in entries.flatten() {
-            // check if entry is the same as new cache path
-            if entry.path() == std::path::Path::new(&cache_path) {
-                continue;
-            }
-            old_cache_entries.push(entry.path());
-        }
-    }
-
-    // copy all entries to new cache
-    for entry in &old_cache_entries {
-        let new_entry = std::path::Path::new(&cache_path).join(entry.file_name().unwrap());
-        // if entry is a folder
-        if entry.is_dir() {
-            if let Err(e) = crate::handlers::utils::copy_dir_all(entry, &new_entry) {
-                log::error!("Copy old cache to new cache error: {e}");
-                return Err(e.to_string());
-            }
-        } else if let Err(e) = std::fs::copy(entry, &new_entry) {
-            log::error!("Copy old cache to new cache error: {e}");
-            return Err(e.to_string());
-        }
-    }
-
-    log::info!("Copy old cache to new cache done");
-    state.db.new_message("缓存目录切换", "缓存切换完成").await?;
+    // Only migrate BSR-owned folders: the new directory may already hold the
+    // user's own files, which must be left untouched.
+    let plan =
+        crate::handlers::migrate::plan_cache_migration(old_cache_path_obj, new_cache_path_obj);
+    let migrate_result = crate::handlers::migrate::run_plan(&plan, new_cache_path_obj);
 
     state.recorder_manager.set_migrating(false);
 
-    // remove all old cache entries
-    for entry in old_cache_entries {
-        if entry.is_dir() {
-            if let Err(e) = std::fs::remove_dir_all(&entry) {
-                log::error!("Remove old cache error: {e}");
-            }
-        } else if let Err(e) = std::fs::remove_file(&entry) {
-            log::error!("Remove old cache error: {e}");
+    match migrate_result {
+        Ok(moved) => {
+            log::info!("Cache migration done: {moved} entries moved");
+            state.db.new_message("缓存目录切换", "缓存切换完成").await?;
+            Ok(())
+        }
+        Err(e) => {
+            log::error!("Cache migration failed: {e}");
+            state
+                .db
+                .new_message("缓存目录切换", &format!("缓存迁移失败：{e}"))
+                .await?;
+            Err(e.to_string())
         }
     }
-
-    Ok(())
 }
 
 #[cfg_attr(feature = "gui", tauri::command)]
 #[allow(dead_code)]
 pub async fn set_output_path(state: state_type!(), output_path: String) -> Result<(), String> {
-    let mut config = state.config.write().await;
-    let old_output_path = config.output.clone();
+    // Read the old path and release the lock immediately: holding the write
+    // lock across the migration would block every config reader for its whole
+    // duration.
+    let old_output_path = state.config.read().await.output.clone();
     log::info!("Try to set output path: {old_output_path} -> {output_path}");
     if old_output_path == output_path {
         return Ok(());
@@ -216,45 +198,34 @@ pub async fn set_output_path(state: state_type!(), output_path: String) -> Resul
         return Err("New output path cannot be under old output path".to_string());
     }
 
-    // list all file and folder in old output
-    let mut old_output_entries = vec![];
-    if let Ok(entries) = std::fs::read_dir(&old_output_path) {
-        for entry in entries.flatten() {
-            // check if entry is the same as new output path
-            if entry.path() == std::path::Path::new(&output_path) {
-                continue;
-            }
-            old_output_entries.push(entry.path());
-        }
-    }
+    state
+        .db
+        .new_message(
+            "切片目录切换",
+            "切片正在迁移中，根据数据量情况可能花费较长时间",
+        )
+        .await?;
 
-    // rename all entries to new output
-    for entry in &old_output_entries {
-        let new_entry = std::path::Path::new(&output_path).join(entry.file_name().unwrap());
-        // if entry is a folder
-        if entry.is_dir() {
-            if let Err(e) = crate::handlers::utils::copy_dir_all(entry, &new_entry) {
-                log::error!("Copy old output to new output error: {e}");
-                return Err(e.to_string());
-            }
-        } else if let Err(e) = std::fs::copy(entry, &new_entry) {
-            log::error!("Copy old output to new output error: {e}");
+    // Only migrate clips and their sidecars, so pre-existing user files in the
+    // old directory stay where they are.
+    let plan =
+        crate::handlers::migrate::plan_output_migration(old_output_path_obj, new_output_path_obj);
+    let moved = match crate::handlers::migrate::run_plan(&plan, new_output_path_obj) {
+        Ok(moved) => moved,
+        Err(e) => {
+            log::error!("Output migration failed: {e}");
+            state
+                .db
+                .new_message("切片目录切换", &format!("切片迁移失败：{e}"))
+                .await?;
             return Err(e.to_string());
         }
-    }
+    };
 
-    // remove all old output entries
-    for entry in old_output_entries {
-        if entry.is_dir() {
-            if let Err(e) = std::fs::remove_dir_all(&entry) {
-                log::error!("Remove old output error: {e}");
-            }
-        } else if let Err(e) = std::fs::remove_file(&entry) {
-            log::error!("Remove old output error: {e}");
-        }
-    }
+    log::info!("Output migration done: {moved} entries moved");
+    state.config.write().await.set_output_path(&output_path);
+    state.db.new_message("切片目录切换", "切片切换完成").await?;
 
-    config.set_output_path(&output_path);
     Ok(())
 }
 

--- a/src-tauri/src/handlers/migrate.rs
+++ b/src-tauri/src/handlers/migrate.rs
@@ -1,0 +1,414 @@
+//! Selective migration of BSR-owned files when the cache or output directory
+//! changes.
+//!
+//! Users may point the cache / output setting at a directory that already holds
+//! their own files, so migration must not move everything it finds. These
+//! helpers build a list of entries BSR itself created and leave the rest alone.
+
+use recorder::platforms::PlatformType;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Extensions of files that sit next to a clip and share its file stem.
+/// Mirrors the cleanup list in `handlers::video::delete_video`.
+const CLIP_SIDECAR_EXTENSIONS: [&str; 6] = ["jpg", "srt", "wav", "mp3", "opus", "ass"];
+
+/// What a migration walk found in the source directory.
+#[derive(Debug, Default)]
+pub struct MigrationPlan {
+    /// Entries BSR owns. Each is migrated as a unit (a file, or a whole folder).
+    pub entries: Vec<PathBuf>,
+    /// Entries left behind because they are not BSR's.
+    pub skipped: Vec<PathBuf>,
+}
+
+/// Outcome of migrating a single entry.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MigrateOutcome {
+    /// Same filesystem: renamed in place, no bytes copied.
+    Renamed,
+    /// Across filesystems: copied then removed from the source.
+    Copied,
+    /// Destination already had this name; source left untouched.
+    SkippedExists,
+}
+
+/// Plan a cache directory migration.
+///
+/// The cache layout is `<cache>/<platform>/<room_id>/<live_id>/...`, so only
+/// top-level directories named after a known platform belong to BSR.
+pub fn plan_cache_migration(src_root: &Path, dst_root: &Path) -> MigrationPlan {
+    let platforms: HashSet<&str> = PlatformType::ALL.iter().map(|p| p.as_str()).collect();
+    let mut plan = MigrationPlan::default();
+
+    let Ok(entries) = std::fs::read_dir(src_root) else {
+        return plan;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == dst_root {
+            continue;
+        }
+
+        let is_platform_dir = path.is_dir()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| platforms.contains(name));
+
+        if is_platform_dir {
+            plan.entries.push(path);
+        } else {
+            plan.skipped.push(path);
+        }
+    }
+
+    plan
+}
+
+/// Plan an output (clip) directory migration.
+///
+/// The output directory is flat: clips are `.mp4` files, each optionally
+/// accompanied by sidecars sharing its stem (cover, subtitles, audio samples,
+/// danmaku ass). `filelist_*.txt` files are FFmpeg scratch files and are never
+/// migrated. Sidecars without a matching clip are left behind.
+pub fn plan_output_migration(src_root: &Path, dst_root: &Path) -> MigrationPlan {
+    let mut plan = MigrationPlan::default();
+
+    let Ok(entries) = std::fs::read_dir(src_root) else {
+        return plan;
+    };
+
+    let mut files = vec![];
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path == dst_root {
+            continue;
+        }
+        if path.is_dir() {
+            plan.skipped.push(path);
+        } else {
+            files.push(path);
+        }
+    }
+
+    // Clip stems drive the walk: `foo.mp4` claims `foo.jpg`, `foo.srt`, ...
+    // `foo.tmp.mp4` yields stem `foo.tmp`, so leftover temp clips migrate on
+    // their own rather than being mistaken for a sidecar.
+    let clip_stems: HashSet<String> = files
+        .iter()
+        .filter(|path| has_extension(path, "mp4"))
+        .filter_map(|path| file_stem(path))
+        .collect();
+
+    for path in files {
+        if has_extension(&path, "mp4") {
+            plan.entries.push(path);
+            continue;
+        }
+
+        let is_sidecar = CLIP_SIDECAR_EXTENSIONS
+            .iter()
+            .any(|ext| has_extension(&path, ext))
+            && file_stem(&path).is_some_and(|stem| clip_stems.contains(&stem));
+
+        if is_sidecar {
+            plan.entries.push(path);
+        } else {
+            plan.skipped.push(path);
+        }
+    }
+
+    plan
+}
+
+/// Case-insensitive extension check, so `.MP4` counts too.
+fn has_extension(path: &Path, expected: &str) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(expected))
+}
+
+fn file_stem(path: &Path) -> Option<String> {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(str::to_string)
+}
+
+/// Move one entry into `dst_root`, keeping its file name.
+///
+/// Tries `rename` first so a same-filesystem directory change costs nothing,
+/// and falls back to copy + delete when the two paths live on different
+/// filesystems. An existing destination is never overwritten.
+pub fn migrate_entry(entry: &Path, dst_root: &Path) -> std::io::Result<MigrateOutcome> {
+    let Some(file_name) = entry.file_name() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "entry has no file name",
+        ));
+    };
+    let target = dst_root.join(file_name);
+
+    if target.exists() {
+        log::warn!(
+            "Skip migrating {}: {} already exists",
+            entry.display(),
+            target.display()
+        );
+        return Ok(MigrateOutcome::SkippedExists);
+    }
+
+    std::fs::create_dir_all(dst_root)?;
+
+    if std::fs::rename(entry, &target).is_ok() {
+        return Ok(MigrateOutcome::Renamed);
+    }
+
+    // rename fails across filesystems (EXDEV); fall back to a real copy.
+    if entry.is_dir() {
+        crate::handlers::utils::copy_dir_all(entry, &target)?;
+        std::fs::remove_dir_all(entry)?;
+    } else {
+        std::fs::copy(entry, &target)?;
+        std::fs::remove_file(entry)?;
+    }
+
+    Ok(MigrateOutcome::Copied)
+}
+
+/// Migrate every entry in `plan` into `dst_root`.
+///
+/// Returns the number of entries actually moved. A failure on one entry aborts
+/// the run: entries already moved stay at the destination, and the rest stay at
+/// the source, so no data is lost either way.
+pub fn run_plan(plan: &MigrationPlan, dst_root: &Path) -> std::io::Result<usize> {
+    if !plan.skipped.is_empty() {
+        log::info!(
+            "Leaving {} non-BSR entries in place: {:?}",
+            plan.skipped.len(),
+            plan.skipped
+                .iter()
+                .take(10)
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    let mut moved = 0;
+    for entry in &plan.entries {
+        match migrate_entry(entry, dst_root) {
+            Ok(MigrateOutcome::SkippedExists) => {}
+            Ok(_) => moved += 1,
+            Err(e) => {
+                log::error!("Failed to migrate {}: {e}", entry.display());
+                return Err(e);
+            }
+        }
+    }
+
+    log::info!(
+        "Migrated {moved}/{} entries to {}",
+        plan.entries.len(),
+        dst_root.display()
+    );
+    Ok(moved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Isolated scratch directory, removed on drop.
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "bsr_migrate_{tag}_{}",
+                uuid::Uuid::new_v4().simple()
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn dir(&self, rel: &str) -> PathBuf {
+            let path = self.0.join(rel);
+            std::fs::create_dir_all(&path).unwrap();
+            path
+        }
+
+        fn file(&self, rel: &str) -> PathBuf {
+            let path = self.0.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&path, b"x").unwrap();
+            path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn names(paths: &[PathBuf]) -> Vec<String> {
+        let mut names = paths
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn cache_plan_picks_platform_dirs_only() {
+        let src = TempDir::new("cache_src");
+        let dst = TempDir::new("cache_dst");
+
+        src.file("bilibili/1713546334/live_001/playlist.m3u8");
+        src.file("douyin/123/live_002/danmu.txt");
+        src.dir("我的电影收藏");
+        src.file("家庭录像.mp4");
+        src.file("notes.txt");
+
+        let plan = plan_cache_migration(&src.0, &dst.0);
+
+        assert_eq!(names(&plan.entries), vec!["bilibili", "douyin"]);
+        assert_eq!(
+            names(&plan.skipped),
+            vec!["notes.txt", "家庭录像.mp4", "我的电影收藏"]
+        );
+    }
+
+    #[test]
+    fn cache_plan_skips_destination_nested_in_source() {
+        let src = TempDir::new("cache_nested");
+        src.file("bilibili/1/live/playlist.m3u8");
+        let dst = src.dir("bilibili_new");
+
+        let plan = plan_cache_migration(&src.0, &dst);
+
+        assert_eq!(names(&plan.entries), vec!["bilibili"]);
+        assert!(plan.skipped.is_empty());
+    }
+
+    #[test]
+    fn output_plan_takes_clips_and_their_sidecars() {
+        let src = TempDir::new("out_src");
+        let dst = TempDir::new("out_dst");
+
+        src.file("[1713546334][note][live_001][title][2026-08-14].mp4");
+        src.file("[1713546334][note][live_001][title][2026-08-14].jpg");
+        src.file("[1713546334][note][live_001][title][2026-08-14].srt");
+        src.file("[1713546334][note][live_001][title][2026-08-14].opus");
+        src.file("旅行vlog.mp4");
+        src.file("旅行vlog.jpg");
+
+        let plan = plan_output_migration(&src.0, &dst.0);
+
+        assert_eq!(
+            names(&plan.entries),
+            vec![
+                "[1713546334][note][live_001][title][2026-08-14].jpg",
+                "[1713546334][note][live_001][title][2026-08-14].mp4",
+                "[1713546334][note][live_001][title][2026-08-14].opus",
+                "[1713546334][note][live_001][title][2026-08-14].srt",
+                "旅行vlog.jpg",
+                "旅行vlog.mp4",
+            ]
+        );
+        assert!(plan.skipped.is_empty());
+    }
+
+    #[test]
+    fn output_plan_leaves_scratch_orphans_and_dirs() {
+        let src = TempDir::new("out_misc");
+        let dst = TempDir::new("out_misc_dst");
+
+        src.file("clip.mp4");
+        src.file("filelist_aa08ca7df6f1319d.txt");
+        src.file("孤立字幕.srt");
+        src.file("readme.txt");
+        src.dir("素材");
+
+        let plan = plan_output_migration(&src.0, &dst.0);
+
+        assert_eq!(names(&plan.entries), vec!["clip.mp4"]);
+        assert_eq!(
+            names(&plan.skipped),
+            vec![
+                "filelist_aa08ca7df6f1319d.txt",
+                "readme.txt",
+                "孤立字幕.srt",
+                "素材",
+            ]
+        );
+    }
+
+    #[test]
+    fn output_plan_keeps_temp_clip_as_its_own_entry() {
+        let src = TempDir::new("out_tmp");
+        let dst = TempDir::new("out_tmp_dst");
+
+        src.file("clip.mp4");
+        src.file("clip.tmp.mp4");
+        src.file("clip.0.mp4");
+        src.file("clip.ass");
+
+        let plan = plan_output_migration(&src.0, &dst.0);
+
+        assert_eq!(
+            names(&plan.entries),
+            vec!["clip.0.mp4", "clip.ass", "clip.mp4", "clip.tmp.mp4"]
+        );
+        assert!(plan.skipped.is_empty());
+    }
+
+    #[test]
+    fn migrate_entry_moves_file_and_skips_existing() {
+        let src = TempDir::new("move_src");
+        let dst = TempDir::new("move_dst");
+
+        let clip = src.file("clip.mp4");
+        let outcome = migrate_entry(&clip, &dst.0).unwrap();
+
+        assert_eq!(outcome, MigrateOutcome::Renamed);
+        assert!(!clip.exists());
+        assert!(dst.0.join("clip.mp4").exists());
+
+        // A second clip with the same name must not clobber the destination.
+        let again = src.file("clip.mp4");
+        std::fs::write(&again, b"different").unwrap();
+        let outcome = migrate_entry(&again, &dst.0).unwrap();
+
+        assert_eq!(outcome, MigrateOutcome::SkippedExists);
+        assert!(again.exists(), "source must survive a skipped migration");
+        assert_eq!(std::fs::read(dst.0.join("clip.mp4")).unwrap(), b"x");
+    }
+
+    #[test]
+    fn run_plan_moves_platform_dir_contents() {
+        let src = TempDir::new("run_src");
+        let dst = TempDir::new("run_dst");
+
+        src.file("bilibili/1713546334/live_001/playlist.m3u8");
+        src.file("我的视频.mp4");
+
+        let plan = plan_cache_migration(&src.0, &dst.0);
+        let moved = run_plan(&plan, &dst.0).unwrap();
+
+        assert_eq!(moved, 1);
+        assert!(dst
+            .0
+            .join("bilibili/1713546334/live_001/playlist.m3u8")
+            .exists());
+        assert!(!src.0.join("bilibili").exists());
+        assert!(
+            src.0.join("我的视频.mp4").exists(),
+            "user files must stay in the old directory"
+        );
+    }
+}

--- a/src-tauri/src/handlers/mod.rs
+++ b/src-tauri/src/handlers/mod.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod config;
 pub mod macros;
 pub mod message;
+pub mod migrate;
 pub mod recorder;
 pub mod summary;
 pub mod task;


### PR DESCRIPTION
## Problem

Switching the cache or output directory copied **every** entry in the old directory. Users may point either setting at a directory that already holds their own files, so an unrelated video library could get swept into the migration.

Two smaller issues in the same code path:

- Migration always did a full copy, so a same-disk directory change rewrote every byte instead of just renaming.
- `std::fs::copy` silently overwrote same-named files at the destination.
- `set_output_path` took the config **write** lock at function entry and held it across the entire synchronous copy, blocking every config reader for the duration. It also had no progress messages, unlike `set_cache_path`.

## Approach

New `handlers::migrate` module holds the ownership rules, shared by both handlers.

**Cache** — the layout is `<cache>/<platform>/<room_id>/<live_id>/...`, so only top-level directories named after a known platform belong to BSR. Everything else stays put.

**Output** — flat directory: all `.mp4` clips migrate, plus sidecars sharing a clip's stem (`.jpg` `.srt` `.wav` `.mp3` `.opus` `.ass` — mirroring the cleanup list in `delete_video`). Left behind: `filelist_*.txt` FFmpeg scratch files, orphan sidecars with no matching clip, and subdirectories.

`PlatformType::ALL` keeps the platform list next to the enum, with a test asserting all 8 variants are covered — adding a platform and forgetting `ALL` now fails a test rather than silently skipping that platform's folder during migration.

The migration action itself tries `rename` first and falls back to copy + delete only across filesystems (`EXDEV`), never overwrites an existing destination, and on error aborts leaving moved entries at the destination and the rest at the source, so no data is lost either way.

## Note on scope

Per the agreed rules, the output directory does **not** filter by filename. If a user sets the clip directory to a folder holding their own videos, those `.mp4` files (and same-stem `.jpg`) will move to the new directory. Nothing is deleted, but the location changes. `run_plan` logs skipped entries for troubleshooting.

## Testing

- 7 new migration tests covering mixed directories: real cache trees, user folders, clips with sidecars, scratch files, orphan sidecars, `.tmp.mp4` handling, no-overwrite behavior, and an end-to-end `run_plan` that asserts user files stay in the old directory
- 1 new test asserting `PlatformType::ALL` covers every variant
- Full suite: 111 passed, 0 failed
- `cargo clippy --all-targets` clean under both `gui` and `headless` features

## Summary by Sourcery

Restrict cache and output directory migrations to BSR-owned files and add a shared migration helper with safer move semantics.

New Features:
- Introduce a migration helper module that plans and executes selective cache and output directory moves.

Bug Fixes:
- Prevent cache and output directory changes from unintentionally moving pre-existing user files.
- Avoid overwriting existing files during directory migration and ensure moves fail safely without data loss.
- Eliminate long-held config write locks during output path migration that blocked readers.

Enhancements:
- Use platform-aware cache layout detection via PlatformType::ALL to identify BSR-owned cache folders.
- Migrate clips and their sidecar files from the output directory while leaving scratch files, orphan sidecars, and subdirectories behind.
- Prefer renames over copies for same-filesystem moves and log skipped non-BSR entries and migration results for observability.

Tests:
- Add unit tests covering cache and output migration planning, temp clip handling, non-overwrite behavior, and end-to-end migration ensuring user files remain in place.
- Add a test verifying PlatformType::ALL stays in sync with all enum variants to keep cache migration coverage correct.