### PR TITLE
fix: treat ffmpeg non-zero exit as failure and focus existing windows

### DIFF
--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -33,6 +33,24 @@ const CREATE_NO_WINDOW: u32 = 0x08000000;
 #[allow(unused_imports)]
 use std::os::windows::process::CommandExt;
 
+/// 等待 ffmpeg 子进程结束，并把非零退出码视为失败。
+///
+/// `child.wait()` 只在无法回收进程时返回 `Err`；ffmpeg 自身以非零码退出时
+/// 依然是 `Ok(status)`。若只判断 `Err`，滤镜初始化失败一类的错误会被当成
+/// 成功，进而产生"任务完成但产物缺失"的假象。
+async fn wait_ffmpeg_exit(child: &mut tokio::process::Child, context: &str) -> Result<(), String> {
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("{context}: 等待 ffmpeg 进程失败: {e}"))?;
+
+    if !status.success() {
+        return Err(format!("{context}: ffmpeg 异常退出（{status}）"));
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Range {
     pub start: f64,
@@ -117,9 +135,7 @@ pub async fn transcode(
         }
     }
 
-    if let Err(e) = child.wait().await {
-        return Err(e.to_string());
-    }
+    wait_ffmpeg_exit(&mut child, "Transcode").await?;
 
     Ok(())
 }
@@ -175,9 +191,9 @@ pub async fn trim_video(
         }
     }
 
-    if let Err(e) = child.wait().await {
+    if let Err(e) = wait_ffmpeg_exit(&mut child, "Trim video").await {
         log::error!("Trim video error: {e}");
-        return Err(e.to_string());
+        return Err(e);
     }
 
     log::info!("Trim video task end: {}", output_path.display());
@@ -234,9 +250,9 @@ pub async fn extract_audio_sample(file: &Path) -> Result<PathBuf, String> {
         }
     }
 
-    if let Err(e) = child.wait().await {
+    if let Err(e) = wait_ffmpeg_exit(&mut child, "Extract audio sample").await {
         log::error!("Extract audio sample error: {e}");
-        return Err(e.to_string());
+        return Err(e);
     }
 
     if let Some(error) = extract_error {
@@ -354,9 +370,9 @@ pub async fn extract_audio_chunks(file: &Path, format: &str) -> Result<PathBuf, 
         }
     }
 
-    if let Err(e) = child.wait().await {
+    if let Err(e) = wait_ffmpeg_exit(&mut child, "Extract audio").await {
         log::error!("Extract audio error: {e}");
-        return Err(e.to_string());
+        return Err(e);
     }
 
     if let Some(error) = extract_error {
@@ -540,6 +556,18 @@ pub async fn encode_video_subtitle(
     // ffmpeg -i fixed_\[30655190\]1742887114_0325084106_81.5.mp4 -vf "subtitles=test.srt:force_style='FontSize=24'" -c:v libx264 -c:a copy output.mp4
     log::info!("Encode video subtitle task start: {}", file.display());
     log::info!("SRT style: {srt_style}");
+
+    // 字幕缺失或为空会让 ffmpeg 在 filter graph 初始化阶段就失败，
+    // 这里提前拦住并给出可读的原因，避免产生空的 [subtitle] 视频。
+    match std::fs::metadata(subtitle) {
+        Ok(metadata) if metadata.len() == 0 => {
+            return Err(format!("字幕文件为空：{}", subtitle.display()));
+        }
+        Ok(_) => {}
+        Err(e) => {
+            return Err(format!("字幕文件不可用：{} ({e})", subtitle.display()));
+        }
+    }
     // output path is file with prefix [subtitle]
     let output_filename = format!(
         "{}{}",
@@ -620,9 +648,9 @@ pub async fn encode_video_subtitle(
         }
     }
 
-    if let Err(e) = child.wait().await {
+    if let Err(e) = wait_ffmpeg_exit(&mut child, "Encode video subtitle").await {
         log::error!("Encode video subtitle error: {e}");
-        return Err(e.to_string());
+        return Err(e);
     }
 
     if let Some(error) = command_error {
@@ -720,9 +748,9 @@ pub async fn encode_video_danmu(
         }
     }
 
-    if let Err(e) = child.wait().await {
+    if let Err(e) = wait_ffmpeg_exit(&mut child, "Encode video danmu").await {
         log::error!("Encode video danmu error: {e}");
-        return Err(e.to_string());
+        return Err(e);
     }
 
     if let Some(error) = command_error {
@@ -764,9 +792,9 @@ pub async fn generic_ffmpeg_command(args: &[&str]) -> Result<String, String> {
         }
     }
 
-    if let Err(e) = child.wait().await {
+    if let Err(e) = wait_ffmpeg_exit(&mut child, "Generic ffmpeg command").await {
         log::error!("Generic ffmpeg command error: {e}");
-        return Err(e.to_string());
+        return Err(e);
     }
 
     Ok(logs.join("\n"))
@@ -1170,8 +1198,9 @@ pub async fn clip_from_video_file(
         }
     }
 
-    if let Err(e) = child.wait().await {
-        return Err(e.to_string());
+    if let Err(e) = wait_ffmpeg_exit(&mut child, "切片").await {
+        log::error!("切片错误: {e}");
+        return Err(e);
     }
 
     if let Some(error) = clip_error {
@@ -1560,6 +1589,72 @@ mod tests {
             end: 2000.0,
         };
         assert_eq!(large_range.duration(), 1000.0);
+    }
+
+    // 非零退出码必须被识别为失败，否则会出现"任务成功但产物缺失"
+    #[tokio::test]
+    async fn test_wait_ffmpeg_exit_rejects_nonzero_status() {
+        let mut child = tokio::process::Command::new("sh")
+            .args(["-c", "exit 254"])
+            .spawn()
+            .expect("spawn sh");
+
+        let result = wait_ffmpeg_exit(&mut child, "测试").await;
+        assert!(result.is_err(), "非零退出码应当返回 Err");
+        assert!(result.unwrap_err().contains("测试"));
+    }
+
+    #[tokio::test]
+    async fn test_wait_ffmpeg_exit_accepts_success() {
+        let mut child = tokio::process::Command::new("sh")
+            .args(["-c", "exit 0"])
+            .spawn()
+            .expect("spawn sh");
+
+        assert!(wait_ffmpeg_exit(&mut child, "测试").await.is_ok());
+    }
+
+    #[derive(Clone)]
+    struct NoopReporter;
+
+    #[async_trait::async_trait]
+    impl ProgressReporterTrait for NoopReporter {
+        async fn update(&self, _content: &str) {}
+        async fn finish(&self, _success: bool, _message: &str) {}
+    }
+
+    // 字幕缺失/为空时应提前失败，而不是产出没有字幕的视频
+    #[tokio::test]
+    async fn test_encode_video_subtitle_rejects_missing_subtitle() {
+        let result = encode_video_subtitle(
+            &NoopReporter,
+            Path::new("tests/video/test.mp4"),
+            Path::new("tests/video/does_not_exist.srt"),
+            "FontSize=24".to_string(),
+        )
+        .await;
+
+        let err = result.expect_err("缺失字幕应当返回 Err");
+        assert!(err.contains("字幕文件不可用"), "unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_encode_video_subtitle_rejects_empty_subtitle() {
+        let empty_srt = std::env::temp_dir().join("bsr_empty_subtitle_test.srt");
+        std::fs::write(&empty_srt, "").expect("write empty srt");
+
+        let result = encode_video_subtitle(
+            &NoopReporter,
+            Path::new("tests/video/test.mp4"),
+            &empty_srt,
+            "FontSize=24".to_string(),
+        )
+        .await;
+
+        let _ = std::fs::remove_file(&empty_srt);
+
+        let err = result.expect_err("空字幕应当返回 Err");
+        assert!(err.contains("字幕文件为空"), "unexpected error: {err}");
     }
 
     // 测试视频元数据提取

--- a/src-tauri/src/handlers/utils.rs
+++ b/src-tauri/src/handlers/utils.rs
@@ -227,9 +227,22 @@ pub async fn open_live(
         use std::str::FromStr;
 
         let platform = PlatformType::from_str(&platform)?;
+        let label = format!("Live:{clean_room_id}:{live_id}");
+
+        // 窗口已存在时 build 会直接失败，这里改为聚焦到已有窗口，
+        // 否则用户点击后没有任何反应。
+        if let Some(window) = state.app_handle.get_webview_window(&label) {
+            log::info!("Live window already exists, focusing: {label}");
+            let _ = window.unminimize();
+            let _ = window.show();
+            return window
+                .set_focus()
+                .map_err(|e| format!("聚焦已有直播窗口失败：{e}"));
+        }
+
         let builder = tauri::WebviewWindowBuilder::new(
             &state.app_handle,
-            format!("Live:{clean_room_id}:{live_id}"),
+            label.clone(),
             tauri::WebviewUrl::App(
                 format!(
                     "index_live.html?platform={}&room_id={}&live_id={}",
@@ -255,6 +268,7 @@ pub async fn open_live(
 
         if let Err(e) = builder.decorations(true).build() {
             log::error!("live window build failed: {e}");
+            return Err(format!("打开直播窗口失败：{e}"));
         }
     }
 
@@ -265,9 +279,22 @@ pub async fn open_live(
 #[tauri::command]
 pub async fn open_clip(state: state_type!(), video_id: i64) -> Result<(), String> {
     log::info!("Open clip window: {video_id}");
+    let label = format!("Clip:{video_id}");
+
+    // 窗口已存在时 build 会直接失败，这里改为聚焦到已有窗口，
+    // 否则用户重复点击切片时没有任何反应。
+    if let Some(window) = state.app_handle.get_webview_window(&label) {
+        log::info!("Clip window already exists, focusing: {label}");
+        let _ = window.unminimize();
+        let _ = window.show();
+        return window
+            .set_focus()
+            .map_err(|e| format!("聚焦已有切片窗口失败：{e}"));
+    }
+
     let builder = tauri::WebviewWindowBuilder::new(
         &state.app_handle,
-        format!("Clip:{video_id}"),
+        label.clone(),
         tauri::WebviewUrl::App(format!("index_clip.html?id={video_id}").into()),
     )
     .title(format!("Clip window:{video_id}"))
@@ -285,6 +312,7 @@ pub async fn open_clip(state: state_type!(), video_id: i64) -> Result<(), String
 
     if let Err(e) = builder.decorations(true).build() {
         log::error!("clip window build failed: {e}");
+        return Err(format!("打开切片窗口失败：{e}"));
     }
 
     Ok(())

--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -943,9 +943,10 @@ async fn update_video_subtitle_inner(
     let filepath = Path::new(state.config.read().await.output.as_str()).join(&video.file);
     let file = Path::new(&filepath);
     let subtitle_path = file.with_extension("srt");
-    if let Err(e) = std::fs::write(subtitle_path, subtitle) {
-        log::warn!("Update video subtitle error: {e}");
-    }
+    std::fs::write(&subtitle_path, subtitle).map_err(|e| {
+        log::error!("Update video subtitle error: {e}");
+        format!("写入字幕文件失败：{} ({e})", subtitle_path.display())
+    })?;
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #266

## Problem

Two independent silent failures, both reported in #266 on macOS.

**Burned-in subtitles missing, but the task reported success.** `child.wait()`
only returns `Err` when the process cannot be reaped — ffmpeg exiting non-zero
still yields `Ok(status)`. The exit code was never inspected. The fallback
`command_error` check relies on `FfmpegEvent::Error`, but filter graph failures
print `Error initializing filters` / `Error opening output file`, which
`async-ffmpeg-sidecar` does not classify as an `Error` event. Both defences
missed it, so `encode_video_subtitle` logged `task end` and returned `Ok`.
`encode_video_subtitle_inner` then unconditionally called `add_video`, inserting
a `[subtitle]` row for a file that was never written.

The reporter's log shows the signature clearly — encoding "completed" one second
after it started, with zero `Encode video subtitle progress` lines across all
four attempts:

```
05:48:27 [INFO] Encode video subtitle task start: .../20260508_051753.mp4
05:48:28 [INFO] Encode video subtitle task end: .../[subtitle]...20260508_051753.mp4
```

I verified on ffmpeg 7.1.1 + `h264_videotoolbox` that the bracketed filenames and
the full `scale/pad + subtitles + force_style` chain burn subtitles correctly, so
this is not a path-escaping or macOS-specific filter issue. Pointing the same
command at a missing srt reproduces it: ffmpeg exits 254 and writes no output.

**Clicking a clip did nothing.** `open_clip` logged the build error and returned
`Ok(())`, so when a webview with that label already existed the frontend saw
success:

```
06:35:08 [ERROR] clip window build failed: a webview with label `Clip:8` already exists
```

The clip file and thumbnail both existed on disk — the reported "path error" was
this silent failure surfacing as a no-op. `open_live` had the same defect.

## Changes

- Add `wait_ffmpeg_exit` in `src-tauri/src/ffmpeg/mod.rs` and use it at the eight
  ffmpeg call sites (transcode, trim, extract audio, extract audio sample, encode
  subtitle, encode danmu, generic command, clip). The ffprobe duration path is
  left as-is; it already fails through `ok_or_else`.
- Validate the subtitle file exists and is non-empty before spawning ffmpeg — a
  missing or empty srt is what breaks the filter graph — so the error names the
  actual cause instead of producing a subtitle-less video.
- Propagate write failures from `update_video_subtitle_inner` instead of only
  logging `warn`, so a failed srt write cannot silently feed the encode step.
- `open_clip` / `open_live`: focus, unminimize and show an existing window rather
  than failing to build, and return an error when the build genuinely fails.

## Testing

`cargo test --features gui --bin bili-shadowreplay` — 116 passed, 0 failed.
Clippy and rustfmt clean for both `gui` and `headless`; all pre-commit hooks pass.

Four new tests cover non-zero exit status, zero exit status, and the missing and
empty subtitle paths.

Not verified: I could not reproduce the user's original failing encode end to end,
since that needs their source recording and whisper output. The root cause is
confirmed by the log signature and by reproducing the identical ffmpeg failure
mode locally.

## Summary by Sourcery

Treat ffmpeg non-zero exits as failures and improve window handling for existing clip/live views to avoid silent no-ops.

Bug Fixes:
- Fail ffmpeg-based operations when the child process exits with a non-zero status instead of silently succeeding.
- Reject missing or empty subtitle files before spawning ffmpeg to avoid generating subtitle-less videos that are reported as successful.
- Propagate subtitle file write failures from video subtitle updates so they surface as errors instead of just warnings.
- Focus, unminimize, and show existing live and clip windows when they already exist instead of returning silent success on build failures, and return errors when window creation genuinely fails.

Enhancements:
- Introduce a shared helper for waiting on ffmpeg child processes with contextual error messages.
- Add targeted tests covering ffmpeg exit handling and missing/empty subtitle scenarios to guard against regressions.

Tests:
- Add async tests verifying wait_ffmpeg_exit behavior for success and non-zero exit codes.
- Add tests ensuring encode_video_subtitle fails for missing or empty subtitle files instead of producing invalid outputs.