### PR TITLE
fix: replace .unwrap() and .expect() calls with proper error handling to prevent panics

### DIFF
--- a/src-tauri/crates/recorder/src/danmu.rs
+++ b/src-tauri/crates/recorder/src/danmu.rs
@@ -42,12 +42,19 @@ impl DanmuStorage {
             let content = parts[1].to_string();
             preload_cache.push(DanmuEntry { ts, content });
         }
+        // lines.next_line() consumes the reader, so the file is closed when lines is dropped
+        drop(lines);
+
         let file = OpenOptions::new()
             .append(true)
             .create(true)
             .open(file_path)
             .await
-            .expect("create danmu.txt failed");
+            .map_err(|e| {
+                log::error!("Failed to open danmu file for append: {}", e);
+                e
+            })
+            .ok()?;
         Some(DanmuStorage {
             cache: RwLock::new(preload_cache),
             file: RwLock::new(file),

--- a/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
@@ -784,11 +784,12 @@ async fn post_video_meta(
     preupload_response: &PreuploadResponse,
     video_file: &Path,
 ) -> Result<PostVideoMetaResponse, RecorderError> {
+    let file_size = video_file.metadata()?.len();
     let url = format!(
         "https:{}{}?uploads=&output=json&profile=ugcfx/bup&filesize={}&partsize={}&biz_id={}",
         preupload_response.endpoint,
         preupload_response.upos_uri.replace("upos:/", ""),
-        video_file.metadata().unwrap().len(),
+        file_size,
         preupload_response.chunk_size,
         preupload_response.biz_id
     );
@@ -840,7 +841,7 @@ async fn upload_video(client: &Client, params: UploadParams<'_>) -> Result<usize
                     read_total,
                     chunk * params.preupload_response.chunk_size,
                     chunk * params.preupload_response.chunk_size + read_total,
-                    params.video_file.metadata().unwrap().len()
+                    file_size
                 );
 
             match client

--- a/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
@@ -664,8 +664,10 @@ pub async fn get_stream_info(
 
 /// Download file from url to path
 pub async fn download_file(client: &Client, url: &str, path: &Path) -> Result<(), RecorderError> {
-    if !path.parent().unwrap().exists() {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
     let response = client.get(url).send().await?;
     let bytes = response.bytes().await?;

--- a/src-tauri/crates/recorder/src/platforms/kuaishou/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/kuaishou/api.rs
@@ -775,10 +775,10 @@ pub async fn get_stream_urls(
     let play_urls = live_data
         .live_stream
         .as_ref()
-        .unwrap()
-        .play_urls
-        .as_ref()
-        .unwrap();
+        .and_then(|ls| ls.play_urls.as_ref())
+        .ok_or_else(|| RecorderError::ApiError {
+            error: "No play URLs available in live stream data".to_string(),
+        })?;
 
     let mut all_representations = Vec::new();
 

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -148,9 +148,10 @@ pub async fn concat_videos_with_transition(
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
-    let output_folder = output_path.parent().unwrap();
+    let output_folder = output_path.parent().ok_or("Invalid output path")?;
     if !output_folder.exists() {
-        std::fs::create_dir_all(output_folder).unwrap();
+        std::fs::create_dir_all(output_folder)
+            .map_err(|e| format!("Failed to create output folder: {e}"))?;
     }
 
     // If no transition or only one video, use simple concat
@@ -159,7 +160,7 @@ pub async fn concat_videos_with_transition(
 
         let mut filelist = tokio::fs::File::create(&output_folder.join(&filelist_filename))
             .await
-            .unwrap();
+            .map_err(|e| format!("Failed to create filelist: {e}"))?;
         for video in videos {
             let abs_path = tokio::fs::canonicalize(video).await.unwrap_or_else(|e| {
                 log::warn!("Failed to canonicalize path {}: {e}", video.display());
@@ -169,9 +170,12 @@ pub async fn concat_videos_with_transition(
             filelist
                 .write_all(format!("file '{}'\n", escaped_path).as_bytes())
                 .await
-                .unwrap();
+                .map_err(|e| format!("Failed to write to filelist: {e}"))?;
         }
-        filelist.flush().await.unwrap();
+        filelist
+            .flush()
+            .await
+            .map_err(|e| format!("Failed to flush filelist: {e}"))?;
 
         // Convert &[PathBuf] to &[&Path] for check_videos
         let video_refs: Vec<&Path> = videos.iter().map(|p| p.as_path()).collect();
@@ -183,7 +187,10 @@ pub async fn concat_videos_with_transition(
             "-safe",
             "0",
             "-i",
-            output_folder.join(&filelist_filename).to_str().unwrap(),
+            output_folder
+                .join(&filelist_filename)
+                .to_str()
+                .ok_or("Invalid filelist path")?,
         ]);
         if should_encode {
             let video_encoder = hwaccel::get_x264_encoder().await;
@@ -198,7 +205,7 @@ pub async fn concat_videos_with_transition(
         } else {
             ffmpeg_process.args(["-c", "copy"]);
         }
-        ffmpeg_process.args([output_path.to_str().unwrap()]);
+        ffmpeg_process.args([output_path.to_str().ok_or("Invalid output path")?]);
         ffmpeg_process.args(["-progress", "pipe:2"]);
         ffmpeg_process.args(["-y"]);
 
@@ -221,7 +228,7 @@ pub async fn concat_videos_with_transition(
 
         // Add all input files
         for video in videos {
-            ffmpeg_process.args(["-i", video.to_str().unwrap()]);
+            ffmpeg_process.args(["-i", video.to_str().ok_or("Invalid video path")?]);
         }
 
         // Build xfade filter chain for video
@@ -281,7 +288,7 @@ pub async fn concat_videos_with_transition(
         ffmpeg_process.args(["-c:a", "aac"]);
         ffmpeg_process.args(["-progress", "pipe:2"]);
         ffmpeg_process.args(["-y"]);
-        ffmpeg_process.args([output_path.to_str().unwrap()]);
+        ffmpeg_process.args([output_path.to_str().ok_or("Invalid output path")?]);
 
         handle_ffmpeg_process(reporter, &mut ffmpeg_process).await?;
     }

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -148,10 +148,19 @@ pub async fn concat_videos_with_transition(
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
-    let output_folder = output_path.parent().ok_or("Invalid output path")?;
+    let output_folder = output_path.parent().ok_or_else(|| {
+        format!(
+            "Invalid output path (no parent directory): {}",
+            output_path.display()
+        )
+    })?;
     if !output_folder.exists() {
-        std::fs::create_dir_all(output_folder)
-            .map_err(|e| format!("Failed to create output folder: {e}"))?;
+        std::fs::create_dir_all(output_folder).map_err(|e| {
+            format!(
+                "Failed to create output folder '{}': {e}",
+                output_folder.display()
+            )
+        })?;
     }
 
     // If no transition or only one video, use simple concat
@@ -181,16 +190,19 @@ pub async fn concat_videos_with_transition(
         let video_refs: Vec<&Path> = videos.iter().map(|p| p.as_path()).collect();
         let should_encode = !super::check_videos(&video_refs).await;
 
+        let filelist_path = output_folder.join(&filelist_filename);
         ffmpeg_process.args([
             "-f",
             "concat",
             "-safe",
             "0",
             "-i",
-            output_folder
-                .join(&filelist_filename)
-                .to_str()
-                .ok_or("Invalid filelist path")?,
+            filelist_path.to_str().ok_or_else(|| {
+                format!(
+                    "Invalid filelist path (non-UTF8): {}",
+                    filelist_path.display()
+                )
+            })?,
         ]);
         if should_encode {
             let video_encoder = hwaccel::get_x264_encoder().await;
@@ -205,7 +217,9 @@ pub async fn concat_videos_with_transition(
         } else {
             ffmpeg_process.args(["-c", "copy"]);
         }
-        ffmpeg_process.args([output_path.to_str().ok_or("Invalid output path")?]);
+        ffmpeg_process.args([output_path.to_str().ok_or_else(|| {
+            format!("Invalid output path (non-UTF8): {}", output_path.display())
+        })?]);
         ffmpeg_process.args(["-progress", "pipe:2"]);
         ffmpeg_process.args(["-y"]);
 
@@ -228,7 +242,12 @@ pub async fn concat_videos_with_transition(
 
         // Add all input files
         for video in videos {
-            ffmpeg_process.args(["-i", video.to_str().ok_or("Invalid video path")?]);
+            ffmpeg_process.args([
+                "-i",
+                video
+                    .to_str()
+                    .ok_or_else(|| format!("Invalid video path (non-UTF8): {}", video.display()))?,
+            ]);
         }
 
         // Build xfade filter chain for video

--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -122,12 +122,6 @@ impl From<&str> for ApiError {
     }
 }
 
-impl From<()> for ApiError {
-    fn from(_: ()) -> Self {
-        Self("Unknown error".to_string())
-    }
-}
-
 impl Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -184,7 +178,9 @@ async fn handler_get_account_count(
 async fn handler_get_qr(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<QrInfo>>, ApiError> {
-    let qr = get_qr(state.0).await?;
+    let qr = get_qr(state.0)
+        .await
+        .map_err(|_| ApiError::from("Failed to get QR code"))?;
     Ok(Json(ApiResponse::success(qr)))
 }
 
@@ -198,14 +194,18 @@ async fn handler_get_qr_status(
     state: axum::extract::State<State>,
     Json(qr_info): Json<GetQrStatusRequest>,
 ) -> Result<Json<ApiResponse<QrStatus>>, ApiError> {
-    let qr_status = get_qr_status(state.0, &qr_info.qrcode_key).await?;
+    let qr_status = get_qr_status(state.0, &qr_info.qrcode_key)
+        .await
+        .map_err(|_| ApiError::from("Failed to get QR status"))?;
     Ok(Json(ApiResponse::success(qr_status)))
 }
 
 async fn handler_get_config(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<Config>>, ApiError> {
-    let config = get_config(state.0).await?;
+    let config = get_config(state.0)
+        .await
+        .map_err(|_| ApiError::from("Failed to get config"))?;
     Ok(Json(ApiResponse::success(config)))
 }
 
@@ -262,7 +262,9 @@ async fn handler_list_llm_models(
 async fn handler_get_static_port(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<u16>>, ApiError> {
-    let static_port = get_static_port(state.0).await?;
+    let static_port = get_static_port(state.0)
+        .await
+        .map_err(|_| ApiError::from("Failed to get static port"))?;
     Ok(Json(ApiResponse::success(static_port)))
 }
 
@@ -276,7 +278,9 @@ async fn handler_update_status_check_interval(
     state: axum::extract::State<State>,
     Json(request): Json<UpdateStatusCheckIntervalRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_status_check_interval(state.0, request.interval).await?;
+    update_status_check_interval(state.0, request.interval)
+        .await
+        .map_err(|_| ApiError::from("Failed to update status check interval"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -300,7 +304,8 @@ async fn handler_update_notify(
         notify.clip_notify,
         notify.post_notify,
     )
-    .await?;
+    .await
+    .map_err(|_| ApiError::from("Failed to update notify settings"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -314,7 +319,9 @@ async fn handler_update_whisper_model(
     state: axum::extract::State<State>,
     Json(whisper_model): Json<UpdateWhisperModelRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_whisper_model(state.0, whisper_model.whisper_model).await?;
+    update_whisper_model(state.0, whisper_model.whisper_model)
+        .await
+        .map_err(|_| ApiError::from("Failed to update whisper model"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -328,7 +335,9 @@ async fn handler_update_whisper_language(
     state: axum::extract::State<State>,
     Json(whisper_language): Json<UpdateWhisperLanguageRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_whisper_language(state.0, whisper_language.whisper_language).await?;
+    update_whisper_language(state.0, whisper_language.whisper_language)
+        .await
+        .map_err(|_| ApiError::from("Failed to update whisper language"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -342,7 +351,9 @@ async fn handler_update_subtitle_setting(
     state: axum::extract::State<State>,
     Json(subtitle_setting): Json<UpdateSubtitleSettingRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_subtitle_setting(state.0, subtitle_setting.auto_subtitle).await?;
+    update_subtitle_setting(state.0, subtitle_setting.auto_subtitle)
+        .await
+        .map_err(|_| ApiError::from("Failed to update subtitle setting"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -356,7 +367,9 @@ async fn handler_update_clip_name_format(
     state: axum::extract::State<State>,
     Json(clip_name_format): Json<UpdateClipNameFormatRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_clip_name_format(state.0, clip_name_format.clip_name_format).await?;
+    update_clip_name_format(state.0, clip_name_format.clip_name_format)
+        .await
+        .map_err(|_| ApiError::from("Failed to update clip name format"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -370,7 +383,9 @@ async fn handler_update_whisper_prompt(
     state: axum::extract::State<State>,
     Json(whisper_prompt): Json<UpdateWhisperPromptRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_whisper_prompt(state.0, whisper_prompt.whisper_prompt).await?;
+    update_whisper_prompt(state.0, whisper_prompt.whisper_prompt)
+        .await
+        .map_err(|_| ApiError::from("Failed to update whisper prompt"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -384,7 +399,9 @@ async fn handler_update_webhook_url(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateWebhookUrlRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_webhook_url(state.0, param.webhook_url).await?;
+    update_webhook_url(state.0, param.webhook_url)
+        .await
+        .map_err(|_| ApiError::from("Failed to update webhook URL"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -398,7 +415,9 @@ async fn handler_update_subtitle_generator_type(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateSubtitleGeneratorTypeRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_subtitle_generator_type(state.0, param.subtitle_generator_type).await?;
+    update_subtitle_generator_type(state.0, param.subtitle_generator_type)
+        .await
+        .map_err(|_| ApiError::from("Failed to update subtitle generator type"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -412,7 +431,9 @@ async fn handler_update_openai_api_endpoint(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateOpenaiApiEndpointRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_openai_api_endpoint(state.0, param.openai_api_endpoint).await?;
+    update_openai_api_endpoint(state.0, param.openai_api_endpoint)
+        .await
+        .map_err(|_| ApiError::from("Failed to update OpenAI API endpoint"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -426,7 +447,9 @@ async fn handler_update_openai_api_key(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateOpenaiApiKeyRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_openai_api_key(state.0, param.openai_api_key).await?;
+    update_openai_api_key(state.0, param.openai_api_key)
+        .await
+        .map_err(|_| ApiError::from("Failed to update OpenAI API key"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -441,7 +464,9 @@ async fn handler_update_auto_generate(
     state: axum::extract::State<State>,
     Json(auto_generate): Json<UpdateAutoGenerateRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_auto_generate(state.0, auto_generate.enable, auto_generate.encode_danmu).await?;
+    update_auto_generate(state.0, auto_generate.enable, auto_generate.encode_danmu)
+        .await
+        .map_err(|_| ApiError::from("Failed to update auto generate setting"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -483,7 +508,9 @@ async fn handler_delete_message(
 async fn handler_get_recorder_list(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<RecorderList>>, ApiError> {
-    let recorders = get_recorder_list(state.0).await?;
+    let recorders = get_recorder_list(state.0)
+        .await
+        .map_err(|_| ApiError::from("Failed to get recorder list"))?;
     Ok(Json(ApiResponse::success(recorders)))
 }
 
@@ -935,7 +962,9 @@ async fn handler_update_video_cover(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateVideoCoverRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_video_cover(state.0, param.id, param.cover).await?;
+    update_video_cover(state.0, param.id, param.cover)
+        .await
+        .map_err(|_| ApiError::from("Failed to update video cover"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -1031,7 +1060,9 @@ async fn handler_update_video_subtitle(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateVideoSubtitleRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_video_subtitle(state.0, param.id, param.subtitle).await?;
+    update_video_subtitle(state.0, param.id, param.subtitle)
+        .await
+        .map_err(|_| ApiError::from("Failed to update video subtitle"))?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -1046,7 +1077,9 @@ async fn handler_update_video_note(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateVideoNoteRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_video_note(state.0, param.id, param.note).await?;
+    update_video_note(state.0, param.id, param.note)
+        .await
+        .map_err(|_| ApiError::from("Failed to update video note"))?;
     Ok(Json(ApiResponse::success(())))
 }
 

--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -122,6 +122,12 @@ impl From<&str> for ApiError {
     }
 }
 
+impl From<()> for ApiError {
+    fn from(_: ()) -> Self {
+        Self("Unknown error".to_string())
+    }
+}
+
 impl Display for ApiError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -178,7 +184,7 @@ async fn handler_get_account_count(
 async fn handler_get_qr(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<QrInfo>>, ApiError> {
-    let qr = get_qr(state.0).await.expect("Failed to get QR code");
+    let qr = get_qr(state.0).await?;
     Ok(Json(ApiResponse::success(qr)))
 }
 
@@ -192,16 +198,14 @@ async fn handler_get_qr_status(
     state: axum::extract::State<State>,
     Json(qr_info): Json<GetQrStatusRequest>,
 ) -> Result<Json<ApiResponse<QrStatus>>, ApiError> {
-    let qr_status = get_qr_status(state.0, &qr_info.qrcode_key)
-        .await
-        .expect("Failed to get QR status");
+    let qr_status = get_qr_status(state.0, &qr_info.qrcode_key).await?;
     Ok(Json(ApiResponse::success(qr_status)))
 }
 
 async fn handler_get_config(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<Config>>, ApiError> {
-    let config = get_config(state.0).await.expect("Failed to get config");
+    let config = get_config(state.0).await?;
     Ok(Json(ApiResponse::success(config)))
 }
 
@@ -258,9 +262,7 @@ async fn handler_list_llm_models(
 async fn handler_get_static_port(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<u16>>, ApiError> {
-    let static_port = get_static_port(state.0)
-        .await
-        .expect("Failed to get static port");
+    let static_port = get_static_port(state.0).await?;
     Ok(Json(ApiResponse::success(static_port)))
 }
 
@@ -274,9 +276,7 @@ async fn handler_update_status_check_interval(
     state: axum::extract::State<State>,
     Json(request): Json<UpdateStatusCheckIntervalRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_status_check_interval(state.0, request.interval)
-        .await
-        .expect("Failed to update status check interval");
+    update_status_check_interval(state.0, request.interval).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -300,8 +300,7 @@ async fn handler_update_notify(
         notify.clip_notify,
         notify.post_notify,
     )
-    .await
-    .expect("Failed to update notify");
+    .await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -315,9 +314,7 @@ async fn handler_update_whisper_model(
     state: axum::extract::State<State>,
     Json(whisper_model): Json<UpdateWhisperModelRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_whisper_model(state.0, whisper_model.whisper_model)
-        .await
-        .expect("Failed to update whisper model");
+    update_whisper_model(state.0, whisper_model.whisper_model).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -331,9 +328,7 @@ async fn handler_update_whisper_language(
     state: axum::extract::State<State>,
     Json(whisper_language): Json<UpdateWhisperLanguageRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_whisper_language(state.0, whisper_language.whisper_language)
-        .await
-        .expect("Failed to update whisper language");
+    update_whisper_language(state.0, whisper_language.whisper_language).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -347,9 +342,7 @@ async fn handler_update_subtitle_setting(
     state: axum::extract::State<State>,
     Json(subtitle_setting): Json<UpdateSubtitleSettingRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_subtitle_setting(state.0, subtitle_setting.auto_subtitle)
-        .await
-        .expect("Failed to update subtitle setting");
+    update_subtitle_setting(state.0, subtitle_setting.auto_subtitle).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -363,9 +356,7 @@ async fn handler_update_clip_name_format(
     state: axum::extract::State<State>,
     Json(clip_name_format): Json<UpdateClipNameFormatRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_clip_name_format(state.0, clip_name_format.clip_name_format)
-        .await
-        .expect("Failed to update clip name format");
+    update_clip_name_format(state.0, clip_name_format.clip_name_format).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -379,9 +370,7 @@ async fn handler_update_whisper_prompt(
     state: axum::extract::State<State>,
     Json(whisper_prompt): Json<UpdateWhisperPromptRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_whisper_prompt(state.0, whisper_prompt.whisper_prompt)
-        .await
-        .expect("Failed to update whisper prompt");
+    update_whisper_prompt(state.0, whisper_prompt.whisper_prompt).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -395,9 +384,7 @@ async fn handler_update_webhook_url(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateWebhookUrlRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_webhook_url(state.0, param.webhook_url)
-        .await
-        .expect("Failed to update webhook url");
+    update_webhook_url(state.0, param.webhook_url).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -411,9 +398,7 @@ async fn handler_update_subtitle_generator_type(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateSubtitleGeneratorTypeRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_subtitle_generator_type(state.0, param.subtitle_generator_type)
-        .await
-        .expect("Failed to update subtitle generator type");
+    update_subtitle_generator_type(state.0, param.subtitle_generator_type).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -427,9 +412,7 @@ async fn handler_update_openai_api_endpoint(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateOpenaiApiEndpointRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_openai_api_endpoint(state.0, param.openai_api_endpoint)
-        .await
-        .expect("Failed to update openai api endpoint");
+    update_openai_api_endpoint(state.0, param.openai_api_endpoint).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -443,9 +426,7 @@ async fn handler_update_openai_api_key(
     state: axum::extract::State<State>,
     Json(param): Json<UpdateOpenaiApiKeyRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_openai_api_key(state.0, param.openai_api_key)
-        .await
-        .expect("Failed to update openai api key");
+    update_openai_api_key(state.0, param.openai_api_key).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -460,16 +441,14 @@ async fn handler_update_auto_generate(
     state: axum::extract::State<State>,
     Json(auto_generate): Json<UpdateAutoGenerateRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    update_auto_generate(state.0, auto_generate.enable, auto_generate.encode_danmu)
-        .await
-        .expect("Failed to update auto generate");
+    update_auto_generate(state.0, auto_generate.enable, auto_generate.encode_danmu).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
 async fn handler_get_messages(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<Vec<MessageRow>>>, ApiError> {
-    let messages = get_messages(state.0).await.expect("Failed to get messages");
+    let messages = get_messages(state.0).await?;
     Ok(Json(ApiResponse::success(messages)))
 }
 
@@ -483,9 +462,7 @@ async fn handler_read_message(
     state: axum::extract::State<State>,
     Json(message): Json<ReadMessageRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    read_message(state.0, message.message_id)
-        .await
-        .expect("Failed to read message");
+    read_message(state.0, message.message_id).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
@@ -499,18 +476,14 @@ async fn handler_delete_message(
     state: axum::extract::State<State>,
     Json(message): Json<DeleteMessageRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    delete_message(state.0, message.message_id)
-        .await
-        .expect("Failed to delete message");
+    delete_message(state.0, message.message_id).await?;
     Ok(Json(ApiResponse::success(())))
 }
 
 async fn handler_get_recorder_list(
     state: axum::extract::State<State>,
 ) -> Result<Json<ApiResponse<RecorderList>>, ApiError> {
-    let recorders = get_recorder_list(state.0)
-        .await
-        .expect("Failed to get recorder list");
+    let recorders = get_recorder_list(state.0).await?;
     Ok(Json(ApiResponse::success(recorders)))
 }
 
@@ -526,9 +499,7 @@ async fn handler_add_recorder(
     state: axum::extract::State<State>,
     Json(param): Json<AddRecorderRequest>,
 ) -> Result<Json<ApiResponse<RecorderRow>>, ApiError> {
-    let recorder = add_recorder(state.0, param.platform, param.room_id, param.extra)
-        .await
-        .expect("Failed to add recorder");
+    let recorder = add_recorder(state.0, param.platform, param.room_id, param.extra).await?;
     Ok(Json(ApiResponse::success(recorder)))
 }
 
@@ -543,9 +514,7 @@ async fn handler_remove_recorder(
     state: axum::extract::State<State>,
     Json(param): Json<RemoveRecorderRequest>,
 ) -> Result<Json<ApiResponse<()>>, ApiError> {
-    remove_recorder(state.0, param.platform, param.room_id)
-        .await
-        .expect("Failed to remove recorder");
+    remove_recorder(state.0, param.platform, param.room_id).await?;
     Ok(Json(ApiResponse::success(())))
 }
 


### PR DESCRIPTION
## Summary

This PR fixes multiple panic issues caused by `.unwrap()` and `.expect()` calls throughout the codebase. All panics have been replaced with proper error handling that returns errors gracefully instead of crashing the application.

## Fixed Panics

### 1. API Handlers (api_server.rs)
- **Issue**: 22 `.expect()` calls in API handlers caused server crashes when operations failed
- **Fix**: Replaced all `.expect()` with `?` operator for proper error propagation
- **Added**: `From<()>` implementation for `ApiError` to handle `Result<_, ()>` types
- **Impact**: API errors now return JSON responses instead of crashing the server

### 2. Video Upload (bilibili/api.rs)
- **Issue**: `params.video_file.metadata().unwrap()` panicked when file was deleted during upload
- **Error**: `Os { code: 2, kind: NotFound }`
- **Fix**: Cached file size at function start, avoiding repeated `metadata()` calls in upload loop
- **Impact**: Prevents panic and improves performance by eliminating redundant system calls

### 3. Video Concatenation (ffmpeg/general.rs)
- **Issue**: Multiple `.unwrap()` calls panicked on disk full or invalid paths
- **Error**: `Os { code: 112, kind: StorageFull, message: "There is not enough space on the disk." }`
- **Fix**: Replaced with `?` operator and `.ok_or()` with descriptive error messages
- **Impact**: Graceful error handling for disk space issues and invalid paths

### 4. File Download (bilibili/api.rs)
- **Issue**: `path.parent().unwrap()` panicked when parent directory was invalid
- **Error**: `Os { code: 3, kind: NotFound }`
- **Fix**: Used `if let Some(parent)` pattern with proper error propagation
- **Impact**: Safe handling of invalid paths

### 5. Kuaishou Stream URLs (kuaishou/api.rs)
- **Issue**: Chained `.unwrap()` calls panicked when stream data was missing
- **Error**: `called Option::unwrap() on a None value`
- **Fix**: Used `.and_then()` and `.ok_or_else()` for safe optional access
- **Impact**: Returns descriptive error instead of panicking

### 6. Danmu Storage (danmu.rs)
- **Issue**: `.expect()` panicked on "Too many open files" error
- **Error**: `Os { code: 24, kind: Uncategorized, message: "Too many open files" }`
- **Fix**: Replaced with `.ok()?` and added explicit `drop(lines)` to ensure file closure
- **Impact**: Graceful error handling and improved file handle management

## Testing

- ✅ All unit tests pass
- ✅ Cargo check passes
- ✅ Cargo clippy passes (both regular and headless)
- ✅ Pre-commit hooks pass (fmt, clippy, tests)

## Breaking Changes

None - all changes are internal error handling improvements.

## Related Issues

Fixes reported panic issues in production.

## Summary by Sourcery

Improve error handling across HTTP API, media processing, and recorder components to avoid panics and surface failures as explicit errors.

Bug Fixes:
- Prevent API handlers from crashing by propagating backend errors via ApiError instead of unwrapping results.
- Avoid panics during video concatenation when paths are invalid or output directories are missing by validating paths and handling I/O failures.
- Fix potential crashes in Bilibili file download and upload flows by safely handling missing parent directories and caching video file size.
- Prevent danmu storage initialization from panicking on file handle exhaustion by treating file open failures as recoverable and closing the reader explicitly.
- Avoid Kuaishou stream URL retrieval panics when live stream data is missing by returning a descriptive API error.

Enhancements:
- Add a From<()> implementation for ApiError to support converting generic failures into structured API errors with a default message.