### PR TITLE
Prevent playlist parsing panics and propagate recorder errors

### DIFF
--- a/src-tauri/crates/recorder/src/core/flv_recorder.rs
+++ b/src-tauri/crates/recorder/src/core/flv_recorder.rs
@@ -51,7 +51,7 @@ impl FlvRecorder {
         let segment_pattern = self.work_dir.join("%d.ts");
 
         if !playlist_path.exists() {
-            let playlist = HlsPlaylist::new(playlist_path.clone()).await;
+            let playlist = HlsPlaylist::new(playlist_path.clone()).await?;
             playlist.flush().await?;
         }
 
@@ -129,8 +129,8 @@ impl FlvRecorder {
         }
 
         if playlist_path.exists() {
-            let mut playlist = HlsPlaylist::new(playlist_path).await;
-            let _ = playlist.close().await;
+            let mut playlist = HlsPlaylist::new(playlist_path).await?;
+            playlist.close().await?;
         }
 
         Ok(())

--- a/src-tauri/crates/recorder/src/core/hls_recorder.rs
+++ b/src-tauri/crates/recorder/src/core/hls_recorder.rs
@@ -10,7 +10,7 @@ use tokio::fs::{File, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 use tokio::sync::{broadcast, Mutex, RwLock};
 
-use crate::core::playlist::HlsPlaylist;
+use crate::core::playlist::{playlist_content_preview, HlsPlaylist};
 use crate::core::{Codec, Format};
 use crate::errors::RecorderError;
 use crate::ffmpeg::VideoMetadata;
@@ -108,13 +108,15 @@ impl HlsRecorder {
                 .map_err(RecorderError::IoError)?;
         }
 
+        let playlist = HlsPlaylist::new(playlist_path).await?;
+
         Ok(Self {
             room_id,
             stream,
             client,
             event_channel,
             work_dir,
-            playlist: Arc::new(Mutex::new(HlsPlaylist::new(playlist_path).await)),
+            playlist: Arc::new(Mutex::new(playlist)),
             headers,
             enabled,
             sequence: Arc::new(AtomicU64::new(sequence)),
@@ -181,7 +183,7 @@ impl HlsRecorder {
         let bytes = response.bytes().await?;
         let (_, playlist) =
             m3u8_rs::parse_playlist(&bytes).map_err(|_| RecorderError::M3u8ParseFailed {
-                content: String::from_utf8(bytes.to_vec()).unwrap(),
+                content: playlist_content_preview(&bytes),
             })?;
         Ok(playlist)
     }

--- a/src-tauri/crates/recorder/src/core/playlist.rs
+++ b/src-tauri/crates/recorder/src/core/playlist.rs
@@ -9,20 +9,26 @@ pub struct HlsPlaylist {
 }
 
 impl HlsPlaylist {
-    pub async fn new(file_path: PathBuf) -> Self {
+    pub async fn new(file_path: PathBuf) -> Result<Self, RecorderError> {
         if file_path.exists() {
-            let bytes = tokio::fs::read(&file_path).await.unwrap();
-            let (_, playlist) = m3u8_rs::parse_media_playlist(&bytes).unwrap();
+            let bytes = tokio::fs::read(&file_path)
+                .await
+                .map_err(RecorderError::IoError)?;
+            let (_, playlist) = m3u8_rs::parse_media_playlist(&bytes).map_err(|_| {
+                RecorderError::M3u8ParseFailed {
+                    content: playlist_content_preview(&bytes),
+                }
+            })?;
 
-            Self {
+            Ok(Self {
                 playlist,
                 file_path,
-            }
+            })
         } else {
-            Self {
+            Ok(Self {
                 playlist: MediaPlaylist::default(),
                 file_path,
-            }
+            })
         }
     }
 
@@ -84,5 +90,56 @@ impl HlsPlaylist {
 
     pub async fn is_empty(&self) -> bool {
         self.playlist.segments.is_empty()
+    }
+}
+
+pub(super) fn playlist_content_preview(bytes: &[u8]) -> String {
+    const MAX_PREVIEW_CHARS: usize = 256;
+    let content = String::from_utf8_lossy(bytes);
+    let mut chars = content.chars();
+    let mut preview: String = chars.by_ref().take(MAX_PREVIEW_CHARS).collect();
+    if chars.next().is_some() {
+        preview.push_str("...");
+    }
+    preview.escape_debug().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn new_returns_parse_error_for_corrupt_playlist() {
+        let path = std::env::temp_dir().join(format!(
+            "bili-shadowreplay-corrupt-{}.m3u8",
+            uuid::Uuid::new_v4()
+        ));
+        tokio::fs::write(&path, vec![0; 1024]).await.unwrap();
+
+        let result = HlsPlaylist::new(path.clone()).await;
+
+        assert!(matches!(result, Err(RecorderError::M3u8ParseFailed { .. })));
+        let _ = tokio::fs::remove_file(path).await;
+    }
+
+    #[tokio::test]
+    async fn new_starts_empty_when_playlist_does_not_exist() {
+        let path = std::env::temp_dir().join(format!(
+            "bili-shadowreplay-missing-{}.m3u8",
+            uuid::Uuid::new_v4()
+        ));
+
+        let playlist = HlsPlaylist::new(path).await.unwrap();
+
+        assert!(playlist.playlist.segments.is_empty());
+    }
+
+    #[test]
+    fn content_preview_is_bounded_and_escaped() {
+        let preview = playlist_content_preview(&vec![0; 1024]);
+
+        assert!(preview.len() < 2048);
+        assert!(preview.ends_with("..."));
+        assert!(preview.contains("\\0"));
     }
 }

--- a/src-tauri/src/ffmpeg/playlist.rs
+++ b/src-tauri/src/ffmpeg/playlist.rs
@@ -53,7 +53,7 @@ pub async fn clip_from_playlist(
     let playlist_bytes = tokio::fs::read(playlist_path)
         .await
         .map_err(|e| format!("Failed to read playlist '{}': {e}", playlist_path.display()))?;
-    let playlist = parse_media_playlist(&playlist_bytes)?;
+    let playlist = parse_media_playlist(&playlist_bytes, playlist_path)?;
     let mut start_offset = None;
     let mut segments = Vec::new();
     if let Some(range) = &range {
@@ -164,10 +164,23 @@ pub async fn clip_from_playlist(
     Ok(())
 }
 
-fn parse_media_playlist(bytes: &[u8]) -> Result<MediaPlaylist, String> {
+fn parse_media_playlist(bytes: &[u8], playlist_path: &Path) -> Result<MediaPlaylist, String> {
     m3u8_rs::parse_media_playlist(bytes)
         .map(|(_, playlist)| playlist)
-        .map_err(|_| "Failed to parse media playlist".to_string())
+        .map_err(|_| {
+            let input_context = if bytes.is_empty() {
+                "input is empty"
+            } else if bytes.iter().all(|byte| *byte == 0) {
+                "input is zero-filled"
+            } else {
+                "invalid playlist syntax"
+            };
+            format!(
+                "Failed to parse media playlist '{}': {input_context} ({} bytes)",
+                playlist_path.display(),
+                bytes.len()
+            )
+        })
 }
 
 fn parse_map_uri(rest: &str) -> Option<String> {
@@ -184,9 +197,38 @@ mod tests {
 
     #[test]
     fn rejects_zero_filled_playlist_without_panicking() {
-        let result = parse_media_playlist(&vec![0; 1024]);
+        let path = Path::new("recordings/playlist.m3u8");
+        let result = parse_media_playlist(&vec![0; 1024], path);
 
-        assert_eq!(result.unwrap_err(), "Failed to parse media playlist");
+        assert_eq!(
+            result.unwrap_err(),
+            "Failed to parse media playlist 'recordings/playlist.m3u8': input is zero-filled (1024 bytes)"
+        );
+    }
+
+    #[test]
+    fn reports_empty_playlist_without_exposing_content() {
+        let result = parse_media_playlist(&[], Path::new("empty.m3u8"));
+
+        assert_eq!(
+            result.unwrap_err(),
+            "Failed to parse media playlist 'empty.m3u8': input is empty (0 bytes)"
+        );
+    }
+
+    #[test]
+    fn reports_invalid_playlist_without_exposing_content() {
+        let result = parse_media_playlist(
+            b"sensitive invalid playlist content",
+            Path::new("invalid.m3u8"),
+        );
+
+        let error = result.unwrap_err();
+        assert_eq!(
+            error,
+            "Failed to parse media playlist 'invalid.m3u8': invalid playlist syntax (34 bytes)"
+        );
+        assert!(!error.contains("sensitive"));
     }
 
     #[test]

--- a/src-tauri/src/ffmpeg/playlist.rs
+++ b/src-tauri/src/ffmpeg/playlist.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use m3u8_rs::Map;
+use m3u8_rs::{Map, MediaPlaylist};
 use tokio::io::AsyncWriteExt;
 
 use crate::progress::progress_reporter::ProgressReporterTrait;
@@ -50,12 +50,10 @@ pub async fn clip_from_playlist(
     output_path: &Path,
     range: Option<Range>,
 ) -> Result<(), String> {
-    let (_, playlist) = m3u8_rs::parse_media_playlist(
-        &tokio::fs::read(playlist_path)
-            .await
-            .map_err(|e| e.to_string())?,
-    )
-    .unwrap();
+    let playlist_bytes = tokio::fs::read(playlist_path)
+        .await
+        .map_err(|e| format!("Failed to read playlist '{}': {e}", playlist_path.display()))?;
+    let playlist = parse_media_playlist(&playlist_bytes)?;
     let mut start_offset = None;
     let mut segments = Vec::new();
     if let Some(range) = &range {
@@ -77,15 +75,16 @@ pub async fn clip_from_playlist(
         return Err("No segments found".to_string());
     }
 
-    let first_segment = playlist.segments.first().unwrap().clone();
+    let first_segment = playlist
+        .segments
+        .first()
+        .ok_or_else(|| "Playlist contains no segments".to_string())?;
     let mut header_url = first_segment
         .unknown_tags
         .iter()
         .find(|t| t.tag == "X-MAP")
-        .map(|t| {
-            let rest = t.rest.clone().unwrap();
-            rest.split('=').nth(1).unwrap().replace("\\\"", "")
-        });
+        .and_then(|tag| tag.rest.as_deref())
+        .and_then(parse_map_uri);
     if header_url.is_none() {
         // map: Some(Map { uri: "h1758725308.m4s"
         if let Some(Map { uri, .. }) = &first_segment.map {
@@ -95,10 +94,15 @@ pub async fn clip_from_playlist(
 
     // write all segments to clip_file
     {
-        let playlist_folder = playlist_path.parent().unwrap();
-        let output_folder = output_path.parent().unwrap();
+        let playlist_folder = playlist_path.parent().unwrap_or_else(|| Path::new("."));
+        let output_folder = output_path.parent().unwrap_or_else(|| Path::new("."));
         if !output_folder.exists() {
-            std::fs::create_dir_all(output_folder).unwrap();
+            std::fs::create_dir_all(output_folder).map_err(|e| {
+                format!(
+                    "Failed to create output folder '{}': {e}",
+                    output_folder.display()
+                )
+            })?;
         }
         let mut file = tokio::fs::File::create(&output_path)
             .await
@@ -140,14 +144,14 @@ pub async fn clip_from_playlist(
     }
 
     // trim for precised duration
-    if let Some(start_offset) = start_offset {
+    if let (Some(start_offset), Some(range)) = (start_offset, range.as_ref()) {
         let tmp_output_path = output_path.with_extension("tmp.mp4");
         super::trim_video(
             reporter,
             output_path,
             &tmp_output_path,
             start_offset,
-            range.as_ref().unwrap().duration(),
+            range.duration(),
         )
         .await?;
 
@@ -158,6 +162,41 @@ pub async fn clip_from_playlist(
     }
 
     Ok(())
+}
+
+fn parse_media_playlist(bytes: &[u8]) -> Result<MediaPlaylist, String> {
+    m3u8_rs::parse_media_playlist(bytes)
+        .map(|(_, playlist)| playlist)
+        .map_err(|_| "Failed to parse media playlist".to_string())
+}
+
+fn parse_map_uri(rest: &str) -> Option<String> {
+    rest.split_once('=').and_then(|(_, value)| {
+        let unescaped = value.trim().replace("\\\"", "\"");
+        let uri = unescaped.trim_matches('"');
+        (!uri.is_empty()).then(|| uri.to_string())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_zero_filled_playlist_without_panicking() {
+        let result = parse_media_playlist(&vec![0; 1024]);
+
+        assert_eq!(result.unwrap_err(), "Failed to parse media playlist");
+    }
+
+    #[test]
+    fn parses_map_uri() {
+        assert_eq!(
+            parse_map_uri(r#"URI=\"header.m4s\""#),
+            Some("header.m4s".to_string())
+        );
+        assert_eq!(parse_map_uri("malformed"), None);
+    }
 }
 
 pub async fn concat_playlists_to_video(

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -795,7 +795,7 @@ impl RecorderManager {
             return Ok(pl);
         }
         Err(RecorderManagerError::M3u8ParseFailed {
-            content: String::from_utf8(bytes).unwrap(),
+            content: String::from_utf8_lossy(&bytes).into_owned(),
         })
     }
 


### PR DESCRIPTION
## Summary

- Propagate playlist I/O and parsing errors instead of panicking or silently ignoring failures.
- Harden playlist clipping against malformed playlists, missing segments, invalid map URIs, and filesystem errors.
- Bound and escape playlist content previews in parse errors.
- Add regression tests for corrupt playlists, missing playlists, preview formatting, and map URI parsing.

## Testing

- Added unit and asynchronous tests covering malformed playlist handling and safe parsing paths.
- Existing test suite not run (not requested).

## Summary by Sourcery

Harden playlist parsing and clipping so recorder failures are reported safely and actionable errors propagate to callers.

Bug Fixes:
- Propagate playlist I/O and parsing failures through recorder initialization, shutdown, and clipping instead of panicking or discarding errors.
- Handle malformed playlists, missing segments, invalid map URIs, and output directory failures without panics.
- Prevent invalid playlist bytes from causing UTF-8 conversion failures when constructing parse errors.

Enhancements:
- Bound and escape playlist content previews included in parse errors.
- Improve playlist clipping diagnostics while safely handling absent paths and optional trimming ranges.

Tests:
- Add regression coverage for corrupt and missing playlists, bounded preview formatting, malformed playlist reporting, and map URI parsing.