### PR TITLE
fix: prevent zero-byte recording archives

### DIFF
--- a/src-tauri/crates/recorder/src/entry.rs
+++ b/src-tauri/crates/recorder/src/entry.rs
@@ -168,6 +168,14 @@ impl EntryStore {
         self.entries.is_empty()
     }
 
+    pub fn total_duration(&self) -> f64 {
+        self.total_duration
+    }
+
+    pub fn total_size(&self) -> u64 {
+        self.total_size
+    }
+
     /// Generate a hls manifest for selected range.
     /// `vod` indicates the manifest is for stream or video.
     /// `force_time` adds DATE-TIME tag for each entry.

--- a/src-tauri/src/migration/migration_methods.rs
+++ b/src-tauri/src/migration/migration_methods.rs
@@ -23,9 +23,43 @@ pub async fn try_rebuild_archives(
                 // use folder name as live_id
                 let live_id = file.file_name();
                 let live_id = live_id.to_str().unwrap();
+                let record_path = file.path();
+                let entry_store = EntryStore::new(record_path.to_string_lossy().as_ref()).await;
+                let existing_record = db.get_record(&room_id, live_id).await;
+
+                // Empty folders are left behind when recording fails before the first segment.
+                // They are not archives and must not be restored as 0-byte records.
+                if entry_store.is_empty() {
+                    match existing_record {
+                        Ok(record) if record.size == 0 => {
+                            db.remove_record(live_id).await?;
+                            tokio::fs::remove_dir_all(&record_path).await?;
+                            log::info!("removed empty archive folder: {}", record_path.display());
+                        }
+                        Ok(_) => {
+                            log::warn!(
+                                "archive {} has database data but no cached entries; preserving it",
+                                record_path.display()
+                            );
+                        }
+                        Err(_) => {
+                            tokio::fs::remove_dir_all(&record_path).await?;
+                            log::info!("removed empty archive folder: {}", record_path.display());
+                        }
+                    }
+                    continue;
+                }
+
                 // check if live_id is in db
-                let record = db.get_record(&room_id, live_id).await;
-                if record.is_ok() {
+                if let Ok(record) = existing_record {
+                    if record.size == 0 {
+                        db.update_record_delta(
+                            live_id,
+                            entry_store.total_duration(),
+                            entry_store.total_size(),
+                        )
+                        .await?;
+                    }
                     continue;
                 }
 
@@ -44,6 +78,12 @@ pub async fn try_rebuild_archives(
                         None,
                     )
                     .await?;
+                db.update_record_delta(
+                    live_id,
+                    entry_store.total_duration(),
+                    entry_store.total_size(),
+                )
+                .await?;
 
                 log::info!("rebuild archive {record:?}");
             }

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -246,7 +246,15 @@ impl RecorderManager {
 
     async fn handle_events(&self) {
         let mut rx = self.event_tx.subscribe();
-        while let Ok(event) = rx.recv().await {
+        loop {
+            let event = match rx.recv().await {
+                Ok(event) => event,
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    log::warn!("Recorder event listener lagged; skipped {skipped} events");
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            };
             match event {
                 RecorderEvent::LiveStart { recorder } => {
                     let event = events::new_webhook_event(
@@ -328,19 +336,26 @@ impl RecorderManager {
                 }
                 RecorderEvent::RecordEnd { recorder } => {
                     log::info!("Record end: {recorder:?}");
+                    let live_id = recorder.live_id.clone();
+                    if live_id.is_empty() {
+                        log::warn!(
+                            "Ignoring record end without live id for room {}",
+                            recorder.room_info.room_id
+                        );
+                        continue;
+                    }
                     let event = events::new_webhook_event(
                         events::RECORD_ENDED,
                         Payload::Room(recorder.clone()),
                     );
                     let _ = self.webhook_poster.post_event(&event).await;
-                    let live_id = recorder.live_id.clone();
                     // check record in db, if length is 0, delete it
                     let room_id = recorder.room_info.room_id.clone();
                     let record = match self.db.get_record(&room_id, &live_id).await {
                         Ok(r) => r,
                         Err(e) => {
                             log::error!("Record not found in db: {recorder:?}, err={e:?}");
-                            return;
+                            continue;
                         }
                     };
                     if record.size == 0 {


### PR DESCRIPTION
## Summary

- keep the recorder event listener alive after malformed or lagged events
- ignore record-end events without a live ID instead of terminating event processing
- discard empty cache directories during archive reconstruction
- restore duration and size from `entries.log` for valid reconstructed archives

## Root cause

A record-end event with an empty live ID caused `handle_events` to return. Recording retries continued creating cache directories without their lifecycle events being processed. On restart, archive reconstruction inserted every leftover directory as a record with zero duration and size.

## Verification

- `rustfmt --edition 2021 --check src-tauri/crates/recorder/src/entry.rs src-tauri/src/migration/migration_methods.rs src-tauri/src/recorder_manager.rs`
- `git diff --check`
- `cargo test --manifest-path src-tauri/crates/recorder/Cargo.toml entry:: --lib` (11 passed)

Full application `cargo check` is currently blocked by the pre-existing missing `src-tauri/crates/whisper-cpp-rs/whisper.cpp` submodule content in this worktree.