### PR TITLE
fix: clip range not shown until list toggled

### DIFF
--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -904,7 +904,7 @@ ${mediaPlaylistUrl}`;
                 end: get_total(),
                 activated: true, // 新建区间默认为激活
               };
-              ranges.push(newRange);
+              ranges = [...ranges, newRange];
               currentRangeIndex = ranges.length - 1;
             }
             saveRanges();
@@ -935,7 +935,7 @@ ${mediaPlaylistUrl}`;
                 end: currentTime,
                 activated: true, // 新建区间默认为激活
               };
-              ranges.push(newRange);
+              ranges = [...ranges, newRange];
               currentRangeIndex = ranges.length - 1;
             }
             saveRanges();
@@ -969,7 +969,7 @@ ${mediaPlaylistUrl}`;
               end: get_total(),
               activated: true, // 新建区间默认为激活
             };
-            ranges.push(newRange);
+            ranges = [...ranges, newRange];
             currentRangeIndex = ranges.length - 1;
             saveRanges();
             console.log(
@@ -985,7 +985,7 @@ ${mediaPlaylistUrl}`;
           e.preventDefault();
           {
             if (currentRangeIndex >= 0 && currentRangeIndex < ranges.length) {
-              ranges.splice(currentRangeIndex, 1);
+              ranges = ranges.filter((_, i) => i !== currentRangeIndex);
               // 调整当前索引
               if (ranges.length === 0) {
                 currentRangeIndex = -1;


### PR DESCRIPTION
## Summary
- Creating a new clip range in the recording preview (`[`, `]`, `n` keys) mutated the `ranges` array in place with `push()`/`splice()` without reassigning it.
- Svelte 3's reactivity is assignment-based, so downstream `$: activeRanges = ranges.filter(...)` in `AppLive.svelte` and `ArchiveClipButton.svelte` never re-ran, and the newly created range was missing when clicking 生成切片.
- Toggling a range in the 切片范围列表 worked because that handler already does `ranges = ranges` to trigger reactivity — this PR applies the same pattern to range creation and deletion.

## Changes
- `src/lib/components/Player.svelte`: replaced `ranges.push(newRange)` (x3, for `[`/`]`/`n` key handlers) with `ranges = [...ranges, newRange]`, and `ranges.splice(currentRangeIndex, 1)` with `ranges = ranges.filter((_, i) => i !== currentRangeIndex)`.

## Testing
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — builds successfully

## Summary by Sourcery

Bug Fixes:
- Fix newly created clip ranges not appearing in the clip generation workflow until the range list was toggled.