### PR TITLE
fix: Implement buvid3 rotation to prevent risk control

### DIFF
--- a/src-tauri/crates/danmu_stream/src/http_client.rs
+++ b/src-tauri/crates/danmu_stream/src/http_client.rs
@@ -15,7 +15,7 @@ pub struct ApiClient {
 impl ApiClient {
     pub fn new(cookies: &str) -> Self {
         let buvid3 = uuid::Uuid::new_v4().to_string();
-        
+
         Self {
             client: reqwest::Client::new(),
             base_cookie: cookies.to_string(),
@@ -28,7 +28,7 @@ impl ApiClient {
         // Check if buvid3 needs to be refreshed (every 1 hour)
         let now = SystemTime::now();
         let last_updated = *self.buvid3_updated_at.read().await;
-        
+
         if let Ok(elapsed) = now.duration_since(last_updated) {
             if elapsed >= Duration::from_secs(3600) {
                 // Update buvid3
@@ -37,7 +37,7 @@ impl ApiClient {
                 *self.buvid3_updated_at.write().await = now;
             }
         }
-        
+
         let buvid3 = self.buvid3.read().await.clone();
         format!("{};buvid3={}", self.base_cookie, buvid3)
     }
@@ -50,7 +50,7 @@ impl ApiClient {
         let cookie = self.get_current_cookie().await;
         let mut header = HeaderMap::new();
         header.insert("cookie", cookie.parse().unwrap());
-        
+
         let resp = self
             .client
             .get(url)

--- a/src-tauri/crates/danmu_stream/src/http_client.rs
+++ b/src-tauri/crates/danmu_stream/src/http_client.rs
@@ -1,23 +1,45 @@
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use reqwest::header::HeaderMap;
+use tokio::sync::RwLock;
 
 use crate::DanmuStreamError;
 
 pub struct ApiClient {
     client: reqwest::Client,
-    header: HeaderMap,
+    base_cookie: String,
+    buvid3: RwLock<String>,
+    buvid3_updated_at: RwLock<SystemTime>,
 }
 
 impl ApiClient {
     pub fn new(cookies: &str) -> Self {
-        let mut header = HeaderMap::new();
-        header.insert("cookie", cookies.parse().unwrap());
-
+        let buvid3 = uuid::Uuid::new_v4().to_string();
+        
         Self {
             client: reqwest::Client::new(),
-            header,
+            base_cookie: cookies.to_string(),
+            buvid3: RwLock::new(buvid3),
+            buvid3_updated_at: RwLock::new(SystemTime::now()),
         }
+    }
+
+    async fn get_current_cookie(&self) -> String {
+        // Check if buvid3 needs to be refreshed (every 1 hour)
+        let now = SystemTime::now();
+        let last_updated = *self.buvid3_updated_at.read().await;
+        
+        if let Ok(elapsed) = now.duration_since(last_updated) {
+            if elapsed >= Duration::from_secs(3600) {
+                // Update buvid3
+                let new_buvid3 = uuid::Uuid::new_v4().to_string();
+                *self.buvid3.write().await = new_buvid3;
+                *self.buvid3_updated_at.write().await = now;
+            }
+        }
+        
+        let buvid3 = self.buvid3.read().await.clone();
+        format!("{};buvid3={}", self.base_cookie, buvid3)
     }
 
     pub async fn get(
@@ -25,11 +47,15 @@ impl ApiClient {
         url: &str,
         query: Option<&[(&str, &str)]>,
     ) -> Result<reqwest::Response, DanmuStreamError> {
+        let cookie = self.get_current_cookie().await;
+        let mut header = HeaderMap::new();
+        header.insert("cookie", cookie.parse().unwrap());
+        
         let resp = self
             .client
             .get(url)
             .query(query.unwrap_or_default())
-            .headers(self.header.clone())
+            .headers(header)
             .timeout(Duration::from_secs(10))
             .send()
             .await?

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili.rs
@@ -47,9 +47,7 @@ impl DanmuProvider for BiliDanmu {
     async fn new(cookie: &str, room_id: &str) -> Result<Self, DanmuStreamError> {
         // find DedeUserID=<user_id> in cookie str
         let user_id = BiliDanmu::parse_user_id(cookie)?;
-        // add buvid3 to cookie
-        let cookie = format!("{};buvid3={}", cookie, uuid::Uuid::new_v4());
-        let client = ApiClient::new(&cookie);
+        let client = ApiClient::new(cookie);
 
         Ok(Self {
             client,

--- a/src-tauri/crates/whisper-cpp-rs/build.rs
+++ b/src-tauri/crates/whisper-cpp-rs/build.rs
@@ -48,16 +48,14 @@ fn macos_deployment_target() -> Option<String> {
 }
 
 fn cuda_root() -> Option<PathBuf> {
-    env::var_os("CUDA_PATH")
-        .map(PathBuf::from)
-        .or_else(|| {
-            env::var_os("CUDACXX").and_then(|value| {
-                let nvcc = PathBuf::from(value);
-                nvcc.parent()
-                    .and_then(|bin| bin.parent())
-                    .map(PathBuf::from)
-            })
+    env::var_os("CUDA_PATH").map(PathBuf::from).or_else(|| {
+        env::var_os("CUDACXX").and_then(|value| {
+            let nvcc = PathBuf::from(value);
+            nvcc.parent()
+                .and_then(|bin| bin.parent())
+                .map(PathBuf::from)
         })
+    })
 }
 
 fn main() {

--- a/src-tauri/crates/whisper-cpp-rs/src/lib.rs
+++ b/src-tauri/crates/whisper-cpp-rs/src/lib.rs
@@ -64,8 +64,12 @@ struct whisper_full_params {
     _opaque: [u8; 1024], // opaque; we only ever hold a pointer from whisper
 }
 
-type whisper_progress_callback =
-    unsafe extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void, c_int, *mut std::ffi::c_void);
+type whisper_progress_callback = unsafe extern "C" fn(
+    *mut std::ffi::c_void,
+    *mut std::ffi::c_void,
+    c_int,
+    *mut std::ffi::c_void,
+);
 
 extern "C" {
     fn whisper_init_from_file_with_params(
@@ -115,10 +119,7 @@ extern "C" {
         i_segment: c_int,
     ) -> *const c_char;
 
-    fn whisper_full_n_tokens_from_state(
-        state: *mut std::ffi::c_void,
-        i_segment: c_int,
-    ) -> c_int;
+    fn whisper_full_n_tokens_from_state(state: *mut std::ffi::c_void, i_segment: c_int) -> c_int;
 
     fn whisper_full_get_token_text_from_state(
         ctx: *mut std::ffi::c_void,
@@ -255,16 +256,17 @@ impl FullParams {
     /// Create default parameters with the given sampling strategy.
     pub fn new(strategy: SamplingStrategy) -> Self {
         let s = match strategy {
-            SamplingStrategy::Greedy { .. } => {
-                whisper_sampling_strategy::WHISPER_SAMPLING_GREEDY
-            }
+            SamplingStrategy::Greedy { .. } => whisper_sampling_strategy::WHISPER_SAMPLING_GREEDY,
             SamplingStrategy::BeamSearch { .. } => {
                 whisper_sampling_strategy::WHISPER_SAMPLING_BEAM_SEARCH
             }
         };
 
         let params = unsafe { whisper_full_default_params_by_ref(s) };
-        assert!(!params.is_null(), "whisper_full_default_params_by_ref returned null");
+        assert!(
+            !params.is_null(),
+            "whisper_full_default_params_by_ref returned null"
+        );
 
         unsafe {
             match strategy {
@@ -409,29 +411,19 @@ impl WhisperState {
     /// Get all tokens for a segment with their text, timestamps, and
     /// probabilities.  Special tokens (`[_BEG_]`, `[_TT_*]`, etc.)
     /// are included — the caller should filter them.
-    pub fn get_segment_tokens(
-        &self,
-        ctx: &WhisperContext,
-        i_segment: i32,
-    ) -> Vec<TokenData> {
+    pub fn get_segment_tokens(&self, ctx: &WhisperContext, i_segment: i32) -> Vec<TokenData> {
         let n = self.full_n_tokens(i_segment);
         let mut tokens = Vec::with_capacity(n as usize);
         for i in 0..n {
             let text = unsafe {
-                let ptr = whisper_full_get_token_text_from_state(
-                    ctx.ctx,
-                    self.state,
-                    i_segment,
-                    i,
-                );
+                let ptr = whisper_full_get_token_text_from_state(ctx.ctx, self.state, i_segment, i);
                 if ptr.is_null() {
                     String::new()
                 } else {
                     CStr::from_ptr(ptr).to_string_lossy().into_owned()
                 }
             };
-            let data =
-                unsafe { whisper_full_get_token_data_from_state(self.state, i_segment, i) };
+            let data = unsafe { whisper_full_get_token_data_from_state(self.state, i_segment, i) };
             tokens.push(TokenData {
                 text,
                 t0: data.t0,
@@ -446,10 +438,7 @@ impl WhisperState {
 // ── Audio conversion utilities ──────────────────────────────────────
 
 /// Convert i16 PCM samples to f32 in range [-1.0, 1.0].
-pub fn convert_integer_to_float_audio(
-    input: &[i16],
-    output: &mut [f32],
-) -> Result<(), String> {
+pub fn convert_integer_to_float_audio(input: &[i16], output: &mut [f32]) -> Result<(), String> {
     if input.len() != output.len() {
         return Err(format!(
             "Input and output must have the same length: {} != {}",
@@ -465,10 +454,7 @@ pub fn convert_integer_to_float_audio(
 
 /// Convert interleaved stereo f32 samples to mono by averaging channels.
 /// Output length must be half of input length.
-pub fn convert_stereo_to_mono_audio(
-    input: &[f32],
-    output: &mut [f32],
-) -> Result<(), String> {
+pub fn convert_stereo_to_mono_audio(input: &[f32], output: &mut [f32]) -> Result<(), String> {
     if input.len() != output.len() * 2 {
         return Err(format!(
             "Input length ({}) must be 2x output length ({})",


### PR DESCRIPTION
## 问题描述

有用户反馈固定的 buvid3 会被 B 站风控，特别是在调用  等 API 时使用同一个 buvid3。

## 解决方案

将 buvid3 的管理从外部移到  内部：

- **内部管理**： 现在内部存储  和 
- **自动轮换**：buvid3 每 1 小时自动更新一次
- **透明处理**：每次 API 调用时自动检查并使用最新的 buvid3

## 主要修改

### `http_client.rs`
- 重构 `ApiClient` 结构，添加 buvid3 管理字段
- 新增 `get_current_cookie()` 方法处理 buvid3 轮换逻辑
- 修改 `get()` 方法使其每次请求都使用最新的 cookie

### `bilibili.rs`
- 移除手动添加 buvid3 的代码
- 简化 `new()` 方法，让 `ApiClient` 处理 buvid3

## 效果

✅ 避免长时间使用固定 buvid3 被风控
✅ 所有 API 调用自动使用当前有效的 buvid3
✅ 代码更加内聚，buvid3 管理逻辑集中在一处