### PR TITLE
feat: support Linux ARM64 headless deployment

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,10 +44,17 @@ jobs:
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,4 +88,4 @@ COPY --from=rust-builder /app/src-tauri/target/release/bili-shadowreplay .
 EXPOSE 3000
 
 # Run the application
-CMD ["sh", "-c", "nscd && ./bili-shadowreplay"]
+CMD ["sh", "-c", "nscd && exec ./bili-shadowreplay"]

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -30,6 +30,10 @@ export default withMermaid({
                 text: "Docker 安装",
                 link: "/getting-started/installation/docker",
               },
+              {
+                text: "Termux 安装",
+                link: "/getting-started/installation/termux",
+              },
             ],
           },
           {

--- a/docs/getting-started/installation/docker.md
+++ b/docs/getting-started/installation/docker.md
@@ -2,6 +2,9 @@
 
 BiliBili ShadowReplay 提供了服务端部署的能力，提供 Web 控制界面，可以用于在服务器等无图形界面环境下部署使用。
 
+官方镜像支持 `linux/amd64` 和 `linux/arm64`。Docker 会根据宿主机架构自动
+选择对应镜像；在 Android Termux 中运行请参考 [Termux 部署](./termux)。
+
 ## 镜像获取
 
 ```bash

--- a/docs/getting-started/installation/termux.md
+++ b/docs/getting-started/installation/termux.md
@@ -1,0 +1,57 @@
+# Termux 部署
+
+BiliBili ShadowReplay 的 headless 模式提供 `linux/arm64` 容器镜像，可以在
+64 位 ARM Android 设备上通过 Termux 和 `proot-distro` 运行。此方案不需要
+root 权限，也不需要在 Android 上启动 Docker daemon。
+
+> [!IMPORTANT]
+> Termux 使用 Android 的 bionic C 库，并不是普通的 GNU/Linux 环境。当前
+> 镜像中的程序是 glibc 二进制，因此必须在 `proot-distro` 提供的 Linux
+> 用户空间中运行，不能直接从 Termux shell 启动。
+
+## 环境要求
+
+- 从 F-Droid 或 Termux GitHub Releases 安装的新版 Termux；
+- `uname -m` 输出 `aarch64`；
+- 建议至少预留 4 GB 存储空间。启用字幕功能时还需要为 Whisper 模型和运行
+  内存预留额外空间；
+- Android 应允许 Termux 在后台运行，否则录制进程可能被系统终止。
+
+## 安装
+
+在 Termux 中执行：
+
+```bash
+pkg update
+pkg install proot-distro tmux
+
+mkdir -p "$HOME/bsr"/{data,cache,output}
+proot-distro install \
+  --name bili-shadowreplay \
+  --architecture linux/arm64 \
+  ghcr.io/xinrea/bili-shadowreplay:latest
+```
+
+`proot-distro` 会根据镜像清单拉取 ARM64 版本，不会在手机上模拟 x86。
+
+## 启动
+
+用 `tmux` 保持服务在终端退出后继续运行：
+
+```bash
+tmux new -s bsr
+
+proot-distro login bili-shadowreplay \
+  --bind "$HOME/bsr/data:/app/data" \
+  --bind "$HOME/bsr/cache:/app/cache" \
+  --bind "$HOME/bsr/output:/app/output" \
+  -- /bin/sh -lc 'cd /app && exec ./bili-shadowreplay'
+```
+
+服务启动后，在手机浏览器中打开 <http://127.0.0.1:3000>。这里不需要 Docker
+的 `-p` 端口映射。按 `Ctrl+B`、再按 `D` 可以退出 `tmux` 而不停止服务；
+之后使用 `tmux attach -t bsr` 返回。
+
+配置文件位于容器内的 `/app/config.toml`，数据库、缓存和输出分别持久化到
+`$HOME/bsr/data`、`$HOME/bsr/cache` 和 `$HOME/bsr/output`。需要长期保留或
+手动编辑配置时，也应把配置文件复制到 Termux 目录并通过 `--bind` 挂载。

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -940,6 +940,30 @@ struct Args {
 }
 
 #[cfg(feature = "headless")]
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut terminate =
+            signal(SignalKind::terminate()).expect("Failed to install SIGTERM handler");
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => {
+                if let Err(error) = result {
+                    log::error!("Failed to listen for Ctrl+C: {error}");
+                }
+            }
+            _ = terminate.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        log::error!("Failed to listen for Ctrl+C: {error}");
+    }
+}
+
+#[cfg(feature = "headless")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = init_sentry_from_env();
@@ -955,6 +979,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(v) => log::info!("Checked ffmpeg version: {v}"),
     }
 
-    http_server::api_server::start_api_server(state).await;
+    let recorder_manager = state.recorder_manager.clone();
+    tokio::select! {
+        _ = http_server::api_server::start_api_server(state) => {}
+        _ = shutdown_signal() => {
+            log::info!("Shutdown signal received");
+        }
+    }
+
+    log::info!("Stopping all recorders...");
+    recorder_manager.stop_all().await;
+    log::info!("All recorders stopped successfully.");
     Ok(())
 }


### PR DESCRIPTION
## Summary

- publish the headless Docker image for both `linux/amd64` and `linux/arm64` using Buildx and QEMU
- document running the ARM64 image on Termux through `proot-distro`
- handle `SIGTERM`/Ctrl+C in headless mode and stop active recorders cleanly
- forward container signals to the Rust process with `exec`

## Verification

- built the complete image with `docker buildx build --platform linux/arm64 --load` on an ARM64 Docker host
- confirmed the image reports `os=linux`, `arch=arm64`
- started the headless container and received HTTP 200 from `/`
- confirmed database migration and FFmpeg 7.1.5 detection in startup logs
- confirmed `docker stop` exits immediately with code 0 and stops all recorders
- built the VitePress documentation in a `linux/arm64` Node container
- ran `cargo fmt --check` and `git diff --check`

Closes #138