### PR TITLE
fix: build frontend natively for multi-arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Build frontend
-FROM node:22-bookworm AS frontend-builder
+# Build the architecture-independent frontend once on the native builder.
+FROM --platform=$BUILDPLATFORM node:22-bookworm AS frontend-builder
 
 WORKDIR /app
 
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install -y \
 # Copy package files
 COPY package.json yarn.lock ./
 
-# Install dependencies with specific flags
-RUN yarn install --frozen-lockfile
+# Allow enough time for large packages when the registry is slow.
+RUN yarn install --frozen-lockfile --network-timeout 600000
 
 # Copy source files
 COPY . .


### PR DESCRIPTION
## Summary

- build the architecture-independent frontend on the native BuildKit platform
- avoid running Yarn dependency installation under ARM64 QEMU
- increase Yarn network timeout to tolerate registry delays

## Context

The v2.21.2 Docker workflow failed twice while the ARM64 frontend stage downloaded `lucide-svelte`, both times with `ESOCKETTIMEDOUT`. The amd64 frontend build completed successfully.

Failed run: https://github.com/Xinrea/bili-shadowreplay/actions/runs/33232951530

## Validation

- `git diff --check`
- confirmed Yarn supports `--network-timeout`
- local multi-platform build was not run because the Docker daemon is unavailable