### PR TITLE
refactor: migrate frontend to Svelte 5 runes

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tailwindcss": "^3.3.0",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.1",
-    "typescript": "^5.0.0",
+    "typescript": "^5.5.0",
     "vite": "^5.4.21",
     "vitepress": "^1.6.3",
     "vitepress-plugin-mermaid": "^2.0.17"

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,7 +12,7 @@
   import Archive from "./page/Archive.svelte";
   import { onMount } from "svelte";
 
-  let active = "总览";
+  let active = $state("总览");
   onMount(async () => {
     await onOpenUrl((urls: string[]) => {
       console.log("Received Deep Link:", urls);
@@ -65,8 +65,8 @@
     <div class="sidebar">
       <BSidebar
         bind:activeUrl={active}
-        on:activeChange={(e) => {
-          active = e.detail;
+        onActiveChange={(label) => {
+          active = label;
         }}
       />
     </div>
@@ -87,7 +87,7 @@
         <Task />
       </div>
       <div class="page" class:visible={active == "助手"}>
-        <AI on:navigateSettings={() => (active = "设置")} />
+        <AI onNavigateSettings={() => (active = "设置")} />
       </div>
       <div class="page" class:visible={active == "账号"}>
         <Account />

--- a/src/AppClip.svelte
+++ b/src/AppClip.svelte
@@ -5,10 +5,10 @@
   import type { Config, VideoItem } from "./lib/interface";
   import { set_title } from "./lib/invoker";
 
-  let video: VideoItem | null = null;
-  let videos: any[] = [];
-  let showVideoPreview = false;
-  let roomId: string = "";
+  let video: VideoItem | null = $state(null);
+  let videos: any[] = $state([]);
+  let showVideoPreview = $state(false);
+  let roomId: string = $state("");
 
   let config: Config = null;
 

--- a/src/AppLive.svelte
+++ b/src/AppLive.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+
   import {
     invoke,
     set_title,
@@ -19,6 +20,10 @@
   import MarkerPanel from "./lib/components/MarkerPanel.svelte";
   import { onDestroy, onMount } from "svelte";
 
+  interface PlayerHandle {
+    seek(offset: number): void;
+  }
+
   const urlParams = new URLSearchParams(window.location.search);
   const room_id = urlParams.get("room_id");
   const platform = urlParams.get("platform");
@@ -29,9 +34,9 @@
   log.info("AppLive loaded", room_id, platform, live_id);
 
   // 弹幕相关变量
-  let danmu_records: DanmuEntry[] = [];
-  let filtered_danmu: DanmuEntry[] = [];
-  let danmu_search_text = "";
+  let danmu_records: DanmuEntry[] = $state([]);
+  let filtered_danmu: DanmuEntry[] = $state([]);
+  let danmu_search_text = $state("");
 
   // 弹幕峰值检测相关变量
   interface DanmuPeak {
@@ -40,10 +45,10 @@
     count: number;
     added: boolean; // 是否已添加为选区
   }
-  let danmu_peaks: DanmuPeak[] = [];
-  let peak_threshold = 80; // 阈值百分比
+  let danmu_peaks: DanmuPeak[] = $state([]);
+  let peak_threshold = $state(80); // 阈值百分比
   const DENSITY_WINDOW_SEC = 30; // 内部固定密度计算窗口
-  let show_peak_panel = false;
+  let show_peak_panel = $state(false);
 
   // 辅助函数：判断两个时间范围是否相似（容差 tolerance 秒）
   function is_range_similar(
@@ -255,25 +260,15 @@
     }
   }
 
-  // 监听弹幕数据变化、面板状态变化、阈值变化，统一检测峰值
-  $: if (show_peak_panel && danmu_records.length > 0) {
-    // 引用 peak_threshold 以便在其变化时触发重新计算
-    peak_threshold;
-    detect_danmu_peaks();
-  }
 
-  // 监听 ranges 变化，更新峰值的添加状态
-  $: if (ranges && danmu_peaks.length > 0) {
-    update_peak_added_status();
-  }
 
   // 虚拟滚动相关变量
   let danmu_container_height = 0;
   let danmu_item_height = 80; // 预估每个弹幕项的高度
-  let visible_start_index = 0;
-  let visible_end_index = 0;
+  let visible_start_index = $state(0);
+  let visible_end_index = $state(0);
   let scroll_top = 0;
-  let container_ref: HTMLElement;
+  let container_ref: HTMLElement = $state();
   let scroll_timeout: ReturnType<typeof setTimeout>;
 
   // 计算可见区域的弹幕
@@ -317,25 +312,7 @@
     }
   }
 
-  // 监听弹幕数据变化，更新过滤结果
-  $: {
-    if (danmu_records) {
-      // 如果当前有搜索文本，重新过滤
-      if (danmu_search_text) {
-        filter_danmu();
-      } else {
-        // 否则直接复制所有弹幕
-        filtered_danmu = [...danmu_records];
-      }
-      // 重新计算可见区域
-      calculate_visible_danmu();
-    }
-  }
 
-  // 监听容器引用变化
-  $: if (container_ref) {
-    handle_resize();
-  }
 
   // 过滤弹幕
   function filter_danmu() {
@@ -393,23 +370,13 @@
     }
   });
 
-  let archive: RecordItem = null;
+  let archive: RecordItem = $state(null);
 
   // load ranges from local storage
-  let ranges: Range[] = JSON.parse(
+  let ranges: Range[] = $state(JSON.parse(
     window.localStorage.getItem(`ranges:${room_id}:${live_id}`) || "[]"
-  );
-  $: activeRanges = ranges.filter((r) => r.activated !== false);
-  // save ranges to local storage when changed
-  $: {
-    if (ranges) {
-      window.localStorage.setItem(
-        `ranges:${room_id}:${live_id}`,
-        JSON.stringify(ranges)
-      );
-    }
-  }
-  let global_offset = 0;
+  ));
+  let global_offset = $state(0);
 
   function handleSelectAll(e: Event) {
     const checked = (e.currentTarget as HTMLInputElement).checked;
@@ -426,17 +393,17 @@
     ranges = ranges.filter((r) => r.activated === false);
   }
 
-  let show_selection_list = false;
-  let clip_running = false;
+  let show_selection_list = $state(false);
+  let clip_running = $state(false);
   let text_style = {
     position: { x: 8, y: 8 },
     fontSize: 24,
     color: "#FF7F00",
   };
-  let video_selected = 0;
-  let videos = [];
+  let video_selected = $state(0);
+  let videos = $state([]);
 
-  let selected_video = null;
+  let selected_video = $state(null);
 
   let video: HTMLVideoElement;
 
@@ -499,8 +466,7 @@
     selected_video = target_video;
   }
 
-  async function handleClipGenerated(event: CustomEvent<VideoItem>) {
-    const newVideo = event.detail;
+  async function handleClipGenerated(newVideo: VideoItem) {
     await get_video_list();
     newVideo.cover = await get_static_url("output", newVideo.cover);
     video_selected = newVideo.id;
@@ -521,21 +487,14 @@
     selected_video = null;
     await get_video_list();
   }
-  let player;
-  let lpanel_collapsed = true;
-  let rpanel_collapsed = false;
-  let markers: Marker[] = [];
+  let player: PlayerHandle = $state();
+  let lpanel_collapsed = $state(true);
+  let rpanel_collapsed = $state(false);
+  let markers: Marker[] = $state([]);
   // load markers from local storage
   markers = JSON.parse(
     window.localStorage.getItem(`markers:${room_id}:${live_id}`) || "[]"
   );
-  $: {
-    // makers changed, save to local storage
-    window.localStorage.setItem(
-      `markers:${room_id}:${live_id}`,
-      JSON.stringify(markers)
-    );
-  }
 
   async function save_video() {
     if (!selected_video) {
@@ -553,6 +512,57 @@
   async function open_clip(video_id: number) {
     await invoke("open_clip", { videoId: video_id });
   }
+  // 监听弹幕数据变化、面板状态变化、阈值变化，统一检测峰值
+  $effect(() => {
+    if (show_peak_panel && danmu_records.length > 0) {
+      // 引用 peak_threshold 以便在其变化时触发重新计算
+      peak_threshold;
+      detect_danmu_peaks();
+    }
+  });
+  // 监听 ranges 变化，更新峰值的添加状态
+  $effect(() => {
+    if (ranges && danmu_peaks.length > 0) {
+      update_peak_added_status();
+    }
+  });
+  // 监听弹幕数据变化，更新过滤结果
+  $effect(() => {
+    if (danmu_records) {
+      // 如果当前有搜索文本，重新过滤
+      if (danmu_search_text) {
+        filter_danmu();
+      } else {
+        // 否则直接复制所有弹幕
+        filtered_danmu = [...danmu_records];
+      }
+      // 重新计算可见区域
+      calculate_visible_danmu();
+    }
+  });
+  // 监听容器引用变化
+  $effect(() => {
+    if (container_ref) {
+      handle_resize();
+    }
+  });
+  let activeRanges = $derived(ranges.filter((r) => r.activated !== false));
+  // save ranges to local storage when changed
+  $effect(() => {
+    if (ranges) {
+      window.localStorage.setItem(
+        `ranges:${room_id}:${live_id}`,
+        JSON.stringify(ranges)
+      );
+    }
+  });
+  $effect(() => {
+    // makers changed, save to local storage
+    window.localStorage.setItem(
+      `markers:${room_id}:${live_id}`,
+      JSON.stringify(markers)
+    );
+  });
 </script>
 
 <main>
@@ -571,8 +581,8 @@
             <MarkerPanel
               {archive}
               bind:markers
-              on:markerClick={(e) => {
-                player.seek(e.detail.offset);
+              onMarkerClick={(marker) => {
+                player.seek(marker.offset);
               }}
             />
           </div>
@@ -580,7 +590,7 @@
       </div>
       <button
         class="collapse-btn lp transition-transform duration-300 absolute"
-        on:click={() => {
+        onclick={() => {
           lpanel_collapsed = !lpanel_collapsed;
         }}
       >
@@ -603,10 +613,10 @@
         {room_id}
         {live_id}
         {markers}
-        on:markerAdd={(e) => {
+        onMarkerAdd={(marker) => {
           markers.push({
-            offset: e.detail.offset,
-            realtime: e.detail.realtime,
+            offset: marker.offset,
+            realtime: marker.realtime,
             content: "[空标记点]",
           });
           markers = markers.sort((a, b) => a.offset - b.offset);
@@ -622,7 +632,7 @@
         class="collapse-btn rp transition-transform duration-300"
         class:translate-x-[-20px]={!rpanel_collapsed}
         class:translate-x-0={rpanel_collapsed}
-        on:click={() => {
+        onclick={() => {
           rpanel_collapsed = !rpanel_collapsed;
         }}
       >
@@ -648,7 +658,7 @@
                 <h3 class="text-sm font-medium text-gray-300">切片列表</h3>
                 <div class="flex space-x-2">
                   <button
-                    on:click={() => (show_selection_list = true)}
+                    onclick={() => (show_selection_list = true)}
                     class="px-4 py-1.5 bg-[#2c2c2e] text-white text-sm rounded-lg
                            hover:bg-[#3c3c3e]/90 transition-all duration-200
                            disabled:opacity-50 disabled:cursor-not-allowed
@@ -661,11 +671,11 @@
                     ranges={activeRanges}
                     captureCover
                     bind:running={clip_running}
-                    on:generated={handleClipGenerated}
+                    onGenerated={handleClipGenerated}
                   />
                   {#if selected_video}
                     <button
-                      on:click={delete_video}
+                      onclick={delete_video}
                       class="px-4 py-1.5 text-red-500 text-sm rounded-lg
                              transition-all duration-200 hover:bg-red-500/10
                              disabled:opacity-50 disabled:cursor-not-allowed"
@@ -685,7 +695,7 @@
               <div class="flex flex-row items-center justify-between">
                 <select
                   bind:value={video_selected}
-                  on:change={find_video}
+                  onchange={find_video}
                   class="w-full px-3 py-2 bg-[#2c2c2e] text-white rounded-lg
                        border border-gray-800/50 focus:border-[#0A84FF]
                        transition duration-200 outline-none appearance-none
@@ -698,7 +708,7 @@
                 </select>
                 {#if !TAURI_ENV && selected_video}
                   <button
-                    on:click={save_video}
+                    onclick={save_video}
                     class="w-24 ml-2 px-3 py-2 bg-[#0A84FF] text-white rounded-lg
                      transition-all duration-200 hover:bg-[#0A84FF]/90
                      disabled:opacity-50 disabled:cursor-not-allowed"
@@ -715,14 +725,14 @@
                 <h3 class="text-sm font-medium text-gray-300">弹幕峰值</h3>
                 {#if show_peak_panel}
                   <button
-                    on:click={() => (show_peak_panel = false)}
+                    onclick={() => (show_peak_panel = false)}
                     class="text-sm text-gray-400 hover:text-[#0A84FF] transition-colors duration-200"
                   >
                     收起
                   </button>
                 {:else}
                   <button
-                    on:click={() => (show_peak_panel = true)}
+                    onclick={() => (show_peak_panel = true)}
                     class="px-4 py-1.5 bg-[#2c2c2e] text-white text-sm rounded-lg
                            transition-all duration-200 hover:bg-[#3c3c3e]"
                   >
@@ -765,7 +775,7 @@
                       检测到 {danmu_peaks.length} 个峰值
                     </span>
                     <button
-                      on:click={add_all_peaks_to_ranges}
+                      onclick={add_all_peaks_to_ranges}
                       class="text-xs text-gray-400 hover:text-[#0A84FF] transition-colors duration-200 font-medium"
                     >
                       + 全部添加
@@ -775,11 +785,13 @@
                     class="max-h-48 overflow-y-auto space-y-2 sidebar-scrollbar"
                   >
                     {#each danmu_peaks as peak}
-                      <!-- svelte-ignore a11y-click-events-have-key-events -->
+                      <!-- svelte-ignore a11y_click_events_have_key_events -->
                       <div
                         class="flex items-center justify-between p-2 bg-[#2c2c2e] rounded-lg border border-gray-800/50
                                hover:border-[#0A84FF]/50 transition-all duration-200 cursor-pointer"
-                        on:click={() => {
+                        role="button"
+                        tabindex="0"
+                        onclick={() => {
                           if (player) {
                             player.seek(peak.start);
                           }
@@ -801,8 +813,10 @@
                           </span>
                         {:else}
                           <button
-                            on:click|stopPropagation={() =>
-                              add_peak_to_ranges(peak)}
+                            onclick={(event) => {
+                              event.stopPropagation();
+                              add_peak_to_ranges(peak);
+                            }}
                             class="text-xs text-gray-400 hover:text-[#0A84FF] transition-colors duration-200 font-medium"
                           >
                             + 添加
@@ -819,11 +833,13 @@
             {#if selected_video && selected_video.id != -1}
               <section class="flex-shrink-0">
                 <div class="group">
-                  <!-- svelte-ignore a11y-click-events-have-key-events -->
+                  <!-- svelte-ignore a11y_click_events_have_key_events -->
                   <div
                     id="capture"
                     class="relative rounded-xl overflow-hidden bg-black/20 border border-gray-800/50 cursor-pointer group"
-                    on:click={async () => {
+                    role="button"
+                    tabindex="0"
+                    onclick={async () => {
                       pauseVideo();
                       await open_clip(selected_video.id);
                     }}
@@ -877,23 +893,25 @@
                 <!-- 弹幕列表 -->
                 <div
                   bind:this={container_ref}
-                  on:scroll={handle_scroll}
+                  onscroll={handle_scroll}
                   class="flex-1 overflow-y-auto space-y-2 sidebar-scrollbar min-h-0 danmu-container"
                 >
                   <!-- 顶部占位符 -->
                   <div
                     style="height: {visible_start_index * danmu_item_height}px;"
-                  />
+></div>
 
                   <!-- 可见的弹幕项 -->
                   {#each filtered_danmu.slice(visible_start_index, visible_end_index) as danmu, index (visible_start_index + index)}
-                    <!-- svelte-ignore a11y-click-events-have-key-events -->
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <div
                       class="p-3 bg-[#2c2c2e] rounded-lg border border-gray-800/50
                              hover:border-[#0A84FF]/50 transition-all duration-200
                              cursor-pointer group danmu-item"
+                      role="button"
+                      tabindex="0"
                       style="content-visibility: auto; contain-intrinsic-size: {danmu_item_height}px;"
-                      on:click={() => seek_to_danmu(danmu)}
+                      onclick={() => seek_to_danmu(danmu)}
                     >
                       <div class="flex items-start justify-between">
                         <div class="flex-1 min-w-0">
@@ -920,7 +938,7 @@
                     style="height: {(filtered_danmu.length -
                       visible_end_index) *
                       danmu_item_height}px;"
-                  />
+></div>
 
                   {#if filtered_danmu.length === 0}
                     <div class="text-center py-8 text-gray-500">
@@ -947,14 +965,14 @@
       role="button"
       tabindex="0"
       aria-label="关闭对话框"
-      on:click={() => (show_selection_list = false)}
-      on:keydown={(e) => {
+      onclick={() => (show_selection_list = false)}
+      onkeydown={(e) => {
         if (e.key === "Escape" || e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           show_selection_list = false;
         }
       }}
-    />
+></div>
 
     <div
       role="dialog"
@@ -973,7 +991,7 @@
                 type="checkbox"
                 checked={ranges.length > 0 &&
                   ranges.every((r) => r.activated !== false)}
-                on:change={handleSelectAll}
+                onchange={handleSelectAll}
                 class="h-4 w-4 rounded border-white/30 bg-[#1c1c1e] text-[#0A84FF] accent-[#0A84FF] focus:outline-none focus:ring-2 focus:ring-[#0A84FF]/40 cursor-pointer"
               />
             </label>
@@ -1010,7 +1028,7 @@
                   <input
                     type="checkbox"
                     checked={range.activated !== false}
-                    on:change={(e) => handleRangeChange(e, range)}
+                    onchange={(e) => handleRangeChange(e, range)}
                     class="h-5 w-5 rounded border-white/30 bg-[#1c1c1e] text-[#0A84FF] accent-[#0A84FF] focus:outline-none focus:ring-2 focus:ring-[#0A84FF]/40 cursor-pointer"
                   />
                 </label>
@@ -1029,13 +1047,13 @@
         class="flex items-center justify-end gap-2 rounded-b-2xl border-t border-white/10 bg-[#111113] px-5 py-3"
       >
         <button
-          on:click={deleteActivatedRanges}
+          onclick={deleteActivatedRanges}
           class="px-3.5 py-2 text-[13px] rounded-lg border border-red-500/20 text-red-500 hover:bg-red-500/10 transition-colors"
         >
           删除选区
         </button>
         <button
-          on:click={() => (show_selection_list = false)}
+          onclick={() => (show_selection_list = false)}
           class="px-3.5 py-2 text-[13px] rounded-lg bg-[#0A84FF] text-white shadow-[inset_0_1px_0_rgba(255,255,255,.15)] hover:bg-[#0A84FF]/90 transition-colors"
         >
           完成

--- a/src/lib/components/AIMessage.svelte
+++ b/src/lib/components/AIMessage.svelte
@@ -14,19 +14,29 @@
   import { marked } from "marked";
   import CopyMarkdownButton from "./CopyMarkdownButton.svelte";
 
-  export let message: AssistantMessage;
-  export let formatTime: (date: Date) => string;
-  export let onToolCallConfirm: ((toolCall: ToolCall) => void) | undefined;
-  export let onToolCallReject: ((toolCall: ToolCall) => void) | undefined;
-  export let getToolCallState: (
-    toolCallId: string,
-  ) => 'confirmed' | 'rejected' | 'none' = () => 'none';
-  export let confirmationDisabled = false;
+  interface Props {
+    message: AssistantMessage;
+    formatTime: (date: Date) => string;
+    onToolCallConfirm?: (toolCall: ToolCall) => void;
+    onToolCallReject?: (toolCall: ToolCall) => void;
+    getToolCallState?: (
+      toolCallId: string,
+    ) => 'confirmed' | 'rejected' | 'none';
+    confirmationDisabled?: boolean;
+  }
 
-  $: isError = message.isError === true;
+  let {
+    message,
+    formatTime,
+    onToolCallConfirm,
+    onToolCallReject,
+    getToolCallState = () => 'none',
+    confirmationDisabled = false
+  }: Props = $props();
 
-  $: messageTime = new Date(message.timestamp);
-  $: contentParts = messageContentToDisplayParts(message.content);
+  let isError = $derived(message.isError === true);
+  let messageTime = $derived(new Date(message.timestamp));
+  let contentParts = $derived(messageContentToDisplayParts(message.content));
 
   function markdownContent(): string {
     return messageContentToMarkdown(message.content);
@@ -37,10 +47,10 @@
       content.includes('|--') || content.includes('| -');
   }
 
-  $: hasTable = contentParts.some(
+  let hasTable = $derived(contentParts.some(
     (part) => part.kind === "text" &&
       part.format === "markdown" && containsTable(part.text),
-  );
+  ));
 
   function isExecutedToolCall(toolCall: ToolCall): boolean {
     return toolCall.executed === true;
@@ -212,7 +222,7 @@
                   {:else if isPendingToolCall(toolCall)}
                     <div class="flex items-center space-x-2 w-full">
                       <button
-                        on:click={() => onToolCallReject?.(toolCall)}
+                        onclick={() => onToolCallReject?.(toolCall)}
                         disabled={confirmationDisabled}
                         class="flex items-center space-x-1 px-4 py-2 bg-red-500 hover:bg-red-600 active:bg-red-700 text-white text-xs font-medium rounded-lg shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
                       >
@@ -220,7 +230,7 @@
                         <span>拒绝</span>
                       </button>
                       <button
-                        on:click={() => onToolCallConfirm?.(toolCall)}
+                        onclick={() => onToolCallConfirm?.(toolCall)}
                         disabled={confirmationDisabled}
                         class="flex items-center justify-center space-x-1 px-4 py-2 bg-blue-500 hover:bg-blue-600 active:bg-blue-700 text-white text-xs font-medium rounded-lg shadow-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 disabled:opacity-50 disabled:cursor-not-allowed flex-1"
                       >

--- a/src/lib/components/ArchiveClipButton.svelte
+++ b/src/lib/components/ArchiveClipButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy, onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { Loader2, Scissors } from "lucide-svelte";
   import type { RecordItem } from "../db";
   import {
@@ -10,19 +10,31 @@
   } from "../interface";
   import { invoke, listen, log } from "../invoker";
 
-  export let archive: RecordItem | null = null;
-  export let ranges: Range[] = [];
-  export let initialNote = "";
-  export let localOffset: number | null = null;
-  export let captureCover = false;
-  export let variant: "primary" | "compact" = "primary";
-  export let disabled = false;
-  export let running = false;
+  interface Props {
+    archive?: RecordItem | null;
+    ranges?: Range[];
+    initialNote?: string;
+    localOffset?: number | null;
+    captureCover?: boolean;
+    variant?: "primary" | "compact";
+    disabled?: boolean;
+    running?: boolean;
+    onGenerated?: (video: VideoItem) => void;
+    onFailed?: (message: string) => void;
+  }
 
-  const dispatch = createEventDispatcher<{
-    generated: VideoItem;
-    failed: string;
-  }>();
+  let {
+    archive = null,
+    ranges = [],
+    initialNote = "",
+    localOffset = null,
+    captureCover = false,
+    variant = "primary",
+    disabled = false,
+    running = $bindable(false),
+    onGenerated,
+    onFailed
+  }: Props = $props();
 
   const transitionOptions = [
     { value: "none", label: "无" },
@@ -34,17 +46,17 @@
     { value: "slidedown", label: "向下滑动" },
   ];
 
-  let showConfirm = false;
-  let currentEventId: string | null = null;
-  let progressText = "生成切片";
-  let clipNote = "";
-  let danmuEnabled = false;
-  let fixEncoding = false;
-  let transition = "none";
+  let showConfirm = $state(false);
+  let currentEventId: string | null = $state(null);
+  let progressText = $state("生成切片");
+  let clipNote = $state("");
+  let danmuEnabled = $state(false);
+  let fixEncoding = $state(false);
+  let transition = $state("none");
   let clearUpdateListener: (() => void) | null = null;
   let clearFinishedListener: (() => void) | null = null;
 
-  $: activeRanges = ranges.filter((range) => range.activated !== false);
+  let activeRanges = $derived(ranges.filter((range) => range.activated !== false));
 
   function openConfirm() {
     if (!archive || disabled || currentEventId) return;
@@ -133,7 +145,7 @@
         if (!event.payload.success) {
           const message = String(event.payload.message || "未知错误");
           alert("请检查 ffmpeg 是否配置正确：" + message);
-          dispatch("failed", message);
+          onFailed?.(message);
         }
         resetTaskState(eventId);
       },
@@ -160,12 +172,12 @@
       });
       clipNote = "";
       transition = "none";
-      dispatch("generated", video as VideoItem);
+      onGenerated?.(video as VideoItem);
     } catch (error) {
       if (currentEventId === eventId) {
         const message = String(error);
         alert("切片生成失败：" + message);
-        dispatch("failed", message);
+        onFailed?.(message);
       }
     } finally {
       resetTaskState(eventId);
@@ -202,7 +214,7 @@
 <div class={variant === "compact" ? "contents" : "flex items-center gap-2"}>
     <button
       type="button"
-      on:click={openConfirm}
+      onclick={openConfirm}
       disabled={disabled || !archive || currentEventId !== null}
       class={variant === "compact"
         ? "inline-flex items-center gap-1.5 whitespace-nowrap rounded-lg border border-violet-200 bg-white px-2.5 py-1.5 text-xs font-medium text-violet-700 transition-colors hover:bg-violet-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-violet-700 dark:bg-gray-900 dark:text-violet-300 dark:hover:bg-violet-950/60"
@@ -219,7 +231,7 @@
     {#if currentEventId && variant === "primary"}
       <button
         type="button"
-        on:click={cancelClip}
+        onclick={cancelClip}
         class="rounded-lg px-4 py-1.5 text-sm text-red-500 transition-all duration-200 hover:bg-red-500/10"
       >
         取消
@@ -234,14 +246,14 @@
       role="button"
       tabindex="0"
       aria-label="关闭对话框"
-      on:click={closeConfirm}
-      on:keydown={(event) => {
+      onclick={closeConfirm}
+      onkeydown={(event) => {
         if (event.key === "Escape" || event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           closeConfirm();
         }
       }}
-    />
+></div>
 
     <div
       role="dialog"
@@ -329,7 +341,7 @@
                   class="rounded-lg border px-2 py-1.5 text-[12px] transition-colors {transition === option.value
                     ? 'border-[#0A84FF] bg-[#0A84FF]/20 text-[#0A84FF]'
                     : 'border-white/5 bg-[#2c2c2e] text-white/70 hover:border-white/20'}"
-                  on:click={() => (transition = option.value)}
+                  onclick={() => (transition = option.value)}
                 >
                   {option.label}
                 </button>
@@ -342,14 +354,14 @@
       <div class="flex items-center justify-end gap-2 rounded-b-2xl border-t border-white/10 bg-[#111113] px-5 py-3">
         <button
           type="button"
-          on:click={closeConfirm}
+          onclick={closeConfirm}
           class="rounded-lg border border-white/20 px-3.5 py-2 text-[13px] text-white/90 transition-colors hover:bg-white/10"
         >
           取消
         </button>
         <button
           type="button"
-          on:click={generateClip}
+          onclick={generateClip}
           disabled={activeRanges.length === 0}
           class="rounded-lg bg-[#0A84FF] px-3.5 py-2 text-[13px] text-white shadow-[inset_0_1px_0_rgba(255,255,255,.15)] transition-colors hover:bg-[#0A84FF]/90 disabled:cursor-not-allowed disabled:opacity-50"
         >

--- a/src/lib/components/ArchiveSummaryModal.svelte
+++ b/src/lib/components/ArchiveSummaryModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
   import { marked } from "marked";
   import { AlertCircle, Loader2, RefreshCw, Sparkles, X } from "lucide-svelte";
   import { invoke } from "../invoker";
@@ -13,27 +13,21 @@
     TaskRow,
   } from "../db";
 
-  export let showModal = false;
-  export let archive: RecordItem | null = null;
+  interface Props {
+    showModal?: boolean;
+    archive?: RecordItem | null;
+    onUpdated?: (status: RecordSummaryStatus) => void;
+  }
 
-  const dispatch = createEventDispatcher<{ updated: RecordSummaryStatus }>();
+  let { showModal = $bindable(false), archive = null, onUpdated }: Props = $props();
 
-  let summary: RecordSummary | null = null;
-  let loading = false;
-  let actionLoading = false;
-  let error = "";
-  let loadedKey = "";
+  let summary: RecordSummary | null = $state(null);
+  let loading = $state(false);
+  let actionLoading = $state(false);
+  let error = $state("");
+  let loadedKey = $state("");
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
 
-  $: currentKey = archive
-    ? `${archive.platform}:${archive.room_id}:${archive.live_id}`
-    : "";
-  $: if (showModal && archive && currentKey !== loadedKey) {
-    loadedKey = currentKey;
-    void loadSummary();
-  }
-  $: highlights = parseHighlights(summary?.highlights_json);
-  $: summaryMarkdown = summary?.summary_markdown || "";
 
   function clearPoll() {
     if (pollTimer) {
@@ -117,7 +111,7 @@
 
   function emitStatus() {
     if (!summary || !archive) return;
-    dispatch("updated", {
+    onUpdated?.({
       platform: archive.platform,
       room_id: archive.room_id,
       live_id: archive.live_id,
@@ -150,6 +144,17 @@
   }
 
   onDestroy(clearPoll);
+  let currentKey = $derived(archive
+    ? `${archive.platform}:${archive.room_id}:${archive.live_id}`
+    : "");
+  $effect(() => {
+    if (showModal && archive && currentKey !== loadedKey) {
+      loadedKey = currentKey;
+      void loadSummary();
+    }
+  });
+  let highlights = $derived(parseHighlights(summary?.highlights_json));
+  let summaryMarkdown = $derived(summary?.summary_markdown || "");
 </script>
 
 {#if showModal && archive}
@@ -168,7 +173,7 @@
             {archive.title}
           </p>
         </div>
-        <button class="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800" on:click={close}>
+        <button class="rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-800" onclick={close}>
           <X class="h-5 w-5" />
         </button>
       </div>
@@ -238,7 +243,7 @@
               <p class="font-medium text-gray-900 dark:text-white">Summary 生成失败</p>
               <p class="mt-2 max-w-xl text-sm text-red-600 dark:text-red-400">{summary.error_message || "未知错误"}</p>
             </div>
-            <button class="flex items-center gap-2 rounded-lg bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-700" on:click={() => generate(false)} disabled={actionLoading}>
+            <button class="flex items-center gap-2 rounded-lg bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-700" onclick={() => generate(false)} disabled={actionLoading}>
               <RefreshCw class="h-4 w-4 {actionLoading ? 'animate-spin' : ''}" />
               从失败阶段重试
             </button>
@@ -250,7 +255,7 @@
               <p class="font-medium text-gray-900 dark:text-white">尚未生成 Summary</p>
               <p class="mt-1 text-sm text-gray-500">将依次提取完整音频、生成字幕并总结直播内容。</p>
             </div>
-            <button class="rounded-lg bg-violet-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-violet-700 disabled:opacity-50" on:click={() => generate(false)} disabled={actionLoading}>
+            <button class="rounded-lg bg-violet-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-violet-700 disabled:opacity-50" onclick={() => generate(false)} disabled={actionLoading}>
               {actionLoading ? "正在创建任务…" : "生成 Summary"}
             </button>
           </div>
@@ -263,8 +268,8 @@
 
       {#if summary?.status === "success"}
         <div class="flex justify-end gap-3 border-t border-gray-200 px-6 py-4 dark:border-gray-700">
-          <button class="rounded-lg px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800" on:click={close}>关闭</button>
-          <button class="rounded-lg bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-700" on:click={() => generate(true)} disabled={actionLoading}>
+          <button class="rounded-lg px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-800" onclick={close}>关闭</button>
+          <button class="rounded-lg bg-violet-600 px-4 py-2 text-sm text-white hover:bg-violet-700" onclick={() => generate(true)} disabled={actionLoading}>
             重新生成
           </button>
         </div>

--- a/src/lib/components/AutoRecordIcon.svelte
+++ b/src/lib/components/AutoRecordIcon.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
   import { Activity, RefreshCw } from "lucide-svelte";
-  export let size: number = 18;
-  export let color: string = "currentColor";
+  interface Props {
+    size?: number;
+    color?: string;
+    class?: string;
+  }
+
+  let { size = 18, color = "currentColor", class: className = "" }: Props = $props();
 </script>
 
-<div class="relative" class:$$props style="width: {size}px; height: {size}px;">
+<div class="relative {className}" style="width: {size}px; height: {size}px;">
   <div class="absolute inset-0 flex items-center justify-center">
     <RefreshCw {size} {color} class="opacity-80" strokeWidth={1} />
     <Activity class="absolute" size={size * 0.6} {color} />

--- a/src/lib/components/BSidebar.svelte
+++ b/src/lib/components/BSidebar.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import {
     FileVideo,
     Info,
@@ -12,17 +12,19 @@
   } from "lucide-svelte";
   import { hasNewVersion } from "../stores/version";
   import SidebarItem from "./SidebarItem.svelte";
-  import { createEventDispatcher } from "svelte";
+  interface Props {
+    activeUrl?: string;
+    onActiveChange?: (label: string) => void;
+  }
 
-  const dispatch = createEventDispatcher();
-
-  export let activeUrl = "总览";
+  let { activeUrl = $bindable("总览"), onActiveChange }: Props = $props();
 
   /**
    * @param {{ detail: String; }} route
    */
-  function navigate(route) {
-    dispatch("activeChange", route.detail);
+  function navigate(label: string) {
+    activeUrl = label;
+    onActiveChange?.(label);
   }
 </script>
 
@@ -30,55 +32,73 @@
   class="w-48 bg-[#f0f0f3]/50 dark:bg-black backdrop-blur-xl border-r border-gray-200 dark:border-gray-700"
 >
   <nav class="p-3 space-y-1">
-    <SidebarItem label="总览" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <LayoutDashboard class="w-5 h-5" />
-      </div>
+    <SidebarItem label="总览" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <LayoutDashboard class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
-    <SidebarItem label="直播间" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <Video class="w-5 h-5" />
-      </div>
+    <SidebarItem label="直播间" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <Video class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
-    <SidebarItem label="录播" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <History class="w-5 h-5" />
-      </div>
+    <SidebarItem label="录播" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <History class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
-    <SidebarItem label="切片" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <FileVideo class="w-5 h-5" />
-      </div>
+    <SidebarItem label="切片" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <FileVideo class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
-    <SidebarItem label="任务" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <List class="w-5 h-5" />
-      </div>
+    <SidebarItem label="任务" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <List class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
-    <SidebarItem label="助手" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <Brain class="w-5 h-5" />
-      </div>
+    <SidebarItem label="助手" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <Brain class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
-    <SidebarItem label="账号" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <Users class="w-5 h-5" />
-      </div>
+    <SidebarItem label="账号" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <Users class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
-    <SidebarItem label="设置" {activeUrl} on:activeChange={navigate}>
-      <div slot="icon">
-        <Settings class="w-5 h-5" />
-      </div>
+    <SidebarItem label="设置" {activeUrl} onActiveChange={navigate}>
+      {#snippet icon()}
+            <div >
+          <Settings class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
     <SidebarItem
       label="关于"
       {activeUrl}
-      on:activeChange={navigate}
+      onActiveChange={navigate}
       dot={$hasNewVersion}
     >
-      <div slot="icon">
-        <Info class="w-5 h-5" />
-      </div>
+      {#snippet icon()}
+            <div >
+          <Info class="w-5 h-5" />
+        </div>
+          {/snippet}
     </SidebarItem>
   </nav>
 </div>

--- a/src/lib/components/BilibiliIcon.svelte
+++ b/src/lib/components/BilibiliIcon.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-  let className = '';
-  export { className as class };
+  interface Props {
+    class?: string;
+  }
+
+  let { class: className = '' }: Props = $props();
+
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="{className}">

--- a/src/lib/components/CopyMarkdownButton.svelte
+++ b/src/lib/components/CopyMarkdownButton.svelte
@@ -2,9 +2,13 @@
   import { onDestroy } from "svelte";
   import { Check, Copy } from "lucide-svelte";
 
-  export let content: string | (() => string);
+  interface Props {
+    content: string | (() => string);
+  }
 
-  let copied = false;
+  let { content }: Props = $props();
+
+  let copied = $state(false);
   let resetTimer: ReturnType<typeof setTimeout> | undefined;
 
   async function copyMarkdown() {
@@ -28,7 +32,7 @@
 
 <button
   type="button"
-  on:click={copyMarkdown}
+  onclick={copyMarkdown}
   class="inline-flex h-6 w-6 items-center justify-center rounded text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-200"
   aria-label={copied ? "已复制 Markdown" : "复制为 Markdown"}
   title={copied ? "已复制" : "复制为 Markdown"}

--- a/src/lib/components/CoverEditor.svelte
+++ b/src/lib/components/CoverEditor.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
   import { Play, X, Type, Palette, Move, Plus, Trash2 } from "lucide-svelte";
   import { invoke, log } from "../invoker";
-  import { onMount, createEventDispatcher } from "svelte";
+  import { onMount } from "svelte";
 
-  const dispatch = createEventDispatcher();
-  export let video = null;
-  export let show: boolean = false;
+  interface Props {
+    video?: any;
+    show?: boolean;
+    onCoverUpdate?: (cover: { cover: string }) => void;
+  }
+
+  let { video = null, show = $bindable(false), onCoverUpdate }: Props = $props();
 
   // 文本列表
-  let texts = [
+  let texts = $state([
     {
       id: 1,
       content: "",
@@ -17,22 +21,22 @@
       color: "#FF7F00",
       strokeColor: "#FFFFFF",
     },
-  ];
+  ]);
 
-  let selectedTextId = 1;
+  let selectedTextId = $state(1);
 
-  let isDragging = false;
+  let isDragging = $state(false);
   let startPos = { x: 0, y: 0 };
   let startTextPos = { x: 0, y: 0 };
 
-  let videoElement: HTMLVideoElement;
+  let videoElement: HTMLVideoElement = $state();
   let videoFrame;
-  let isVideoLoaded = false;
-  let currentTime = 0;
-  let duration = 0;
+  let isVideoLoaded = $state(false);
+  let currentTime = $state(0);
+  let duration = $state(0);
 
-  let canvas: HTMLCanvasElement;
-  let ctx: CanvasRenderingContext2D;
+  let canvas: HTMLCanvasElement = $state();
+  let ctx: CanvasRenderingContext2D = $state();
   let canvasWidth = 1280;
   let canvasHeight = 720;
   let scale = 1;
@@ -329,7 +333,7 @@
             });
 
             // 触发自定义事件通知父组件更新封面
-            dispatch("coverUpdate", { cover: newCover });
+            onCoverUpdate?.({ cover: newCover });
             handleClose();
           } catch (e) {
             alert("更新封面失败: " + e);
@@ -346,7 +350,7 @@
     scheduleRedraw();
   }
 
-  $: {
+  $effect(() => {
     // 当文本内容或样式改变时重绘
     if (ctx) {
       texts = texts.map((text) => {
@@ -363,28 +367,30 @@
       });
       scheduleRedraw();
     }
-  }
+  });
 
-  $: selectedText = texts.find((t) => t.id === selectedTextId);
+  let selectedText = $derived(texts.find((t) => t.id === selectedTextId));
 
   // 监听 show 变化，当模态框显示时重新绘制
-  $: if (show && ctx) {
-    setTimeout(() => {
-      if (isVideoLoaded && videoElement) {
-        // 如果视频已加载，更新封面
-        updateCoverFromVideo();
-      }
-      loadBackgroundImage();
-      resizeCanvas();
-    }, 50);
-  }
+  $effect(() => {
+    if (show && ctx) {
+      setTimeout(() => {
+        if (isVideoLoaded && videoElement) {
+          // 如果视频已加载，更新封面
+          updateCoverFromVideo();
+        }
+        loadBackgroundImage();
+        resizeCanvas();
+      }, 50);
+    }
+  });
 </script>
 
 <svelte:window
-  on:mousemove={handleMouseMove}
-  on:mouseup={handleMouseUp}
-  on:blur={() => (isDragging = false)}
-  on:visibilitychange={() => {
+  onmousemove={handleMouseMove}
+  onmouseup={handleMouseUp}
+  onblur={() => (isDragging = false)}
+  onvisibilitychange={() => {
     if (document.hidden) {
       isDragging = false;
     }
@@ -413,7 +419,7 @@
       <h3 class="text-base font-medium text-white">编辑封面</h3>
       <button
         class="w-[22px] h-[22px] rounded-full bg-[#ff5f57] hover:bg-[#ff5f57]/90 transition-colors duration-200 flex items-center justify-center group"
-        on:click={handleClose}
+        onclick={handleClose}
       >
         <X
           class="w-3 h-3 text-[#1c1c1e] opacity-0 group-hover:opacity-100 transition-opacity duration-200"
@@ -435,16 +441,16 @@
         </div>
 
         <!-- Hidden Video Element -->
-        <!-- svelte-ignore a11y-media-has-caption -->
+        <!-- svelte-ignore a11y_media_has_caption -->
         <video
           bind:this={videoElement}
           src={video?.file}
           class="hidden"
           crossorigin="anonymous"
-          on:loadedmetadata={handleVideoLoaded}
-          on:timeupdate={handleTimeUpdate}
-          on:seeked={handleVideoSeeked}
-        />
+          onloadedmetadata={handleVideoLoaded}
+          ontimeupdate={handleTimeUpdate}
+          onseeked={handleVideoSeeked}
+></video>
 
         <!-- Video Controls -->
         <div class="flex items-center space-x-2">
@@ -454,7 +460,7 @@
             max={duration}
             step="0.1"
             bind:value={currentTime}
-            on:input={handleSeek}
+            oninput={handleSeek}
             class="flex-1"
             disabled={!isVideoLoaded}
           />
@@ -475,9 +481,9 @@
         >
           <canvas
             bind:this={canvas}
-            on:mousedown={handleMouseDown}
+            onmousedown={handleMouseDown}
             class="w-full h-full"
-          />
+></canvas>
         </div>
       </div>
 
@@ -488,7 +494,7 @@
           <div class="flex-1 space-y-3">
             <!-- Text List -->
             <div class="flex items-center justify-between">
-              <!-- svelte-ignore a11y-label-has-associated-control -->
+              <!-- svelte-ignore a11y_label_has_associated_control -->
               <label
                 class="flex items-center space-x-2 text-sm font-medium text-gray-300"
               >
@@ -496,7 +502,7 @@
                 <span>文字列表</span>
               </label>
               <button
-                on:click={addNewText}
+                onclick={addNewText}
                 class="p-1.5 rounded-lg bg-[#2c2c2e] hover:bg-[#3c3c3e] transition-colors duration-200 text-white"
               >
                 <Plus class="w-4 h-4" />
@@ -504,21 +510,23 @@
             </div>
             <div class="space-y-1.5">
               {#each texts as text (text.id)}
-                <!-- svelte-ignore a11y-click-events-have-key-events -->
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
                 <div
                   class="flex items-center space-x-2 p-2 rounded-lg transition-colors duration-200 cursor-pointer"
+                  role="button"
+                  tabindex="0"
                   class:bg-[#2c2c2e]={selectedTextId === text.id}
-                  on:click={() => (selectedTextId = text.id)}
+                  onclick={() => (selectedTextId = text.id)}
                 >
                   <textarea
                     value={text.content}
-                    on:input={(e) => handleTextInput(text, e)}
+                    oninput={(e) => handleTextInput(text, e)}
                     placeholder="输入文字内容"
                     class="flex-1 bg-transparent text-white text-sm outline-none resize-none placeholder:text-gray-500"
-                  />
+></textarea>
                   {#if texts.length > 1}
                     <button
-                      on:click={() => deleteText(text.id)}
+                      onclick={() => deleteText(text.id)}
                       class="p-1 rounded hover:bg-[#3c3c3e] transition-colors duration-200 text-red-500"
                     >
                       <Trash2 class="w-4 h-4" />
@@ -532,7 +540,7 @@
           <!-- Text Style Controls -->
           {#if selectedText}
             <div class="w-48 space-y-2">
-              <!-- svelte-ignore a11y-label-has-associated-control -->
+              <!-- svelte-ignore a11y_label_has_associated_control -->
               <label
                 class="flex items-center space-x-2 text-sm font-medium text-gray-300"
               >
@@ -599,13 +607,13 @@
     >
       <button
         class="px-4 py-1.5 text-gray-400 hover:text-white transition-colors duration-200 text-sm font-medium"
-        on:click={handleClose}
+        onclick={handleClose}
       >
         取消
       </button>
       <button
         class="px-4 py-1.5 bg-[#0A84FF] text-white rounded-lg hover:bg-[#0A84FF]/90 transition-colors duration-200 text-sm font-medium"
-        on:click={handleSave}
+        onclick={handleSave}
       >
         确定
       </button>

--- a/src/lib/components/DouyinIcon.svelte
+++ b/src/lib/components/DouyinIcon.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-  let className = '';
-  export { className as class };
+  interface Props {
+    class?: string;
+  }
+
+  let { class: className = '' }: Props = $props();
+
 </script>
 
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class={className}>

--- a/src/lib/components/GenerateWholeClipModal.svelte
+++ b/src/lib/components/GenerateWholeClipModal.svelte
@@ -3,27 +3,26 @@
   import type { RecordItem } from "../db";
   import { fade, scale } from "svelte/transition";
   import { X, FileVideo, Info } from "lucide-svelte";
-  import { createEventDispatcher, onMount } from "svelte";
+  import { onMount } from "svelte";
   import { clickOutside } from "../actions/clickOutside";
 
-  export let showModal = false;
-  export let archive: RecordItem | null = null;
-  export let roomId: string;
+  interface Props {
+    showModal?: boolean;
+    archive?: RecordItem | null;
+    roomId: string;
+    onGenerated?: () => void;
+  }
+
+  let { showModal = $bindable(false), archive = null, roomId, onGenerated }: Props = $props();
   export const platform: string = "";
 
-  const dispatch = createEventDispatcher();
+  let wholeClipArchives: RecordItem[] = $state([]);
+  let isLoading = $state(false);
+  let encodeDanmu = $state(false);
+  let selectedLiveIds: string[] = $state([]);
+  let outputName = $state("");
+  let showSelectionHelp = $state(false);
 
-  let wholeClipArchives: RecordItem[] = [];
-  let isLoading = false;
-  let encodeDanmu = false;
-  let selectedLiveIds: string[] = [];
-  let outputName = "";
-  let showSelectionHelp = false;
-
-  // 当modal显示且有archive时，加载相关片段
-  $: if (showModal && archive) {
-    loadWholeClipArchives(roomId, archive.parent_id);
-  }
 
   async function loadWholeClipArchives(roomId: string, parentId: string) {
     if (isLoading) return;
@@ -74,7 +73,7 @@
       });
 
       showModal = false;
-      dispatch("generated");
+      onGenerated?.();
     } catch (error) {
       console.error("Failed to generate whole clip:", error);
     }
@@ -160,16 +159,8 @@
     }
   }
 
-  $: selectedArchives = selectedLiveIds
-    .map((id) => wholeClipArchives.find((item) => item.live_id === id))
-    .filter((item): item is RecordItem => Boolean(item));
 
-  $: totalDuration = selectedArchives.reduce(
-    (sum, item) => sum + item.length,
-    0
-  );
 
-  $: totalSize = selectedArchives.reduce((sum, item) => sum + item.size, 0);
 
   function closeModal() {
     showModal = false;
@@ -178,23 +169,38 @@
     outputName = "";
     showSelectionHelp = false;
   }
+  // 当modal显示且有archive时，加载相关片段
+  $effect(() => {
+    if (showModal && archive) {
+      loadWholeClipArchives(roomId, archive.parent_id);
+    }
+  });
+  let selectedArchives = $derived(selectedLiveIds
+    .map((id) => wholeClipArchives.find((item) => item.live_id === id))
+    .filter((item): item is RecordItem => Boolean(item)));
+  let totalDuration = $derived(selectedArchives.reduce(
+    (sum, item) => sum + item.length,
+    0
+  ));
+  let totalSize = $derived(selectedArchives.reduce((sum, item) => sum + item.size, 0));
 </script>
 
 {#if showModal}
   <div
     class="fixed inset-0 bg-black/20 dark:bg-black/40 backdrop-blur-sm z-50 flex items-center justify-center"
     transition:fade={{ duration: 200 }}
-    on:click={closeModal}
-    on:keydown={(e) => e.key === "Escape" && closeModal()}
+    onclick={closeModal}
+    onkeydown={(e) => e.key === "Escape" && closeModal()}
     role="dialog"
+    tabindex="-1"
     aria-modal="true"
   >
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="mac-modal w-[900px] bg-white dark:bg-[#323234] rounded-xl shadow-xl overflow-hidden flex flex-col max-h-[90vh]"
       transition:scale={{ duration: 150, start: 0.95 }}
-      on:click|stopPropagation
+      onclick={(event) => event.stopPropagation()}
     >
       <!-- Header -->
       <div
@@ -210,7 +216,7 @@
         </div>
         <button
           class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors"
-          on:click={closeModal}
+          onclick={closeModal}
         >
           <X class="w-5 h-5 dark:icon-white" />
         </button>
@@ -245,23 +251,23 @@
                 <div class="flex items-center space-x-3 text-sm">
                   <button
                     class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-                    on:click={selectAll}
+                    onclick={selectAll}
                   >
                     全选
                   </button>
                   <button
                     class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
-                    on:click={clearSelection}
+                    onclick={clearSelection}
                   >
                     取消全选
                   </button>
                   <div class="relative" use:clickOutside={() => (showSelectionHelp = false)}>
                     <button
                       class="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100"
-                      on:click={() =>
+                      onclick={() =>
                         (showSelectionHelp = !showSelectionHelp)}
-                      on:mouseenter={() => (showSelectionHelp = true)}
-                      on:mouseleave={() => (showSelectionHelp = false)}
+                      onmouseenter={() => (showSelectionHelp = true)}
+                      onmouseleave={() => (showSelectionHelp = false)}
                       aria-label="选择顺序说明"
                     >
                       <Info class="w-4 h-4" />
@@ -285,7 +291,7 @@
                       type="checkbox"
                       class="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
                       checked={selectedLiveIds.includes(archiveItem.live_id)}
-                      on:change={(event) =>
+                      onchange={(event) =>
                         handleSelectionChange(event, archiveItem.live_id)}
                     />
                     <div class="flex items-center justify-center w-6">
@@ -385,14 +391,14 @@
       >
         <button
           class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
-          on:click={closeModal}
+          onclick={closeModal}
         >
           取消
         </button>
         <button
           class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           disabled={isLoading || selectedArchives.length === 0}
-          on:click={generateWholeClip}
+          onclick={generateWholeClip}
         >
           开始合成
         </button>

--- a/src/lib/components/HumanMessage.svelte
+++ b/src/lib/components/HumanMessage.svelte
@@ -3,10 +3,13 @@
   import type { HumanMessage } from "../agent/messages";
   import CopyMarkdownButton from "./CopyMarkdownButton.svelte";
 
-  export let message: HumanMessage;
-  export let formatTime: (date: Date) => string;
+  interface Props {
+    message: HumanMessage;
+    formatTime: (date: Date) => string;
+  }
 
-  $: messageTime = new Date(message.timestamp);
+  let { message, formatTime }: Props = $props();
+  let messageTime = $derived(new Date(message.timestamp));
 </script>
 
 <div class="flex justify-end">

--- a/src/lib/components/HuyaIcon.svelte
+++ b/src/lib/components/HuyaIcon.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  let className = "";
-  export { className as class };
+  let { class: className = "" }: { class?: string } = $props();
 </script>
 
 <img src="/imgs/huya.png" class={className} alt="huya" />

--- a/src/lib/components/ImportVideoDialog.svelte
+++ b/src/lib/components/ImportVideoDialog.svelte
@@ -1,39 +1,42 @@
 <script lang="ts">
   import { invoke, TAURI_ENV, ENDPOINT, listen } from "../invoker";
   import { Upload, X, CheckCircle } from "lucide-svelte";
-  import { createEventDispatcher, onDestroy } from "svelte";
+  import { onDestroy } from "svelte";
   import { open } from "@tauri-apps/plugin-dialog";
   import type { ProgressUpdate, ProgressFinished } from "../interface";
 
-  export let showDialog = false;
-  export let roomId: string | null = null;
+  interface Props {
+    showDialog?: boolean;
+    roomId?: string | null;
+    onImported?: () => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let { showDialog = $bindable(false), roomId = null, onImported }: Props = $props();
   const IMPORTED_VIDEO_ROOM = "bsr:import";
 
-  let selectedFilePath: string | null = null;
-  let selectedFileName: string = "";
-  let selectedFileSize: number = 0;
-  let videoTitle = "";
-  let importing = false;
-  let uploading = false;
-  let uploadProgress = 0;
-  let dragOver = false;
-  let fileInput: HTMLInputElement;
-  let importProgress = "";
+  let selectedFilePath: string | null = $state(null);
+  let selectedFileName: string = $state("");
+  let selectedFileSize: number = $state(0);
+  let videoTitle = $state("");
+  let importing = $state(false);
+  let uploading = $state(false);
+  let uploadProgress = $state(0);
+  let dragOver = $state(false);
+  let fileInput: HTMLInputElement = $state();
+  let importProgress = $state("");
   let currentImportEventId: string | null = null;
 
   // 批量导入状态
-  let selectedFiles: string[] = [];
-  let batchImporting = false;
-  let currentFileIndex = 0;
+  let selectedFiles: string[] = $state([]);
+  let batchImporting = $state(false);
+  let currentFileIndex = $state(0);
   let totalFiles = 0;
 
   // 获取当前正在处理的文件名（从文件路径中提取文件名）
-  $: currentFileName =
-    currentFileIndex > 0 && selectedFiles.length > 0
+  let currentFileName =
+    $derived(currentFileIndex > 0 && selectedFiles.length > 0
       ? selectedFiles[currentFileIndex - 1]?.split(/[/\\]/).pop() || "未知文件"
-      : "";
+      : "");
 
   // 格式化文件大小
   function formatFileSize(sizeInBytes: number): string {
@@ -67,7 +70,7 @@
         currentImportEventId = null;
         importProgress = "";
         resetBatchImportState();
-        dispatch("imported");
+        onImported?.();
       }
     } catch (error) {
       console.error(`[ImportDialog] Failed to check task status:`, error);
@@ -295,7 +298,7 @@
             selectedFileSize = 0;
             videoTitle = "";
             resetBatchImportState();
-            dispatch("imported");
+            onImported?.();
           } else {
             throw new Error(response.message || "批量导入失败");
           }
@@ -374,7 +377,7 @@
             selectedFileSize = 0;
             videoTitle = "";
             resetBatchImportState();
-            dispatch("imported");
+            onImported?.();
           } else {
             alert("导入失败: " + e.payload.message);
             resetBatchImportState();
@@ -447,7 +450,7 @@
             selectedFileSize = 0;
             videoTitle = "";
             resetBatchImportState();
-            dispatch("imported");
+            onImported?.();
           } else {
             alert("导入失败: " + e.payload.message);
             resetBatchImportState();
@@ -518,7 +521,7 @@
     accept=".mp4,.mkv,.avi,.mov,.wmv,.flv,.m4v,.webm,video/*"
     multiple
     style="display: none"
-    on:change={handleFileInputChange}
+    onchange={handleFileInputChange}
   />
 {/if}
 
@@ -536,7 +539,7 @@
               导入外部视频
             </h3>
             <button
-              on:click={closeDialog}
+              onclick={closeDialog}
               class="text-gray-400 hover:text-gray-600"
             >
               <X class="w-5 h-5" />
@@ -548,9 +551,10 @@
             class="border-2 border-dashed rounded-lg p-8 text-center transition-colors {dragOver
               ? 'border-blue-400 bg-blue-50 dark:bg-blue-900/20'
               : 'border-gray-300 dark:border-gray-600'}"
-            on:dragover={handleDragOver}
-            on:dragleave={handleDragLeave}
-            on:drop={handleDrop}
+            role="presentation"
+            ondragover={handleDragOver}
+            ondragleave={handleDragLeave}
+            ondrop={handleDrop}
           >
             {#if uploading}
               <!-- 上传进度 -->
@@ -625,7 +629,7 @@
                   {selectedFilePath}
                 </p>
                 <button
-                  on:click={() => {
+                  onclick={() => {
                     selectedFilePath = null;
                     selectedFileName = "";
                     selectedFileSize = 0;
@@ -657,7 +661,7 @@
 
             {#if !uploading && !selectedFilePath && !batchImporting}
               <button
-                on:click={handleFileSelect}
+                onclick={handleFileSelect}
                 class="mt-4 px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
               >
                 {TAURI_ENV ? "选择文件" : "选择或拖拽文件"}
@@ -694,13 +698,13 @@
       >
         <div class="flex justify-end space-x-3">
           <button
-            on:click={closeDialog}
+            onclick={closeDialog}
             class="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
           >
             取消
           </button>
           <button
-            on:click={startImport}
+            onclick={startImport}
             disabled={!selectedFilePath ||
               importing ||
               !videoTitle.trim() ||

--- a/src/lib/components/KuaishouIcon.svelte
+++ b/src/lib/components/KuaishouIcon.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  let className = "";
-  export { className as class };
+  let { class: className = "" }: { class?: string } = $props();
 </script>
 
 <img src="/imgs/kuaishou.svg" class={className} alt="kuaishou" />

--- a/src/lib/components/MarkerPanel.svelte
+++ b/src/lib/components/MarkerPanel.svelte
@@ -6,16 +6,19 @@
     ClockOutline,
   } from "flowbite-svelte-icons";
   import type { Marker } from "../interface";
-  import { createEventDispatcher } from "svelte";
   import { Tooltip } from "flowbite-svelte";
   import { invoke, TAURI_ENV } from "../invoker";
   import { save } from "@tauri-apps/plugin-dialog";
   import type { RecordItem } from "../db";
-  const dispatch = createEventDispatcher();
-  export let archive: RecordItem;
-  export let markers: Marker[] = [];
+  interface Props {
+    archive: RecordItem;
+    markers?: Marker[];
+    onMarkerClick?: (marker: Marker) => void;
+  }
 
-  let realtime = false;
+  let { archive, markers = $bindable([]), onMarkerClick }: Props = $props();
+
+  let realtime = $state(false);
 
   function format_duration(duration: number) {
     const hours = Math.floor(duration / 3600);
@@ -30,7 +33,7 @@
   }
 
   function dispatch_markerclick(marker: Marker) {
-    dispatch("markerClick", marker);
+    onMarkerClick?.(marker);
   }
 
   async function export_to_file() {
@@ -69,17 +72,17 @@
       <span class="mr-1">标记列表</span>
       <button
         class="mr-1"
-        on:click={() => {
+        onclick={() => {
           realtime = !realtime;
         }}><ClockOutline /></button
       >
       <Tooltip>切换时间形式</Tooltip>
-      <button on:click={export_to_file}><ForwardOutline /></button>
+      <button onclick={export_to_file}><ForwardOutline /></button>
       <Tooltip>导出为文件</Tooltip>
     </div>
     <button
       class="mr-2"
-      on:click={() => {
+      onclick={() => {
         markers = [];
       }}><BanOutline /></button
     >
@@ -90,11 +93,19 @@
     {#each markers as marker, i}
       <div class="marker-entry">
         <div class="marker-control">
-          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
           <span
             class="offset"
-            on:click={() => {
+            role="button"
+            tabindex="0"
+            onclick={() => {
               dispatch_markerclick(marker);
+            }}
+            onkeydown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                dispatch_markerclick(marker);
+              }
             }}
             >{realtime
               ? format_realtime(marker.realtime)
@@ -102,7 +113,7 @@
           >
           <button
             class="hover:bg-red-900"
-            on:click={() => {
+            onclick={() => {
               // remove this entry
               markers = markers.filter((_, idx) => idx !== i);
             }}><CloseOutline /></button
@@ -111,7 +122,7 @@
         <input
           class="content w-full"
           bind:value={marker.content}
-          on:change={(v) => {
+          onchange={(v) => {
             if (marker.content == "") {
               marker.content = "[空标记点]";
             }

--- a/src/lib/components/Player.svelte
+++ b/src/lib/components/Player.svelte
@@ -1,4 +1,4 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
   declare const shaka: any;
 </script>
 
@@ -7,14 +7,12 @@
   import type { AccountInfo } from "../db";
   import type { Marker, RecorderList, RecorderInfo, Range } from "../interface";
 
-  import { createEventDispatcher } from "svelte";
   import {
     GridOutline,
     SortHorizontalOutline,
     FileExportOutline,
   } from "flowbite-svelte-icons";
   import { save } from "@tauri-apps/plugin-dialog";
-  const dispatch = createEventDispatcher();
   const DANMU_STATISTIC_GAP = 5;
 
   interface DanmuEntry {
@@ -22,31 +20,50 @@
     content: string;
   }
 
-  export let platform: string;
-  export let room_id: string;
-  export let live_id: string;
-  export let ranges: Range[] = [];
-  export let global_offset = 0;
-  export let focus_start = 0;
-  export let focus_end = 0;
-  export let markers: Marker[] = [];
-  export let danmu_records: DanmuEntry[] = [];
+  interface Props {
+    platform: string;
+    room_id: string;
+    live_id: string;
+    ranges?: Range[];
+    global_offset?: number;
+    focus_start?: number;
+    focus_end?: number;
+    markers?: Marker[];
+    danmu_records?: DanmuEntry[];
+    onMarkerAdd?: (marker: { offset: number; realtime: number }) => void;
+  }
+
+  let {
+    platform,
+    room_id,
+    live_id,
+    ranges = $bindable([]),
+    global_offset = $bindable(0),
+    focus_start = 0,
+    focus_end = 0,
+    markers = [],
+    danmu_records = $bindable([]),
+    onMarkerAdd
+  }: Props = $props();
   export function seek(offset: number) {
     video.currentTime = offset;
   }
   let video: HTMLVideoElement;
-  let show_detail = false;
+  let show_detail = $state(false);
   let show_list = false;
   let show_export = false;
-  let recorders: RecorderInfo[] = [];
+  let recorders: RecorderInfo[] = $state([]);
 
-  let start = 0;
-  let end = 0;
+  let start = $state(0);
+  let end = $state(0);
   let currentRangeIndex: number = -1; // 当前正在编辑的区间索引，-1 表示没有区间
 
   // local setting of danmu offset
-  let local_offset: number =
-    parseInt(localStorage.getItem(`local_offset:${live_id}`) || "0", 10) || 0;
+  let local_offset = $state(0);
+  $effect(() => {
+    local_offset =
+      parseInt(localStorage.getItem(`local_offset:${live_id}`) || "0", 10) || 0;
+  });
 
   // 获取当前区间
   function getCurrentRange(): Range | null {
@@ -199,7 +216,7 @@
   }
 
   // 向后兼容：保持 start 和 end 的 getter/setter
-  $: {
+  $effect(() => {
     const current = getCurrentRange();
     if (current) {
       start = current.start;
@@ -208,7 +225,7 @@
       start = 0;
       end = 0;
     }
-  }
+  });
 
   async function load_metadata(url: string) {
     let offset = 0;
@@ -1036,7 +1053,7 @@ ${mediaPlaylistUrl}`;
             break;
           }
           // dispatch event
-          dispatch("markerAdd", {
+          onMarkerAdd?.({
             offset: video.currentTime,
             realtime: global_offset + video.currentTime,
           });
@@ -1400,7 +1417,7 @@ ${mediaPlaylistUrl}`;
     data-shaka-player-container
     style="width: 100%; height: 100vh;"
   >
-    <!-- svelte-ignore a11y-media-has-caption -->
+    <!-- svelte-ignore a11y_media_has_caption -->
     <video
       autoplay
       data-shaka-player
@@ -1444,10 +1461,11 @@ ${mediaPlaylistUrl}`;
   </button>
   <ul class="shortcut-list">
     {#each recorders as recorder}
-      <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <li
+      <!-- svelte-ignore a11y_click_events_have_key_events -->
+      <button
+        type="button"
         class="shortcut"
-        on:click={() => {
+        onclick={() => {
           go_to(
             recorder.room_info.platform,
             recorder.room_info.room_id,
@@ -1457,7 +1475,7 @@ ${mediaPlaylistUrl}`;
       >
         <SortHorizontalOutline />[{recorder.user_info.user_name}]{recorder
           .room_info.room_title}
-      </li>
+      </button>
     {/each}
     {#if recorders.length == 0}
       <p>没有其它正在直播的房间</p>
@@ -1470,24 +1488,26 @@ ${mediaPlaylistUrl}`;
     <FileExportOutline />
   </button>
   <ul class="export-list">
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <li
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <button
+      type="button"
       class="export-item"
-      on:click={() => {
+      onclick={() => {
         exportDanmu(false);
       }}
     >
       导出弹幕为 TXT
-    </li>
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <li
+    </button>
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <button
+      type="button"
       class="export-item"
-      on:click={() => {
+      onclick={() => {
         exportDanmu(true);
       }}
     >
       导出弹幕为 ASS
-    </li>
+    </button>
   </ul>
 </div>
 

--- a/src/lib/components/SidebarItem.svelte
+++ b/src/lib/components/SidebarItem.svelte
@@ -1,28 +1,33 @@
-<script>
+<script lang="ts">
   import { Info, LayoutDashboard, Settings, Users, Video } from "lucide-svelte";
-  import { createEventDispatcher } from "svelte";
+  interface Props {
+    // acitveUrl is shared between project
+    activeUrl?: string;
+    label?: string;
+    dot?: boolean;
+    icon?: import('svelte').Snippet<[any]>;
+    onActiveChange?: (label: string) => void;
+  }
 
-  const dispatch = createEventDispatcher();
-
-  // acitveUrl is shared between project
-  export let activeUrl = "总览";
-  export let label = "";
-  export let dot = false;
+  let {
+    activeUrl = "总览",
+    label = "",
+    dot = false,
+    icon,
+    onActiveChange
+  }: Props = $props();
 </script>
 
 <button
-  on:click={() => dispatch("activeChange", label)}
+  onclick={() => onActiveChange?.(label)}
   class="flex w-full items-center space-x-2 px-3 py-2 rounded-lg {activeUrl ===
   label
     ? 'bg-blue-500/10 text-[#0A84FF] dark:bg-transparent dark:text-white'
     : 'text-gray-700 dark:text-white'} hover:bg-[#e5e5e5] dark:hover:bg-transparent"
 >
-  <slot
-    name="icon"
-    class={activeUrl === label
+  {@render icon?.({ class: activeUrl === label
       ? "text-[#0A84FF] dark:text-white"
-      : "text-gray-700 dark:text-white"}
-  ></slot>
+      : "text-gray-700 dark:text-white", })}
   <span>{label}</span>
   {#if dot}
     <div class="absolute right-6 w-2 h-2 bg-red-500 rounded-full"></div>

--- a/src/lib/components/SubtitleStyleEditor.svelte
+++ b/src/lib/components/SubtitleStyleEditor.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
+
   import { X } from "lucide-svelte";
   import { parseSubtitleStyle, type SubtitleStyle } from "../interface";
 
-  export let show = false;
-  export let onClose: () => void;
-  export let roomId: string;
+  interface Props {
+    show?: boolean;
+    onClose: () => void;
+    roomId: string;
+  }
+
+  let { show = $bindable(false), onClose, roomId }: Props = $props();
 
   // 默认样式
   const defaultStyle: SubtitleStyle = {
@@ -20,10 +25,10 @@
   };
 
   // 从 localStorage 加载样式，如果没有则使用默认值
-  let style: SubtitleStyle = (() => {
+  let style: SubtitleStyle = $state((() => {
     const savedStyle = localStorage.getItem(`subtitle_style_${roomId}`);
     return savedStyle ? JSON.parse(savedStyle) : defaultStyle;
-  })();
+  })());
 
   // 保存样式到 localStorage
   function saveStyle() {
@@ -31,10 +36,10 @@
   }
 
   // 生成 ffmpeg 样式参数
-  $: styleString = parseSubtitleStyle(style);
+  let styleString = $derived(parseSubtitleStyle(style));
 
   // 预览样式
-  $: previewStyle = (() => {
+  let previewStyle = $derived((() => {
     // 将颜色值转换为 rgba 格式
     const fontColor = style.fontColor.startsWith("#")
       ? `rgba(${parseInt(style.fontColor.slice(1, 3), 16)}, ${parseInt(style.fontColor.slice(3, 5), 16)}, ${parseInt(style.fontColor.slice(5, 7), 16)}, 1)`
@@ -59,7 +64,7 @@
       display: inline-block;
       white-space: nowrap;
     `;
-  })();
+  })());
 
   // 对齐方式选项
   const alignmentOptions = [
@@ -81,10 +86,14 @@
 </script>
 
 {#if show}
-  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
     class="fixed inset-0 bg-black/50 z-[1100] flex items-center justify-center"
-    on:click|self={handleClose}
+    role="presentation"
+    onclick={(event) => {
+      event.stopPropagation();
+      handleClose();
+    }}
   >
     <div
       class="bg-[#1c1c1e] rounded-lg w-[600px] max-h-[80vh] overflow-y-auto sidebar-scrollbar"
@@ -96,7 +105,7 @@
         <h2 class="text-lg font-medium text-white">字幕压制样式设置</h2>
         <button
           class="text-gray-400 hover:text-white transition-colors duration-200"
-          on:click={handleClose}
+          onclick={handleClose}
         >
           <X class="w-5 h-5" />
         </button>
@@ -109,7 +118,7 @@
           <h3 class="text-sm font-medium text-gray-300">字体设置</h3>
           <div class="grid grid-cols-2 gap-4">
             <div class="space-y-2">
-              <!-- svelte-ignore a11y-label-has-associated-control -->
+              <!-- svelte-ignore a11y_label_has_associated_control -->
               <label class="block text-sm text-gray-400">字体名称</label>
               <input
                 type="text"
@@ -120,7 +129,7 @@
               />
             </div>
             <div class="space-y-2">
-              <!-- svelte-ignore a11y-label-has-associated-control -->
+              <!-- svelte-ignore a11y_label_has_associated_control -->
               <label class="block text-sm text-gray-400">字体大小</label>
               <input
                 type="number"
@@ -138,7 +147,7 @@
           <h3 class="text-sm font-medium text-gray-300">颜色设置</h3>
           <div class="grid grid-cols-2 gap-4">
             <div class="space-y-2">
-              <!-- svelte-ignore a11y-label-has-associated-control -->
+              <!-- svelte-ignore a11y_label_has_associated_control -->
               <label class="block text-sm text-gray-400">字体颜色</label>
               <input
                 type="color"
@@ -149,7 +158,7 @@
               />
             </div>
             <div class="space-y-2">
-              <!-- svelte-ignore a11y-label-has-associated-control -->
+              <!-- svelte-ignore a11y_label_has_associated_control -->
               <label class="block text-sm text-gray-400">描边颜色</label>
               <input
                 type="color"
@@ -166,7 +175,7 @@
         <div class="space-y-4">
           <h3 class="text-sm font-medium text-gray-300">描边设置</h3>
           <div class="space-y-2">
-            <!-- svelte-ignore a11y-label-has-associated-control -->
+            <!-- svelte-ignore a11y_label_has_associated_control -->
             <label class="block text-sm text-gray-400">描边宽度</label>
             <input
               type="range"

--- a/src/lib/components/TikTokIcon.svelte
+++ b/src/lib/components/TikTokIcon.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  let className = "";
-  export { className as class };
+  let { class: className = "" }: { class?: string } = $props();
 </script>
 
 <img src="/imgs/tiktok.png" class={className} alt="TikTok" />

--- a/src/lib/components/ToolMessage.svelte
+++ b/src/lib/components/ToolMessage.svelte
@@ -13,14 +13,18 @@
   } from "../agent/messages";
   import CopyMarkdownButton from "./CopyMarkdownButton.svelte";
 
-  export let message: ToolMessage;
-  export let formatTime: (date: Date) => string;
+  interface Props {
+    message: ToolMessage;
+    formatTime: (date: Date) => string;
+  }
+
+  let { message, formatTime }: Props = $props();
 
   // 折叠状态 - 默认折叠
-  let isExpanded = false;
+  let isExpanded = $state(false);
 
-  $: messageTime = new Date(message.timestamp);
-  $: contentParts = messageContentToDisplayParts(message.content);
+  let messageTime = $derived(new Date(message.timestamp));
+  let contentParts = $derived(messageContentToDisplayParts(message.content));
 
   function markdownContent(): string {
     return messageContentToMarkdown(message.content);
@@ -55,8 +59,8 @@
     isExpanded = !isExpanded;
   }
 
-  $: statusInfo = getStatusInfo();
-  $: StatusIcon = statusInfo.icon;
+  let statusInfo = $derived(getStatusInfo());
+  let StatusIcon = $derived(statusInfo.icon);
 </script>
 
 <div class="flex justify-start">
@@ -85,8 +89,7 @@
           <!-- 工具信息头部 -->
           <div class="mb-3">
             <div class="flex items-center space-x-2 mb-2">
-              <svelte:component
-                this={StatusIcon}
+              <StatusIcon
                 class="w-4 h-4 {statusInfo.color}"
               />
               <span
@@ -104,7 +107,7 @@
           <div class="space-y-2">
             <!-- 折叠按钮 -->
             <button
-              on:click={toggleExpanded}
+              onclick={toggleExpanded}
               class="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
             >
               {#if isExpanded}

--- a/src/lib/components/TypeSelect.svelte
+++ b/src/lib/components/TypeSelect.svelte
@@ -3,12 +3,16 @@
   import { ChevronDownOutline } from "flowbite-svelte-icons";
   import { scale } from "svelte/transition";
   import type { Children, VideoType } from "../interface";
-  export let value = 0;
-  let parentSelected: VideoType;
-  let areaSelected: Children;
-  let parentOpen = false;
-  let areaOpen = false;
-  let items: VideoType[] = [];
+  interface Props {
+    value?: number;
+  }
+
+  let { value = $bindable(0) }: Props = $props();
+  let parentSelected: VideoType = $state();
+  let areaSelected: Children = $state();
+  let parentOpen = $state(false);
+  let areaOpen = $state(false);
+  let items: VideoType[] = $state([]);
 
   async function get_video_typelist() {
     items = (await invoke("get_video_typelist")) as VideoType[];
@@ -66,7 +70,7 @@
   get_video_typelist();
 </script>
 
-<svelte:window on:click={handleClickOutside} />
+<svelte:window onclick={handleClickOutside} />
 
 <div class="type-select-container flex w-full max-w-md">
   <!-- Parent Select -->
@@ -74,7 +78,7 @@
     <button
       class="w-full inline-flex justify-between items-center px-3 py-2 text-sm font-medium text-left bg-[#1c1c1e] text-white border border-gray-600 rounded-l-lg hover:bg-[#2c2c2e] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
       type="button"
-      on:click={handleParentClick}
+      onclick={handleParentClick}
     >
       <span class="truncate">{parentSelected ? parentSelected.name : ""}</span>
       <ChevronDownOutline
@@ -95,7 +99,7 @@
             item.id
               ? 'bg-blue-900/20 text-blue-400'
               : ''}"
-            on:click={() => selectParent(item)}
+            onclick={() => selectParent(item)}
           >
             {item.name}
           </button>
@@ -109,7 +113,7 @@
     <button
       class="w-full inline-flex justify-between items-center px-3 py-2 text-sm font-medium text-left bg-[#1c1c1e] text-white border border-l-0 border-gray-600 rounded-r-lg hover:bg-[#2c2c2e] focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors duration-200"
       type="button"
-      on:click={handleAreaClick}
+      onclick={handleAreaClick}
     >
       <span class="truncate">{areaSelected ? areaSelected.name : ""}</span>
       <ChevronDownOutline
@@ -130,7 +134,7 @@
             child.id
               ? 'bg-blue-900/20 text-blue-400'
               : ''}"
-            on:click={() => selectArea(child)}
+            onclick={() => selectArea(child)}
           >
             {child.name}
           </button>

--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -40,13 +40,23 @@
   import type { AccountInfo } from "../db";
   import WaveSurfer from "wavesurfer.js";
 
-  export let show = false;
-  export let video: VideoItem;
-  export let roomId: string;
-  export let videos: any[] = [];
-  export let onVideoChange: ((video: VideoItem) => void) | undefined =
-    undefined;
-  export let onVideoListUpdate: (() => Promise<void>) | undefined = undefined;
+  interface Props {
+    show?: boolean;
+    video: VideoItem;
+    roomId: string;
+    videos?: any[];
+    onVideoChange?: ((video: VideoItem) => void) | undefined;
+    onVideoListUpdate?: (() => Promise<void>) | undefined;
+  }
+
+  let {
+    show = $bindable(false),
+    video = $bindable(),
+    roomId,
+    videos = [],
+    onVideoChange = undefined,
+    onVideoListUpdate = undefined
+  }: Props = $props();
 
   interface Subtitle {
     startTime: number;
@@ -55,42 +65,38 @@
     layerOrder: number;
   }
 
-  let subtitles: Subtitle[] = [];
-  let currentTime = 0;
-  let videoElement: HTMLVideoElement;
-  let showDefaultCoverIcon = false;
-  let timelineWidth = 0;
+  let subtitles: Subtitle[] = $state([]);
+  let currentTime = $state(0);
+  let videoElement: HTMLVideoElement = $state();
+  let showDefaultCoverIcon = $state(false);
+  let timelineWidth = $state(0);
 
-  // 当视频改变时重置封面错误状态
-  $: if (video) {
-    showDefaultCoverIcon = false;
-  }
-  let timelineElement: HTMLElement;
-  let draggingSubtitle: { index: number; isStart: boolean } | null = null;
-  let draggingBlock: number | null = null;
-  let timelineScale = 1; // 时间轴缩放比例，1 表示正常大小
-  let isPlaying = false;
-  let timeMarkers: number[] = [];
+  let timelineElement: HTMLElement = $state();
+  let draggingSubtitle: { index: number; isStart: boolean } | null = $state(null);
+  let draggingBlock: number | null = $state(null);
+  let timelineScale = $state(1); // 时间轴缩放比例，1 表示正常大小
+  let isPlaying = $state(false);
+  let timeMarkers: number[] = $state([]);
   let dragOffset: number = 0; // 添加拖动偏移量
-  let isVideoLoaded = false;
-  let showStyleEditor = false;
-  let volume = 1;
+  let isVideoLoaded = $state(false);
+  let showStyleEditor = $state(false);
+  let volume = $state(1);
   let previousVolume = 1;
-  let isMuted = false;
-  let currentSubtitleIndex = -1;
-  let currentSubtitleIndices: number[] = [];
-  let currentSubtitles: Subtitle[] = [];
-  let subtitleElements: HTMLElement[] = [];
-  let subtitleLanes: number[] = [];
-  let subtitleLaneCount = 1;
-  let subtitleTrackHeight = 48;
-  let timelineTotalHeight = 196;
+  let isMuted = $state(false);
+  let currentSubtitleIndex = $state(-1);
+  let currentSubtitleIndices: number[] = $state([]);
+  let currentSubtitles: Subtitle[] = $state([]);
+  let subtitleElements: HTMLElement[] = $state([]);
+  let subtitleLanes: number[] = $state([]);
+  let subtitleLaneCount = $state(1);
+  let subtitleTrackHeight = $state(48);
+  let timelineTotalHeight = $state(196);
   let nextSubtitleLayerOrder = 0;
-  let timelineContainer: HTMLElement;
-  let showEncodeModal = false;
+  let timelineContainer: HTMLElement = $state();
+  let showEncodeModal = $state(false);
   let videoWidth = 0;
-  let videoHeight = 0;
-  let subtitleStyle: SubtitleStyle = {
+  let videoHeight = $state(0);
+  let subtitleStyle: SubtitleStyle = $state({
     fontName: "Arial",
     fontSize: 18,
     fontColor: "#FFFFFF",
@@ -100,64 +106,44 @@
     marginV: 20,
     marginL: 20,
     marginR: 20,
-  };
+  });
 
-  let current_encode_event_id = null;
-  let current_generate_event_id = null;
+  let current_encode_event_id = $state(null);
+  let current_generate_event_id = $state(null);
   let windowCloseUnlisten: (() => void) | null = null;
-  let activeTab = "subtitle"; // 添加当前激活的 tab
+  let activeTab = $state("subtitle"); // 添加当前激活的 tab
 
   // 切片功能相关变量
-  let clipStartTime = 0;
-  let clipEndTime = 0;
-  let clipTitle = "";
-  let clipping = false;
-  let current_clip_event_id = null;
-  let show_detail = false; // 控制快捷键说明的展开
-  let lastVideoId = -1; // 记录上一个视频ID，避免重复初始化
-  let clipTimesSet = false; // 标记用户是否主动设置过切片时间
+  let clipStartTime = $state(0);
+  let clipEndTime = $state(0);
+  let clipTitle = $state("");
+  let clipping = $state(false);
+  let current_clip_event_id = $state(null);
+  let show_detail = $state(false); // 控制快捷键说明的展开
+  let lastVideoId = $state(-1); // 记录上一个视频ID，避免重复初始化
+  let clipTimesSet = $state(false); // 标记用户是否主动设置过切片时间
 
   // 进度条拖动相关变量
-  let isDraggingSeekbar = false;
-  let seekbarElement: HTMLElement;
-  let previewTime = 0; // 拖动时预览的时间
+  let isDraggingSeekbar = $state(false);
+  let seekbarElement: HTMLElement = $state();
+  let previewTime = $state(0); // 拖动时预览的时间
   let wasPlayingBeforeDrag = false; // 拖动前的播放状态
 
   // 投稿相关变量
-  let current_post_event_id = null;
+  let current_post_event_id = $state(null);
   let config: Config = null;
-  let accounts: any[] = [];
-  let uid_selected = 0;
-  let show_cover_editor = false;
+  let accounts: any[] = $state([]);
+  let uid_selected = $state(0);
+  let show_cover_editor = $state(false);
 
   // WaveSurfer.js 相关变量
   let wavesurfer: any = null;
-  let waveformContainer: HTMLElement;
+  let waveformContainer: HTMLElement = $state();
   let isWaveformLoaded = false;
-  let isWaveformLoading = false;
+  let isWaveformLoading = $state(false);
   let syncTimeout: ReturnType<typeof setTimeout> | null = null;
 
-  $: {
-    const laneLayout = calculateSubtitleLanes(subtitles);
-    subtitleLanes = laneLayout.lanes;
-    subtitleLaneCount = laneLayout.count;
-    subtitleTrackHeight = Math.max(48, subtitleLaneCount * 36 + 8);
-    timelineTotalHeight = 148 + subtitleTrackHeight;
-  }
 
-  $: {
-    currentSubtitleIndices = subtitles
-      .map((subtitle, index) => ({ subtitle, index }))
-      .filter(
-        ({ subtitle }) =>
-          currentTime >= subtitle.startTime && currentTime < subtitle.endTime
-      )
-      .map(({ index }) => index);
-    currentSubtitleIndex = currentSubtitleIndices[0] ?? -1;
-    currentSubtitles = currentSubtitleIndices
-      .map((index) => subtitles[index])
-      .sort((a, b) => a.layerOrder - b.layerOrder);
-  }
 
   // 获取 profile 从 localStorage
   function get_profile(): Profile {
@@ -168,11 +154,8 @@
     return default_profile();
   }
 
-  let profile: Profile = get_profile();
+  let profile: Profile = $state(get_profile());
 
-  $: {
-    window.localStorage.setItem("profile-" + roomId, JSON.stringify(profile));
-  }
 
   // 初始化 WaveSurfer.js
   async function initWaveSurfer() {
@@ -426,13 +409,6 @@
     }
   }
 
-  // 监听当前字幕索引变化
-  $: if (currentSubtitleIndex >= 0 && subtitleElements[currentSubtitleIndex]) {
-    subtitleElements[currentSubtitleIndex].scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-    });
-  }
 
   function parseSrtTime(time: string): number {
     // hours:minutes:seconds,milliseconds
@@ -601,31 +577,8 @@
     }
   }
 
-  $: if (show) {
-    isVideoLoaded = false;
-    subtitles = []; // 清空字幕列表
-    currentSubtitleIndex = -1;
-    subtitleElements = [];
-    loadSubtitleStyle(); // 加载字幕样式
 
-    // 销毁旧的波形图实例
-    destroyWaveSurfer();
-  }
 
-  // 当视频改变时重新初始化切片时间（只在视频ID改变时触发）
-  $: if (video && videoElement?.duration && video.id !== lastVideoId) {
-    lastVideoId = video.id;
-    // 切换视频时重置切片时间 - 不设置默认值，等待用户输入
-    clipStartTime = 0;
-    clipEndTime = 0;
-    clipTitle = "";
-    clipTimesSet = false; // 重置标记，新视频默认透明
-  }
-
-  // 监听样式编辑器关闭，重新加载样式
-  $: if (!showStyleEditor) {
-    loadSubtitleStyle();
-  }
 
   async function handleVideoLoaded() {
     isVideoLoaded = true;
@@ -1378,6 +1331,73 @@
     a.download = video_name;
     a.click();
   }
+  // 当视频改变时重置封面错误状态
+  $effect(() => {
+    if (video) {
+      showDefaultCoverIcon = false;
+    }
+  });
+  $effect(() => {
+    if (show) {
+      isVideoLoaded = false;
+      subtitles = []; // 清空字幕列表
+      currentSubtitleIndex = -1;
+      subtitleElements = [];
+      loadSubtitleStyle(); // 加载字幕样式
+
+      // 销毁旧的波形图实例
+      destroyWaveSurfer();
+    }
+  });
+  $effect(() => {
+    const laneLayout = calculateSubtitleLanes(subtitles);
+    subtitleLanes = laneLayout.lanes;
+    subtitleLaneCount = laneLayout.count;
+    subtitleTrackHeight = Math.max(48, subtitleLaneCount * 36 + 8);
+    timelineTotalHeight = 148 + subtitleTrackHeight;
+  });
+  $effect(() => {
+    currentSubtitleIndices = subtitles
+      .map((subtitle, index) => ({ subtitle, index }))
+      .filter(
+        ({ subtitle }) =>
+          currentTime >= subtitle.startTime && currentTime < subtitle.endTime
+      )
+      .map(({ index }) => index);
+    currentSubtitleIndex = currentSubtitleIndices[0] ?? -1;
+    currentSubtitles = currentSubtitleIndices
+      .map((index) => subtitles[index])
+      .sort((a, b) => a.layerOrder - b.layerOrder);
+  });
+  $effect(() => {
+    window.localStorage.setItem("profile-" + roomId, JSON.stringify(profile));
+  });
+  // 监听当前字幕索引变化
+  $effect(() => {
+    if (currentSubtitleIndex >= 0 && subtitleElements[currentSubtitleIndex]) {
+      subtitleElements[currentSubtitleIndex].scrollIntoView({
+        behavior: "smooth",
+        block: "nearest",
+      });
+    }
+  });
+  // 当视频改变时重新初始化切片时间（只在视频ID改变时触发）
+  $effect(() => {
+    if (video && videoElement?.duration && video.id !== lastVideoId) {
+      lastVideoId = video.id;
+      // 切换视频时重置切片时间 - 不设置默认值，等待用户输入
+      clipStartTime = 0;
+      clipEndTime = 0;
+      clipTitle = "";
+      clipTimesSet = false; // 重置标记，新视频默认透明
+    }
+  });
+  // 监听样式编辑器关闭，重新加载样式
+  $effect(() => {
+    if (!showStyleEditor) {
+      loadSubtitleStyle();
+    }
+  });
 </script>
 
 {#if show}
@@ -1396,7 +1416,7 @@
           <select
             class="bg-[#1c1c1e] text-gray-300 text-sm rounded-md px-3 py-1.5 border border-gray-700 focus:border-[#0A84FF] outline-none appearance-none cursor-pointer hover:bg-[#2c2c2e] transition-colors duration-200"
             value={video.id}
-            on:change={handleVideoSelect}
+            onchange={handleVideoSelect}
           >
             {#each videos as v}
               <option value={v.id}>{v.name}</option>
@@ -1406,7 +1426,7 @@
           {#if !TAURI_ENV}
             <button
               class="text-blue-500 hover:text-blue-400 transition-colors duration-200 px-2 py-1.5 rounded-md hover:bg-blue-500/10"
-              on:click={saveVideo}
+              onclick={saveVideo}
             >
               <Download class="w-4 h-4" />
             </button>
@@ -1414,7 +1434,7 @@
           <!-- 删除按钮 -->
           <button
             class="text-red-500 hover:text-red-400 transition-colors duration-200 px-2 py-1.5 rounded-md hover:bg-red-500/10"
-            on:click={async () => {
+            onclick={async () => {
               if (!video) return;
               try {
                 await invoke("delete_video", { id: video.id });
@@ -1443,7 +1463,7 @@
         {#if canBeClipped(video)}
           <button
             class="px-4 py-1.5 text-sm bg-green-600 text-white rounded-md hover:bg-green-600/90 transition-colors duration-200 border border-gray-600/50 flex items-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-            on:click={generateClip}
+            onclick={generateClip}
             disabled={clipping || current_clip_event_id != null}
           >
             {#if clipping || current_clip_event_id != null}
@@ -1477,7 +1497,7 @@
         {/if}
         <button
           class="px-4 py-1.5 text-sm bg-[#0A84FF] text-white rounded-md hover:bg-[#0A84FF]/90 transition-colors duration-200 border border-gray-600/50 flex items-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-          on:click={() => (showEncodeModal = true)}
+          onclick={() => (showEncodeModal = true)}
           disabled={current_encode_event_id != null}
         >
           {#if current_encode_event_id != null}
@@ -1522,7 +1542,8 @@
             <h3 class="text-sm font-medium text-gray-200">确认压制</h3>
             <button
               class="text-gray-400 hover:text-white transition-colors duration-200"
-              on:click={() => (showEncodeModal = false)}
+              aria-label="关闭压制确认"
+              onclick={() => (showEncodeModal = false)}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -1551,13 +1572,13 @@
           >
             <button
               class="px-4 py-1.5 text-sm bg-gray-700/50 text-gray-200 rounded-md hover:bg-gray-700/70 transition-colors duration-200 border border-gray-600/50"
-              on:click={() => (showEncodeModal = false)}
+              onclick={() => (showEncodeModal = false)}
             >
               取消
             </button>
             <button
               class="px-4 py-1.5 text-sm bg-[#0A84FF] text-white rounded-md hover:bg-[#0A84FF]/90 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center space-x-1"
-              on:click={() => {
+              onclick={() => {
                 showEncodeModal = false;
                 encodeVideoSubtitle();
               }}
@@ -1599,16 +1620,16 @@
         <!-- 视频容器 -->
         <div class="flex-1 bg-black relative">
           <div class="absolute inset-0 flex items-center">
-            <!-- svelte-ignore a11y-media-has-caption -->
+            <!-- svelte-ignore a11y_media_has_caption -->
             <video
               bind:this={videoElement}
               src={video?.file}
               class="w-full h-auto max-h-full cursor-pointer"
-              on:timeupdate={handleTimeUpdate}
-              on:ended={handleVideoEnded}
-              on:loadedmetadata={handleVideoLoaded}
-              on:click={togglePlay}
-            />
+              ontimeupdate={handleTimeUpdate}
+              onended={handleVideoEnded}
+              onloadedmetadata={handleVideoLoaded}
+              onclick={togglePlay}
+></video>
 
             <!-- 切片快捷键说明 -->
             {#if canBeClipped(video)}
@@ -1727,7 +1748,7 @@
                 max="10"
                 step="0.1"
                 value={timelineScale}
-                on:input={handleScaleChange}
+                oninput={handleScaleChange}
                 class="w-32 h-1 bg-gray-600 rounded-lg appearance-none cursor-pointer"
               />
             </div>
@@ -1736,7 +1757,7 @@
             <div class="flex-1 flex justify-center">
               <button
                 class="p-1.5 rounded-lg bg-[#2c2c2e] hover:bg-[#3c3c3e] transition-colors duration-200"
-                on:click={togglePlay}
+                onclick={togglePlay}
               >
                 {#if isPlaying}
                   <Pause class="w-4 h-4 text-white" />
@@ -1750,7 +1771,7 @@
             <div class="flex items-center space-x-2">
               <button
                 class="text-white hover:text-gray-300 transition-colors duration-200"
-                on:click={toggleMute}
+                onclick={toggleMute}
               >
                 {#if isMuted || volume === 0}
                   <svg
@@ -1795,7 +1816,7 @@
                 max="1"
                 step="0.1"
                 bind:value={volume}
-                on:input={handleVolumeChange}
+                oninput={handleVolumeChange}
                 class="w-20 h-1 bg-gray-600 rounded-lg appearance-none cursor-pointer"
               />
             </div>
@@ -1838,27 +1859,40 @@
             <div
               class="flex-1 overflow-x-auto overflow-y-hidden sidebar-scrollbar"
               bind:this={timelineContainer}
-              on:wheel|preventDefault={handleWheel}
+              onwheel={(event) => {
+                event.preventDefault();
+                handleWheel(event);
+              }}
             >
-              <!-- svelte-ignore a11y-click-events-have-key-events -->
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
               <div
                 bind:this={timelineElement}
+                role="button"
+                tabindex="0"
+                aria-label="视频时间轴"
                 class="relative min-w-full group select-none flex flex-col"
                 style="width: {100 * timelineScale}%; height: {timelineTotalHeight}px"
-                on:mousemove={() => {
+                onmousemove={() => {
                   if (!timelineElement) return;
                   timelineWidth = timelineElement.getBoundingClientRect().width;
                   updateTimeMarkers();
                 }}
-                on:click|preventDefault|stopPropagation={(e) => {
+                onclick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
                   if (!isDraggingSeekbar) handleTimelineClick(e);
                 }}
               >
                 <div
                   bind:this={seekbarElement}
+                  role="slider"
+                  tabindex="0"
+                  aria-valuemin="0"
+                  aria-valuemax={videoElement?.duration || 0}
+                  aria-valuenow={isDraggingSeekbar ? previewTime : currentTime}
                   class="order-0 shrink-0 relative h-7 border-b border-gray-800/70 bg-[#202022] cursor-pointer"
                   class:dragging={isDraggingSeekbar}
-                  on:mousedown={handleSeekbarMouseDown}
+                  onmousedown={handleSeekbarMouseDown}
                 >
                   <div
                     class="absolute bottom-0 left-0 h-0.5 bg-[#0A84FF] pointer-events-none"
@@ -1965,14 +1999,16 @@
                   {#each subtitles as subtitle, index}
                     <div
                       bind:this={subtitleElements[index]}
+                      role="button"
+                      tabindex="0"
                       class="absolute h-8 rounded-md border border-[#0A84FF]/50 bg-[#0A84FF]/20 cursor-move overflow-hidden {currentSubtitleIndices.includes(
                         index
                       ) || draggingSubtitle?.index === index || draggingBlock === index
                         ? 'z-20 border-[#0A84FF]/90 bg-[#0A84FF]/30'
                         : 'z-10'}"
                       style={getSubtitleStyle(subtitle, index)}
-                      on:mousedown={(e) => handleBlockMouseDown(e, index)}
-                      on:click|stopPropagation
+                      onmousedown={(e) => handleBlockMouseDown(e, index)}
+                      onclick={(event) => event.stopPropagation()}
                     >
                       <div
                         class="h-full px-1.5 flex items-center text-[10px] text-blue-100"
@@ -2035,7 +2071,7 @@
             class:text-gray-400={activeTab !== "subtitle"}
             class:bg-[#2c2c2e]={activeTab === "subtitle"}
             class:bg-transparent={activeTab !== "subtitle"}
-            on:click={() => (activeTab = "subtitle")}
+            onclick={() => (activeTab = "subtitle")}
           >
             字幕
             {#if activeTab === "subtitle"}
@@ -2051,7 +2087,7 @@
             class:text-gray-400={activeTab !== "upload"}
             class:bg-[#2c2c2e]={activeTab === "upload"}
             class:bg-transparent={activeTab !== "upload"}
-            on:click={() => (activeTab = "upload")}
+            onclick={() => (activeTab = "upload")}
           >
             快速投稿
             {#if activeTab === "upload"}
@@ -2071,14 +2107,14 @@
                 <div class="flex space-x-2">
                   <button
                     class="flex-1 px-3 py-1.5 text-sm bg-[#1c1c1e] text-gray-300 rounded-lg hover:bg-[#2c2c2e] transition-colors duration-200 flex items-center justify-center space-x-1 border border-gray-700"
-                    on:click={() => (showStyleEditor = true)}
+                    onclick={() => (showStyleEditor = true)}
                   >
                     <Settings class="w-4 h-4" />
                     <span>字幕样式</span>
                   </button>
                   <button
                     class="flex-1 px-3 py-1.5 text-sm bg-[#1c1c1e] text-gray-300 rounded-lg hover:bg-[#2c2c2e] transition-colors duration-200 flex items-center justify-center space-x-1 border border-gray-700"
-                    on:click={clearSubtitles}
+                    onclick={clearSubtitles}
                   >
                     <Eraser class="w-4 h-4" />
                     <span>清空列表</span>
@@ -2087,7 +2123,7 @@
                 <div class="flex space-x-2">
                   <button
                     class="flex-1 px-3 py-1.5 text-sm bg-[#1c1c1e] text-gray-300 rounded-lg hover:bg-[#2c2c2e] transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-1 border border-gray-700"
-                    on:click={generateSubtitles}
+                    onclick={generateSubtitles}
                     disabled={current_generate_event_id !== null}
                   >
                     {#if current_generate_event_id !== null}
@@ -2134,7 +2170,7 @@
                   <button
                     class="w-6 shrink-0 text-right text-[11px] text-gray-500 hover:text-[#0A84FF] font-mono"
                     title="跳转到字幕开始"
-                    on:click={() => seekToTime(subtitle.startTime)}
+                    onclick={() => seekToTime(subtitle.startTime)}
                   >
                     {index + 1}
                   </button>
@@ -2151,14 +2187,14 @@
                   <button
                     class="p-1 shrink-0 text-gray-600 opacity-60 hover:opacity-100 hover:text-[#0A84FF] transition-all"
                     title="在后面添加字幕"
-                    on:click={() => insertSubtitleAfter(index)}
+                    onclick={() => insertSubtitleAfter(index)}
                   >
                     <Plus class="w-3.5 h-3.5" />
                   </button>
                   <button
                     class="p-1 shrink-0 text-gray-600 opacity-60 hover:opacity-100 hover:text-red-400 transition-all"
                     title="删除字幕"
-                    on:click={async () => await removeSubtitle(index)}
+                    onclick={async () => await removeSubtitle(index)}
                   >
                     <Trash2 class="w-3.5 h-3.5" />
                   </button>
@@ -2179,7 +2215,7 @@
                     <span>视频封面</span>
                     <button
                       class="text-[#0A84FF] hover:text-[#0A84FF]/80 transition-colors duration-200 flex items-center space-x-1"
-                      on:click={() => (show_cover_editor = true)}
+                      onclick={() => (show_cover_editor = true)}
                     >
                       <Pen class="w-4 h-4" />
                       <span class="text-xs">创建新封面</span>
@@ -2193,7 +2229,7 @@
                         src={video.cover}
                         alt="视频封面"
                         class="w-full"
-                        on:error={handleCoverError}
+                        onerror={handleCoverError}
                         style:display={showDefaultCoverIcon ? "none" : "block"}
                       />
                     {/if}
@@ -2281,7 +2317,7 @@
                   bind:value={profile.desc}
                   placeholder="输入视频描述"
                   class="w-full px-3 py-2 bg-[#1c1c1e] text-white rounded-lg border border-gray-800/50 focus:border-[#0A84FF] transition duration-200 outline-none resize-none h-24 hover:border-gray-700/50"
-                />
+></textarea>
               </div>
 
               <!-- 标签 -->
@@ -2309,7 +2345,7 @@
                   bind:value={profile.dynamic}
                   placeholder="输入动态内容"
                   class="w-full px-3 py-2 bg-[#1c1c1e] text-white rounded-lg border border-gray-800/50 focus:border-[#0A84FF] transition duration-200 outline-none resize-none h-24 hover:border-gray-700/50"
-                />
+></textarea>
               </div>
             </div>
 
@@ -2318,20 +2354,20 @@
               <div class="pt-4">
                 <div class="flex gap-2">
                   <button
-                    on:click={do_post}
+                    onclick={do_post}
                     disabled={current_post_event_id != null || !uid_selected}
                     class="flex-1 px-3 py-2 bg-[#0A84FF] text-white rounded-lg transition-all duration-200 hover:bg-[#0A84FF]/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2 text-sm"
                   >
                     {#if current_post_event_id != null}
                       <div
                         class="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin"
-                      />
+></div>
                     {/if}
                     <span id="post-prompt">投稿</span>
                   </button>
                   {#if current_post_event_id != null}
                     <button
-                      on:click={() => cancel_post()}
+                      onclick={() => cancel_post()}
                       class="px-3 py-2 bg-red-500 text-white rounded-lg transition-all duration-200 hover:bg-red-500/90 flex items-center justify-center text-sm"
                     >
                       取消
@@ -2356,16 +2392,16 @@
 <CoverEditor
   bind:show={show_cover_editor}
   {video}
-  on:coverUpdate={(event) => {
+  onCoverUpdate={(event) => {
     video = {
       ...video,
-      cover: event.detail.cover,
+      cover: event.cover,
     };
   }}
 />
 
 <!-- 键盘快捷键监听 -->
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 
 <style>
   /* 拖动时禁用过渡动画，避免与JS更新冲突 */

--- a/src/lib/components/XiaohongshuIcon.svelte
+++ b/src/lib/components/XiaohongshuIcon.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  let className = "";
-  export { className as class };
+  let { class: className = "" }: { class?: string } = $props();
 </script>
 
 <svg

--- a/src/lib/components/ai/InputArea.svelte
+++ b/src/lib/components/ai/InputArea.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
   import { Send, Trash2, Settings } from "lucide-svelte";
 
-  export let inputMessage: string;
-  export let isProcessing: boolean;
-  export let agent: any;
-  export let onSend: () => void;
-  export let onClear: () => void;
-  export let onSettings: () => void;
-  export let onKeyPress: (e: KeyboardEvent) => void;
+  interface Props {
+    inputMessage: string;
+    isProcessing: boolean;
+    agent: any;
+    onSend: () => void;
+    onClear: () => void;
+    onSettings: () => void;
+    onKeyPress: (e: KeyboardEvent) => void;
+  }
+
+  let {
+    inputMessage = $bindable(),
+    isProcessing,
+    agent,
+    onSend,
+    onClear,
+    onSettings,
+    onKeyPress
+  }: Props = $props();
 </script>
 
 <div class="border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-4">
@@ -17,7 +29,7 @@
       <div class="flex-1 relative">
         <textarea
           bind:value={inputMessage}
-          on:keypress={onKeyPress}
+          onkeypress={onKeyPress}
           placeholder={!agent ? "请先配置 AI 模型..." : "输入您的消息..."}
           class="w-full px-4 py-3 pr-16 border border-gray-300 dark:border-gray-700 rounded-xl bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-100 focus:border-transparent resize-none min-h-[52px] max-h-[200px] text-[15px] leading-relaxed disabled:opacity-50 disabled:cursor-not-allowed transition-shadow"
           rows="1"
@@ -34,7 +46,7 @@
       <button
         class="px-4 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-xl hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center space-x-2"
         disabled={!inputMessage.trim() || isProcessing || !agent}
-        on:click={onSend}
+        onclick={onSend}
       >
         <Send class="w-4 h-4" />
         <span class="text-sm font-medium">发送</span>
@@ -45,7 +57,7 @@
     <div class="flex items-center justify-between">
       <button
         class="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center space-x-1.5"
-        on:click={onClear}
+        onclick={onClear}
         disabled={!agent}
       >
         <Trash2 class="w-3.5 h-3.5" />
@@ -54,7 +66,7 @@
 
       <button
         class="p-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        on:click={onSettings}
+        onclick={onSettings}
         title="设置"
       >
         <Settings class="w-4 h-4" />

--- a/src/lib/components/ai/PresetPrompts.svelte
+++ b/src/lib/components/ai/PresetPrompts.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
-  export let presetPrompts: Array<{
-    title: string;
-    description: string;
-    prompt: string;
-    icon: string;
-  }>;
-  export let onSelectPrompt: (prompt: string) => void;
+  interface Props {
+    presetPrompts: Array<{
+      title: string;
+      description: string;
+      prompt: string;
+      icon: string;
+    }>;
+    onSelectPrompt: (prompt: string) => void;
+  }
+
+  let { presetPrompts, onSelectPrompt }: Props = $props();
 </script>
 
 <div class="py-12 space-y-8">
@@ -28,7 +32,7 @@
   <div class="max-w-4xl mx-auto grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
     {#each presetPrompts as prompt}
       <button
-        on:click={() => onSelectPrompt(prompt.prompt)}
+        onclick={() => onSelectPrompt(prompt.prompt)}
         class="group p-4 text-left bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-sm transition-all"
       >
         <div class="flex items-start space-x-3">

--- a/src/lib/components/ai/WelcomeScreen.svelte
+++ b/src/lib/components/ai/WelcomeScreen.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import { Settings, Sparkles, Zap } from "lucide-svelte";
 
-  export let onOpenSettings: () => void;
+  interface Props {
+    onOpenSettings: () => void;
+  }
+
+  let { onOpenSettings }: Props = $props();
 </script>
 
 <div class="flex items-center justify-center min-h-[500px] px-6">
@@ -23,7 +27,7 @@
 
     <!-- CTA Button -->
     <button
-      on:click={onOpenSettings}
+      onclick={onOpenSettings}
       class="inline-flex items-center justify-center space-x-2 px-6 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-xl hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors font-medium"
     >
       <Settings class="w-4 h-4" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import "./styles.css";
 import { mount } from "svelte";
 import App from "./App.svelte";
 
-const app = mount(App as any, {
+const app = mount(App, {
   target: document.getElementById("app")!,
 });
 

--- a/src/main_clip.ts
+++ b/src/main_clip.ts
@@ -2,7 +2,7 @@ import "./styles.css";
 import { mount } from "svelte";
 import App from "./AppClip.svelte";
 
-const app = mount(App as any, {
+const app = mount(App, {
   target: document.getElementById("app")!,
 });
 

--- a/src/main_live.ts
+++ b/src/main_live.ts
@@ -2,7 +2,7 @@ import "./styles.css";
 import { mount } from "svelte";
 import App from "./AppLive.svelte";
 
-const app = mount(App as any, {
+const app = mount(App, {
   target: document.getElementById("app")!,
 });
 

--- a/src/page/AI.svelte
+++ b/src/page/AI.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher, onDestroy, onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { Settings, Send, Sparkles, Trash2, Zap, Bot } from "lucide-svelte";
   import { agentChat } from "../lib/agent/agent";
   import type { LlmConfig } from "../lib/interface";
@@ -18,21 +18,25 @@
   import ProcessingMessageComponent from "../lib/components/ProcessingMessage.svelte";
   import ToolMessageComponent from "../lib/components/ToolMessage.svelte";
 
-  const dispatch = createEventDispatcher<{ navigateSettings: void }>();
+  interface Props {
+    onNavigateSettings?: () => void;
+  }
 
-  let messages: ChatMessage[] = [];
-  let inputMessage = "";
-  let isProcessing = false;
-  let messageContainer: HTMLElement;
-  let inputAreaHeight = 0;
-  let agentConfigured = false;
+  let { onNavigateSettings }: Props = $props();
 
-  let settings = {
+  let messages: ChatMessage[] = $state([]);
+  let inputMessage = $state("");
+  let isProcessing = $state(false);
+  let messageContainer: HTMLElement = $state();
+  let inputAreaHeight = $state(0);
+  let agentConfigured = $state(false);
+
+  let settings = $state({
     provider: "openai" as "openai" | "ollama",
     endpoint: "",
     api_key: "",
     model: ""
-  };
+  });
 
   type ToolCallState = 'confirmed' | 'rejected' | 'none';
 
@@ -47,7 +51,7 @@
   ];
 
   function openSettings() {
-    dispatch("navigateSettings");
+    onNavigateSettings?.();
   }
 
   function updateConfiguredState() {
@@ -90,7 +94,7 @@
     );
   }
 
-  $: hasPendingToolCalls = hasUnresolvedPendingToolCalls();
+  let hasPendingToolCalls = $derived(hasUnresolvedPendingToolCalls());
 
   function persistConversation() {
     try {
@@ -303,7 +307,7 @@
                 </p>
               </div>
               <button
-                on:click={openSettings}
+                onclick={openSettings}
                 class="inline-flex items-center space-x-2 px-6 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-xl hover:bg-gray-800 dark:hover:bg-gray-200 transition-colors font-medium shadow-lg"
               >
                 <Settings class="w-4 h-4" />
@@ -338,7 +342,7 @@
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
               {#each presetPrompts as prompt}
                 <button
-                  on:click={() => handlePresetPrompt(prompt.prompt)}
+                  onclick={() => handlePresetPrompt(prompt.prompt)}
                   class="group p-4 text-left bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-md transition-all"
                 >
                   <div class="flex items-start space-x-3">
@@ -390,7 +394,7 @@
           <div class="relative">
             <textarea
               bind:value={inputMessage}
-              on:keypress={handleKeyPress}
+              onkeypress={handleKeyPress}
               placeholder={!agentConfigured ? "请先配置 AI 模型..." : hasPendingToolCalls ? "请先确认或拒绝待执行的工具调用..." : "输入您的消息..."}
               class="w-full px-4 pt-3 pb-3 border-0 bg-transparent text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-0 resize-none min-h-[52px] max-h-[200px] text-[15px] leading-relaxed disabled:opacity-50 disabled:cursor-not-allowed"
               rows="1"
@@ -403,7 +407,7 @@
             <div class="flex items-center space-x-3">
               <!-- Model info -->
               <button
-                on:click={openSettings}
+                onclick={openSettings}
                 class="flex items-center space-x-1.5 px-2 py-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
                 title="点击配置模型"
               >
@@ -417,7 +421,7 @@
 
               <button
                 class="flex items-center space-x-1 px-2 py-1 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                on:click={clearConversation}
+                onclick={clearConversation}
                 disabled={!agentConfigured}
                 title="清空对话"
               >
@@ -433,7 +437,7 @@
               <button
                 class="px-3 py-1.5 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center space-x-1.5 text-sm font-medium"
                 disabled={!inputMessage.trim() || isProcessing || hasPendingToolCalls || !agentConfigured}
-                on:click={sendMessage}
+                onclick={sendMessage}
               >
                 <Send class="w-3.5 h-3.5" />
                 <span>发送</span>

--- a/src/page/About.svelte
+++ b/src/page/About.svelte
@@ -1,10 +1,10 @@
-<script type="ts">
+<script lang="ts">
   import { open } from "../lib/invoker";
   import { BookOpen, MessageCircle, Video, Heart } from "lucide-svelte";
   import { hasNewVersion, latestVersion } from "../lib/stores/version";
   let version = `v${__APP_VERSION__}`;
-  let showDonateModal = false;
-  let releases = [];
+  let showDonateModal = $state(false);
+  let releases = $state([]);
 
   // get releases from github api
   fetch("https://api.github.com/repos/Xinrea/bili-shadowreplay/releases")
@@ -77,7 +77,7 @@
     <div class="grid grid-cols-3 gap-4">
       <button
         class="p-4 rounded-xl bg-white dark:bg-[#3c3c3e] border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-        on:click={() => {
+        onclick={() => {
           // tauri open url
           open("https://bsr.xinrea.cn/");
         }}
@@ -95,7 +95,7 @@
       </button>
       <button
         class="p-4 rounded-xl bg-white dark:bg-[#3c3c3e] border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-        on:click={() => {
+        onclick={() => {
           // tauri open url
           open("https://qm.qq.com/q/v4lrE6gyum");
         }}
@@ -113,7 +113,7 @@
       </button>
       <button
         class="p-4 rounded-xl bg-white dark:bg-[#3c3c3e] border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
-        on:click={toggleDonateModal}
+        onclick={toggleDonateModal}
       >
         <div class="flex flex-col items-center space-y-2">
           <div
@@ -137,12 +137,14 @@
         class="bg-white dark:bg-[#3c3c3e] rounded-xl border border-gray-200 dark:border-gray-700"
       >
         {#each releases as release}
-          <!-- svelte-ignore a11y-click-events-have-key-events -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
           <div
             class="p-4 cursor-pointer {release !== releases[releases.length - 1]
               ? 'border-b border-gray-200 dark:border-gray-700'
               : ''}"
-            on:click={() => {
+            role="button"
+            tabindex="0"
+            onclick={() => {
               open(release.url);
             }}
           >
@@ -183,7 +185,7 @@
         </h3>
         <button
           class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-          on:click={toggleDonateModal}
+          onclick={toggleDonateModal}
         >
           ✕
         </button>
@@ -202,4 +204,4 @@
   </div>
 {/if}
 
-<svelte:window on:mousedown={handleModalClickOutside} />
+<svelte:window onmousedown={handleModalClickOutside} />

--- a/src/page/Account.svelte
+++ b/src/page/Account.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+
   import { get, invoke } from "../lib/invoker";
   import { scale, fade } from "svelte/transition";
   import { Textarea } from "flowbite-svelte";
@@ -6,9 +7,9 @@
   import type { AccountItem, AccountInfo } from "../lib/db";
   import { Ellipsis, Plus } from "lucide-svelte";
 
-  let account_info: AccountInfo = {
+  let account_info: AccountInfo = $state({
     accounts: [],
-  };
+  });
 
   let avatar_cache: Map<string, string> = new Map();
 
@@ -34,16 +35,16 @@
 
   update_accounts();
 
-  let addModal = false;
-  let activeTab = "qr"; // 'qr' or 'manual'
-  let selectedPlatform = "bilibili"; // 'bilibili' or 'douyin'
+  let addModal = $state(false);
+  let activeTab = $state("qr"); // 'qr' or 'manual'
+  let selectedPlatform = $state("bilibili"); // 'bilibili' or 'douyin'
   let oauth_key = "";
   let check_interval = null;
-  let cookie_str = "";
+  let cookie_str = $state("");
 
   let manualModal = false;
 
-  let activeDropdown = null;
+  let activeDropdown = $state(null);
 
   function toggleDropdown(uid) {
     if (activeDropdown === uid) {
@@ -149,8 +150,8 @@
 </script>
 
 <svelte:window
-  on:click={handleClickOutside}
-  on:mousedown={handleModalClickOutside}
+  onclick={handleClickOutside}
+  onmousedown={handleModalClickOutside}
 />
 
 <div
@@ -170,7 +171,7 @@
         </div>
       </div>
       <button
-        on:click={() => {
+        onclick={() => {
           addModal = true;
           if (activeTab === "qr") {
             requestAnimationFrame(handle_qr);
@@ -230,7 +231,10 @@
               <div class="relative dropdown-container">
                 <button
                   class="p-2 rounded-lg hover:bg-[#e5e5e5] dark:hover:bg-[#3a3a3c]"
-                  on:click|stopPropagation={() => toggleDropdown(account.uid)}
+                  onclick={(event) => {
+                    event.stopPropagation();
+                    toggleDropdown(account.uid);
+                  }}
                 >
                   <Ellipsis class="w-5 h-5 dark:icon-white" />
                 </button>
@@ -243,7 +247,7 @@
                   >
                     <button
                       class="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-[#e5e5e5] dark:hover:bg-[#3a3a3c] rounded-t-lg rounded-b-lg"
-                      on:click={async () => {
+                      onclick={async () => {
                         await invoke("remove_account", {
                           platform: account.platform,
                           uid: account.uid,
@@ -265,7 +269,7 @@
       <!-- Add Account Card -->
       <button
         class="w-full p-4 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-blue-500 dark:hover:border-blue-400 transition-colors"
-        on:click={() => {
+        onclick={() => {
           addModal = true;
           if (activeTab === "qr") {
             requestAnimationFrame(handle_qr);
@@ -325,7 +329,7 @@
               'bilibili'
                 ? 'bg-white dark:bg-[#3c3c3e] shadow-sm text-gray-900 dark:text-white'
                 : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-              on:click={() => {
+              onclick={() => {
                 selectedPlatform = "bilibili";
                 activeTab = "qr";
                 requestAnimationFrame(handle_qr);
@@ -338,7 +342,7 @@
               'douyin'
                 ? 'bg-white dark:bg-[#3c3c3e] shadow-sm text-gray-900 dark:text-white'
                 : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-              on:click={() => {
+              onclick={() => {
                 selectedPlatform = "douyin";
                 activeTab = "manual";
               }}
@@ -350,7 +354,7 @@
               'huya'
                 ? 'bg-white dark:bg-[#3c3c3e] shadow-sm text-gray-900 dark:text-white'
                 : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-              on:click={() => {
+              onclick={() => {
                 selectedPlatform = "huya";
                 activeTab = "manual";
               }}
@@ -362,7 +366,7 @@
               'kuaishou'
                 ? 'bg-white dark:bg-[#3c3c3e] shadow-sm text-gray-900 dark:text-white'
                 : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-              on:click={() => {
+              onclick={() => {
                 selectedPlatform = "kuaishou";
                 activeTab = "manual";
               }}
@@ -374,7 +378,7 @@
               'tiktok'
                 ? 'bg-white dark:bg-[#3c3c3e] shadow-sm text-gray-900 dark:text-white'
                 : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-              on:click={() => {
+              onclick={() => {
                 selectedPlatform = "tiktok";
                 activeTab = "manual";
               }}
@@ -392,7 +396,7 @@
               'qr'
                 ? 'bg-white dark:bg-[#3c3c3e] shadow-sm font-medium'
                 : 'text-gray-600 dark:text-gray-400'}"
-              on:click={() => {
+              onclick={() => {
                 activeTab = "qr";
                 requestAnimationFrame(handle_qr);
               }}
@@ -404,7 +408,7 @@
               'manual'
                 ? 'bg-white dark:bg-[#3c3c3e] shadow-sm font-medium'
                 : 'text-gray-600 dark:text-gray-400'}"
-              on:click={() => {
+              onclick={() => {
                 activeTab = "manual";
               }}
             >
@@ -418,7 +422,7 @@
           {#if selectedPlatform === "bilibili" && activeTab === "qr"}
             <div class="flex flex-col items-center space-y-4">
               <div class="bg-white p-4 rounded-lg">
-                <canvas id="qr" />
+                <canvas id="qr"></canvas>
               </div>
               <p class="text-sm text-center text-gray-600 dark:text-gray-400">
                 请使用 BiliBili App 扫描二维码登录
@@ -447,7 +451,7 @@
                 {/if}
                 <button
                   class="px-4 py-2 bg-[#0A84FF] hover:bg-[#0A84FF]/90 text-white text-sm font-medium rounded-lg transition-colors"
-                  on:click={() => {
+                  onclick={() => {
                     add_cookie();
                   }}
                 >

--- a/src/page/Archive.svelte
+++ b/src/page/Archive.svelte
@@ -29,36 +29,36 @@
   import type { RecorderInfo, RecorderList } from "src/lib/interface";
 
   let archives: RecordItem[] = [];
-  let filteredArchives: RecordItem[] = [];
-  let loading = false;
-  let sortBy = "created_at";
-  let sortOrder = "desc";
+  let filteredArchives: RecordItem[] = $state([]);
+  let loading = $state(false);
+  let sortBy = $state("created_at");
+  let sortOrder = $state("desc");
   type RoomOption = {
     id: string;
     label: string;
   };
 
-  let selectedRoomId: string | null = null;
-  let roomOptions: RoomOption[] = [];
+  let selectedRoomId: string | null = $state(null);
+  let roomOptions: RoomOption[] = $state([]);
 
-  let selectedArchives: Set<string> = new Set();
-  let showDeleteConfirm = false;
-  let archiveToDelete: RecordItem | null = null;
+  let selectedArchives: Set<string> = $state(new Set());
+  let showDeleteConfirm = $state(false);
+  let archiveToDelete: RecordItem | null = $state(null);
 
   // 生成完整录播相关状态
-  let showWholeClipModal = false;
-  let wholeClipArchive: RecordItem | null = null;
-  let showSummaryModal = false;
-  let summaryArchive: RecordItem | null = null;
+  let showWholeClipModal = $state(false);
+  let wholeClipArchive: RecordItem | null = $state(null);
+  let showSummaryModal = $state(false);
+  let summaryArchive: RecordItem | null = $state(null);
   let summaryStatuses: Record<string, RecordSummaryStatus> = {};
 
   // 分页相关状态
-  let currentPage = 1;
-  let pageSize = 20;
-  let totalPages = 1;
-  let totalCount = 0;
+  let currentPage = $state(1);
+  let pageSize = $state(20);
+  let totalPages = $state(1);
+  let totalCount = $state(0);
   let isLoading = false;
-  let loadError = "";
+  let loadError = $state("");
 
   // 页面大小选项
   const pageSizeOptions = [10, 20, 50, 100];
@@ -534,7 +534,7 @@
       <div class="flex items-center space-x-3">
         <button
           class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-          on:click={loadArchives}
+          onclick={loadArchives}
           disabled={loading}
         >
           <RefreshCw
@@ -554,7 +554,7 @@
         <div class="flex space-x-3">
           <select
             bind:value={selectedRoomId}
-            on:change={applyFilters}
+            onchange={applyFilters}
             class="px-3 py-2 bg-gray-100 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 cursor-pointer"
           >
             <option value={null}>所有直播间</option>
@@ -590,7 +590,7 @@
                 >
                 <select
                   bind:value={pageSize}
-                  on:change={() => changePageSize(pageSize)}
+                  onchange={() => changePageSize(pageSize)}
                   class="px-2 py-1 text-sm bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-500 rounded-md text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 cursor-pointer min-w-[50px]"
                 >
                   {#each pageSizeOptions as size}
@@ -608,7 +608,7 @@
                 <div class="flex items-center space-x-2">
                   <button
                     class="p-1.5 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-white dark:hover:bg-gray-700 rounded-md transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
-                    on:click={prevPage}
+                    onclick={prevPage}
                     disabled={currentPage === 1}
                     title="上一页"
                   >
@@ -633,7 +633,7 @@
 
                   <button
                     class="p-1.5 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-white dark:hover:bg-gray-700 rounded-md transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
-                    on:click={nextPage}
+                    onclick={nextPage}
                     disabled={currentPage === totalPages}
                     title="下一页"
                   >
@@ -653,7 +653,7 @@
             'room_id'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("room_id")}
+            onclick={() => toggleSort("room_id")}
           >
             直播间号
             {#if sortBy === "room_id"}
@@ -669,7 +669,7 @@
             'title'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("title")}
+            onclick={() => toggleSort("title")}
           >
             标题
             {#if sortBy === "title"}
@@ -685,7 +685,7 @@
             'length'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("length")}
+            onclick={() => toggleSort("length")}
           >
             时长
             {#if sortBy === "length"}
@@ -701,7 +701,7 @@
             'size'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("size")}
+            onclick={() => toggleSort("size")}
           >
             大小
             {#if sortBy === "size"}
@@ -717,7 +717,7 @@
             'created_at'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("created_at")}
+            onclick={() => toggleSort("created_at")}
           >
             创建时间
             {#if sortBy === "created_at"}
@@ -746,7 +746,7 @@
           </div>
           <button
             class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors flex items-center space-x-2"
-            on:click={() => {
+            onclick={() => {
               showDeleteConfirm = true;
               archiveToDelete = null;
             }}
@@ -770,7 +770,7 @@
           <p class="text-sm">{loadError}</p>
           <button
             class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
-            on:click={loadArchives}
+            onclick={loadArchives}
           >
             重试
           </button>
@@ -806,7 +806,7 @@
                     type="checkbox"
                     checked={selectedArchives.size ===
                       filteredArchives.length && filteredArchives.length > 0}
-                    on:change={selectAllArchives}
+                    onchange={selectAllArchives}
                     class="rounded border-gray-300 dark:border-gray-600"
                   />
                 </th>
@@ -849,7 +849,7 @@
                     <input
                       type="checkbox"
                       checked={selectedArchives.has(archive.live_id)}
-                      on:change={() => toggleArchiveSelection(archive.live_id)}
+                      onchange={() => toggleArchiveSelection(archive.live_id)}
                       class="rounded border-gray-300 dark:border-gray-600"
                     />
                   </td>
@@ -943,21 +943,21 @@
                       <button
                         class="p-1.5 rounded-lg hover:bg-blue-500/10 transition-colors"
                         title="预览录播"
-                        on:click={() => playArchive(archive)}
+                        onclick={() => playArchive(archive)}
                       >
                         <Play class="w-4 h-4 text-blue-500" />
                       </button>
                       <button
                         class="p-1.5 rounded-lg hover:bg-blue-500/10 transition-colors"
                         title="生成完整切片"
-                        on:click={() => openWholeClipModal(archive)}
+                        onclick={() => openWholeClipModal(archive)}
                       >
                         <FileVideo class="w-4 h-4 text-blue-500" />
                       </button>
                       <button
                         class="p-1.5 rounded-lg transition-colors {summaryButtonClass(archive)}"
                         title={summaryButtonTitle(archive)}
-                        on:click={() => openSummaryModal(archive)}
+                        onclick={() => openSummaryModal(archive)}
                       >
                         {#if getSummaryStatus(archive) === "processing"}
                           <Loader2 class="w-4 h-4 animate-spin {summaryIconClass(archive)}" />
@@ -968,7 +968,7 @@
                       <button
                         class="p-1.5 rounded-lg hover:bg-red-500/10 transition-colors"
                         title="删除记录"
-                        on:click={() => {
+                        onclick={() => {
                           archiveToDelete = archive;
                           showDeleteConfirm = true;
                         }}
@@ -1012,7 +1012,7 @@
         <div class="flex justify-center space-x-3">
           <button
             class="w-24 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
-            on:click={() => {
+            onclick={() => {
               showDeleteConfirm = false;
               archiveToDelete = null;
             }}
@@ -1021,7 +1021,7 @@
           </button>
           <button
             class="w-24 px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
-            on:click={() => {
+            onclick={() => {
               if (archiveToDelete) {
                 deleteArchive(archiveToDelete);
               } else {
@@ -1042,14 +1042,13 @@
   bind:showModal={showWholeClipModal}
   archive={wholeClipArchive}
   roomId={wholeClipArchive?.room_id || ""}
-  platform={wholeClipArchive?.platform || ""}
-  on:generated={handleWholeClipGenerated}
+  onGenerated={handleWholeClipGenerated}
 />
 
 <ArchiveSummaryModal
   bind:showModal={showSummaryModal}
   archive={summaryArchive}
-  on:updated={(event) => updateSummaryStatus(event.detail)}
+  onUpdated={updateSummaryStatus}
 />
 
 <style>

--- a/src/page/Clip.svelte
+++ b/src/page/Clip.svelte
@@ -30,22 +30,22 @@
   import TikTokIcon from "../lib/components/TikTokIcon.svelte";
 
   let videos: VideoItem[] = [];
-  let filteredVideos: VideoItem[] = [];
-  let loading = false;
-  let sortBy = "created_at";
-  let sortOrder = "desc";
-  let selectedRoomId = null;
-  let roomIds: string[] = [];
+  let filteredVideos: VideoItem[] = $state([]);
+  let loading = $state(false);
+  let sortBy = $state("created_at");
+  let sortOrder = $state("desc");
+  let selectedRoomId = $state(null);
+  let roomIds: string[] = $state([]);
 
-  let selectedVideos: Set<number> = new Set();
-  let showDeleteConfirm = false;
-  let videoToDelete: VideoItem | null = null;
-  let showImportDialog = false;
+  let selectedVideos: Set<number> = $state(new Set());
+  let showDeleteConfirm = $state(false);
+  let videoToDelete: VideoItem | null = $state(null);
+  let showImportDialog = $state(false);
 
   // 编辑备注相关状态
-  let showEditNoteDialog = false;
-  let videoToEditNote: VideoItem | null = null;
-  let editingNote = "";
+  let showEditNoteDialog = $state(false);
+  let videoToEditNote: VideoItem | null = $state(null);
+  let editingNote = $state("");
 
   onMount(async () => {
     await loadVideos();
@@ -55,15 +55,17 @@
     stopProgressPolling();
   });
 
-  let importProgressInfo = null;
+  let importProgressInfo = $state(null);
   let progressPollingTimer = null;
 
   /**
    * 响应式语句：当检测到转换任务时，确保 loading 状态为 true
    */
-  $: if (importProgressInfo) {
-    loading = true;
-  }
+  $effect(() => {
+    if (importProgressInfo) {
+      loading = true;
+    }
+  });
 
   /**
    * 启动进度轮询定时器
@@ -466,8 +468,8 @@
   }
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events -->
-<svelte:window on:keydown={handleKeydown} />
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<svelte:window onkeydown={handleKeydown} />
 
 <div class="flex-1 p-6 overflow-auto custom-scrollbar-light bg-gray-50 dark:bg-black">
   <div class="space-y-6">
@@ -485,14 +487,14 @@
       <div class="flex items-center space-x-3">
         <button
           class="px-4 py-2 bg-green-500 text-white rounded-lg hover:bg-green-600 transition-colors flex items-center space-x-2"
-          on:click={() => (showImportDialog = true)}
+          onclick={() => (showImportDialog = true)}
         >
           <Upload class="w-4 h-4 text-white" />
           <span>导入视频</span>
         </button>
         <button
           class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
-          on:click={loadVideos}
+          onclick={loadVideos}
           disabled={loading}
         >
           <RefreshCw
@@ -511,7 +513,7 @@
         <div class="flex space-x-3">
           <select
             bind:value={selectedRoomId}
-            on:change={applyFilters}
+            onchange={applyFilters}
             class="px-3 py-2 bg-gray-100 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-blue-400 cursor-pointer"
           >
             <option value={null}>所有直播间</option>
@@ -528,7 +530,7 @@
             'room_id'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("room_id")}
+            onclick={() => toggleSort("room_id")}
           >
             直播间号
             {#if sortBy === "room_id"}
@@ -544,7 +546,7 @@
             'title'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("title")}
+            onclick={() => toggleSort("title")}
           >
             文件名
             {#if sortBy === "title"}
@@ -560,7 +562,7 @@
             'note'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("note")}
+            onclick={() => toggleSort("note")}
           >
             备注
             {#if sortBy === "note"}
@@ -576,7 +578,7 @@
             'length'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("length")}
+            onclick={() => toggleSort("length")}
           >
             时长
             {#if sortBy === "length"}
@@ -592,7 +594,7 @@
             'size'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("size")}
+            onclick={() => toggleSort("size")}
           >
             大小
             {#if sortBy === "size"}
@@ -608,7 +610,7 @@
             'created_at'
               ? 'bg-blue-500 text-white'
               : 'bg-gray-100 dark:bg-gray-700/50 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'}"
-            on:click={() => toggleSort("created_at")}
+            onclick={() => toggleSort("created_at")}
           >
             创建时间
             {#if sortBy === "created_at"}
@@ -633,7 +635,7 @@
         </span>
         <button
           class="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg transition-colors flex items-center space-x-2"
-          on:click={() => {
+          onclick={() => {
             showDeleteConfirm = true;
             videoToDelete = null;
           }}
@@ -706,7 +708,7 @@
                     type="checkbox"
                     checked={selectedVideos.size === filteredVideos.length &&
                       filteredVideos.length > 0}
-                    on:change={selectAllVideos}
+                    onchange={selectAllVideos}
                     class="rounded border-gray-300 dark:border-gray-600"
                   />
                 </th>
@@ -753,7 +755,7 @@
                     <input
                       type="checkbox"
                       checked={selectedVideos.has(video.id)}
-                      on:change={() => toggleVideoSelection(video.id)}
+                      onchange={() => toggleVideoSelection(video.id)}
                       class="rounded border-gray-300 dark:border-gray-600"
                     />
                   </td>
@@ -886,7 +888,7 @@
                             src={video.cover}
                             alt="封面"
                             class="w-full h-full object-cover"
-                            on:error={handleImageError}
+                            onerror={handleImageError}
                           />
                         {:else}
                           <!-- 默认视频图标 -->
@@ -984,14 +986,14 @@
                       <button
                         class="p-1.5 rounded-lg hover:bg-blue-500/10 transition-colors"
                         title="播放"
-                        on:click={() => playVideo(video)}
+                        onclick={() => playVideo(video)}
                       >
                         <Play class="w-4 h-4 text-blue-500" />
                       </button>
                       <button
                         class="p-1.5 rounded-lg hover:bg-green-500/10 transition-colors"
                         title="编辑备注"
-                        on:click={() => openEditNoteDialog(video)}
+                        onclick={() => openEditNoteDialog(video)}
                       >
                         <Edit class="w-4 h-4 text-green-500" />
                       </button>
@@ -999,7 +1001,7 @@
                         <button
                           class="p-1.5 rounded-lg hover:bg-blue-500/10 transition-colors"
                           title="导出"
-                          on:click={async () => await exportVideo(video)}
+                          onclick={async () => await exportVideo(video)}
                         >
                           <Download class="w-4 h-4 text-blue-500" />
                         </button>
@@ -1007,7 +1009,7 @@
                       <button
                         class="p-1.5 rounded-lg hover:bg-red-500/10 transition-colors"
                         title="删除"
-                        on:click={() => {
+                        onclick={() => {
                           videoToDelete = video;
                           showDeleteConfirm = true;
                         }}
@@ -1051,7 +1053,7 @@
         <div class="flex justify-center space-x-3">
           <button
             class="w-24 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
-            on:click={() => {
+            onclick={() => {
               showDeleteConfirm = false;
               videoToDelete = null;
             }}
@@ -1060,7 +1062,7 @@
           </button>
           <button
             class="w-24 px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
-            on:click={() => {
+            onclick={() => {
               if (videoToDelete) {
                 deleteVideo(videoToDelete);
               } else {
@@ -1078,18 +1080,19 @@
 
 <!-- Edit Note Dialog -->
 {#if showEditNoteDialog && videoToEditNote}
-  <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     class="fixed inset-0 bg-black/30 dark:bg-black/50 z-50 flex items-center justify-center p-4"
-    on:click={closeEditNoteDialog}
+    onclick={closeEditNoteDialog}
   >
-    <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <!-- svelte-ignore a11y-no-static-element-interactions -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="mac-modal w-[480px] max-w-full bg-white dark:bg-[#2d2d30] rounded-xl shadow-xl border border-gray-200 dark:border-gray-600 overflow-hidden"
-      on:click|stopPropagation
+      onclick={(event) => event.stopPropagation()}
       role="dialog"
+      tabindex="-1"
       aria-labelledby="edit-note-title"
       aria-describedby="edit-note-description"
     >
@@ -1141,7 +1144,7 @@
                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500
                      transition-colors duration-150 resize-none"
               rows="5"
-              on:keydown={(e) => {
+              onkeydown={(e) => {
                 if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                   saveNote();
                 }
@@ -1162,13 +1165,13 @@
         <div class="flex justify-end space-x-3">
           <button
             class="w-24 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
-            on:click={closeEditNoteDialog}
+            onclick={closeEditNoteDialog}
           >
             取消
           </button>
           <button
             class="w-24 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-lg transition-colors"
-            on:click={saveNote}
+            onclick={saveNote}
           >
             保存
           </button>
@@ -1182,7 +1185,7 @@
 <ImportVideoDialog
   bind:showDialog={showImportDialog}
   roomId={selectedRoomId}
-  on:imported={handleVideoImported}
+  onImported={handleVideoImported}
 />
 
 <style>

--- a/src/page/Room.svelte
+++ b/src/page/Room.svelte
@@ -26,24 +26,28 @@
   import GenerateWholeClipModal from "../lib/components/GenerateWholeClipModal.svelte";
   import { onMount } from "svelte";
 
-  export let room_count = 0;
-  let room_active = 0;
-  let room_inactive = 0;
+  interface Props {
+    room_count?: number;
+  }
 
-  let summary: RecorderList = {
+  let { room_count = $bindable(0) }: Props = $props();
+  let room_active = $state(0);
+  let room_inactive = $state(0);
+
+  let summary: RecorderList = $state({
     count: 0,
     recorders: [],
-  };
+  });
 
-  let searchQuery = "";
-  $: filteredRecorders = summary.recorders.filter((room) => {
+  let searchQuery = $state("");
+  let filteredRecorders = $derived(summary.recorders.filter((room) => {
     const query = searchQuery.toLowerCase();
     return (
       room.room_info.room_title.toLowerCase().includes(query) ||
       room.user_info.user_name.toLowerCase().includes(query) ||
       room.room_info.room_id.toString().includes(query)
     );
-  });
+  }));
 
   function default_avatar(platform: string) {
     const avatarMap = {
@@ -138,23 +142,23 @@
   setInterval(update_summary, 5000);
 
   // modals
-  let deleteModal = false;
-  let deleteRoom = null;
+  let deleteModal = $state(false);
+  let deleteRoom = $state(null);
 
-  let addModal = false;
-  let addRoom = "";
-  let selectedPlatform = "bilibili";
+  let addModal = $state(false);
+  let addRoom = $state("");
+  let selectedPlatform = $state("bilibili");
 
-  let archiveModal = false;
-  let archiveRoom: RecorderInfo = null;
-  let archives: RecordItem[] = [];
+  let archiveModal = $state(false);
+  let archiveRoom: RecorderInfo = $state(null);
+  let archives: RecordItem[] = $state([]);
 
   // 分页相关状态
-  let currentPage = 0;
+  let currentPage = $state(0);
   let pageSize = 20;
-  let hasMore = true;
-  let isLoading = false;
-  let loadError = "";
+  let hasMore = $state(true);
+  let isLoading = $state(false);
+  let loadError = $state("");
 
   async function showArchives(room_id: string) {
     // 重置分页状态
@@ -439,8 +443,8 @@
       });
   }
 
-  let generateWholeClipModal = false;
-  let generateWholeClipArchive: RecordItem = null;
+  let generateWholeClipModal = $state(false);
+  let generateWholeClipArchive: RecordItem = $state(null);
 
   async function openGenerateWholeClipModal(archive: RecordItem) {
     generateWholeClipModal = true;
@@ -525,7 +529,7 @@
         </div>
         <button
           class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center space-x-2"
-          on:click={() => {
+          onclick={() => {
             addModal = true;
           }}
         >
@@ -590,7 +594,7 @@
             <Dropdown class="whitespace-nowrap">
               <button
                 class="px-4 py-2 flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer"
-                on:click={() => toggleEnabled(room)}
+                onclick={() => toggleEnabled(room)}
               >
                 <span
                   class="text-sm text-gray-700 dark:text-gray-200 font-medium"
@@ -602,13 +606,13 @@
                 </label>
               </button>
               <DropdownItem
-                on:click={() => {
+                onclick={() => {
                   openLiveUrl(room);
                 }}>打开网页直播间</DropdownItem
               >
               <DropdownItem
                 class="text-red-500"
-                on:click={() => {
+                onclick={() => {
                   deleteRoom = room;
                   deleteModal = true;
                 }}>移除直播间</DropdownItem
@@ -644,7 +648,7 @@
               >
                 <button
                   class="flex items-center space-x-2 p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-                  on:click={() => {
+                  onclick={() => {
                     openUserUrl(room);
                   }}
                 >
@@ -660,7 +664,7 @@
                 {#if room.recording}
                   <button
                     class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-                    on:click={() => {
+                    onclick={() => {
                       invoke("open_live", {
                         platform: room.room_info.platform,
                         roomId: room.room_info.room_id,
@@ -673,7 +677,7 @@
                 {/if}
                 <button
                   class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-                  on:click={() => {
+                  onclick={() => {
                     archiveRoom = room;
                     showArchives(room.room_info.room_id);
                   }}
@@ -689,7 +693,7 @@
       <!-- Add Room Card -->
       <button
         class="p-4 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-blue-500 dark:hover:border-blue-400 transition-colors flex flex-col items-center justify-center space-y-2"
-        on:click={() => {
+        onclick={() => {
           addModal = true;
         }}
       >
@@ -729,7 +733,7 @@
         <div class="flex justify-center space-x-3">
           <button
             class="w-24 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
-            on:click={() => {
+            onclick={() => {
               deleteModal = false;
             }}
           >
@@ -737,7 +741,7 @@
           </button>
           <button
             class="w-24 px-4 py-2 bg-red-600 hover:bg-red-700 text-white text-sm font-medium rounded-lg transition-colors"
-            on:click={async () => {
+            onclick={async () => {
               await invoke("remove_recorder", {
                 roomId: deleteRoom.room_info.room_id,
                 platform: deleteRoom.room_info.platform,
@@ -786,7 +790,7 @@
                 'bilibili'
                   ? 'bg-white dark:bg-[#323234] shadow-sm text-gray-900 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-                on:click={() => (selectedPlatform = "bilibili")}
+                onclick={() => (selectedPlatform = "bilibili")}
               >
                 哔哩哔哩
               </button>
@@ -795,7 +799,7 @@
                 'douyin'
                   ? 'bg-white dark:bg-[#323234] shadow-sm text-gray-900 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-                on:click={() => (selectedPlatform = "douyin")}
+                onclick={() => (selectedPlatform = "douyin")}
               >
                 抖音
               </button>
@@ -804,7 +808,7 @@
                 'huya'
                   ? 'bg-white dark:bg-[#323234] shadow-sm text-gray-900 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-                on:click={() => (selectedPlatform = "huya")}
+                onclick={() => (selectedPlatform = "huya")}
               >
                 虎牙
               </button>
@@ -813,7 +817,7 @@
                 'kuaishou'
                   ? 'bg-white dark:bg-[#323234] shadow-sm text-gray-900 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-                on:click={() => (selectedPlatform = "kuaishou")}
+                onclick={() => (selectedPlatform = "kuaishou")}
               >
                 快手
               </button>
@@ -822,7 +826,7 @@
                 'tiktok'
                   ? 'bg-white dark:bg-[#323234] shadow-sm text-gray-900 dark:text-white'
                   : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'}"
-                on:click={() => (selectedPlatform = "tiktok")}
+                onclick={() => (selectedPlatform = "tiktok")}
               >
                 TikTok
               </button>
@@ -848,7 +852,7 @@
           <div class="flex justify-end space-x-3">
             <button
               class="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-lg transition-colors"
-              on:click={() => {
+              onclick={() => {
                 addModal = false;
               }}
             >
@@ -857,7 +861,7 @@
             <button
               class="px-4 py-2 bg-[#0A84FF] hover:bg-[#0A84FF]/90 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               disabled={!addRoom}
-              on:click={() => {
+              onclick={() => {
                 addNewRecorder(addRoom, selectedPlatform);
                 addModal = false;
                 addRoom = "";
@@ -896,7 +900,7 @@
         </div>
         <button
           class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors"
-          on:click={() => (archiveModal = false)}
+          onclick={() => (archiveModal = false)}
         >
           <X class="w-5 h-5 dark:icon-white" />
         </button>
@@ -904,7 +908,7 @@
 
       <div
         class="flex-1 overflow-auto custom-scrollbar-light"
-        on:scroll={handleScroll}
+        onscroll={handleScroll}
       >
         <div class="p-6">
           <div class="overflow-x-auto custom-scrollbar-light">
@@ -979,7 +983,7 @@
                         <button
                           class="p-1.5 rounded-lg hover:bg-blue-500/10 transition-colors"
                           title="预览录播"
-                          on:click={() => {
+                          onclick={() => {
                             invoke("open_live", {
                               platform: archiveRoom.room_info.platform,
                               roomId: archiveRoom.room_info.room_id,
@@ -992,7 +996,7 @@
                         <button
                           class="p-1.5 rounded-lg hover:bg-blue-500/10 transition-colors"
                           title="生成完整切片"
-                          on:click={() => {
+                          onclick={() => {
                             openGenerateWholeClipModal(archive);
                           }}
                         >
@@ -1001,7 +1005,7 @@
                         <button
                           class="p-1.5 rounded-lg hover:bg-red-500/10 transition-colors"
                           title="删除记录"
-                          on:click={() => {
+                          onclick={() => {
                             invoke("delete_archive", {
                               platform: archiveRoom.room_info.platform,
                               roomId: archiveRoom.room_info.room_id,
@@ -1037,7 +1041,7 @@
                 {loadError}
                 <button
                   class="ml-2 text-blue-500 hover:text-blue-600 underline"
-                  on:click={() => {
+                  onclick={() => {
                     loadError = "";
                     loadMoreArchives();
                   }}
@@ -1082,11 +1086,10 @@
   bind:showModal={generateWholeClipModal}
   archive={generateWholeClipArchive}
   roomId={generateWholeClipArchive?.room_id || ""}
-  platform={generateWholeClipArchive?.platform || ""}
-  on:generated={handleWholeClipGenerated}
+  onGenerated={handleWholeClipGenerated}
 />
 
-<svelte:window on:mousedown={handleModalClickOutside} />
+<svelte:window onmousedown={handleModalClickOutside} />
 
 <style>
   /* macOS style toggle switch */

--- a/src/page/Setting.svelte
+++ b/src/page/Setting.svelte
@@ -17,7 +17,7 @@
   } from "lucide-svelte";
   import { onMount } from "svelte";
 
-  let setting_model: Config = {
+  let setting_model: Config = $state({
     cache: "",
     output: "",
     primary_uid: 0,
@@ -52,17 +52,17 @@
       font_size: 36,
       opacity: 0.8,
     },
-  };
+  });
 
-  let showModal = false;
-  let show_clip_name_help = false;
+  let showModal = $state(false);
+  let show_clip_name_help = $state(false);
   let endpoint = localStorage.getItem("endpoint") || "";
-  let endpointValue = endpoint;
-  let llmModels: string[] = [];
-  let llmModelsLoading = false;
-  let llmSaving = false;
-  let llmSaveMessage = "";
-  let llmError = "";
+  let endpointValue = $state(endpoint);
+  let llmModels: string[] = $state([]);
+  let llmModelsLoading = $state(false);
+  let llmSaving = $state(false);
+  let llmSaveMessage = $state("");
+  let llmError = $state("");
 
   function handleEndpointChange() {
     endpointValue = normalizeEndpoint(endpointValue);
@@ -278,7 +278,7 @@
                     type="number"
                     class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-24"
                     bind:value={setting_model.status_check_interval}
-                    on:blur={update_status_check_interval}
+                    onblur={update_status_check_interval}
                   />
                 </div>
               </div>
@@ -302,7 +302,7 @@
                     type="text"
                     class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                     bind:value={setting_model.webhook_url}
-                    on:change={update_webhook_url}
+                    onchange={update_webhook_url}
                     placeholder="https://example.com/webhook"
                   />
                 </div>
@@ -339,7 +339,7 @@
                       type="text"
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                       bind:value={endpointValue}
-                      on:blur={handleEndpointChange}
+                      onblur={handleEndpointChange}
                       placeholder="http://localhost:3000"
                     />
                   </div>
@@ -377,7 +377,7 @@
                     </div>
                     <button
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                      on:click={handleCacheChange}
+                      onclick={handleCacheChange}
                     >
                       变更
                     </button>
@@ -397,7 +397,7 @@
                     </div>
                     <button
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                      on:click={handleOutputChange}
+                      onclick={handleOutputChange}
                     >
                       变更
                     </button>
@@ -417,7 +417,7 @@
                     </div>
                     <button
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                      on:click={handleLogFolder}
+                      onclick={handleLogFolder}
                     >
                       打开
                     </button>
@@ -456,7 +456,7 @@
                       type="checkbox"
                       class="peer opacity-0 w-0 h-0"
                       bind:checked={setting_model.live_start_notify}
-                      on:change={update_notify}
+                      onchange={update_notify}
                     />
                     <span
                       class="switch-slider absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-gray-300 dark:bg-gray-600 rounded-full transition-all duration-300 before:absolute before:h-4 before:w-4 before:left-1 before:bottom-1 before:bg-white before:rounded-full before:transition-all before:duration-300 peer-checked:bg-blue-500 peer-checked:before:translate-x-5"
@@ -481,7 +481,7 @@
                       type="checkbox"
                       class="peer opacity-0 w-0 h-0"
                       bind:checked={setting_model.live_end_notify}
-                      on:change={update_notify}
+                      onchange={update_notify}
                     />
                     <span
                       class="switch-slider absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-gray-300 dark:bg-gray-600 rounded-full transition-all duration-300 before:absolute before:h-4 before:w-4 before:left-1 before:bottom-1 before:bg-white before:rounded-full before:transition-all before:duration-300 peer-checked:bg-blue-500 peer-checked:before:translate-x-5"
@@ -506,7 +506,7 @@
                       type="checkbox"
                       class="peer opacity-0 w-0 h-0"
                       bind:checked={setting_model.clip_notify}
-                      on:change={update_notify}
+                      onchange={update_notify}
                     />
                     <span
                       class="switch-slider absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-gray-300 dark:bg-gray-600 rounded-full transition-all duration-300 before:absolute before:h-4 before:w-4 before:left-1 before:bottom-1 before:bg-white before:rounded-full before:transition-all before:duration-300 peer-checked:bg-blue-500 peer-checked:before:translate-x-5"
@@ -531,7 +531,7 @@
                       type="checkbox"
                       class="peer opacity-0 w-0 h-0"
                       bind:checked={setting_model.post_notify}
-                      on:change={update_notify}
+                      onchange={update_notify}
                     />
                     <span
                       class="switch-slider absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-gray-300 dark:bg-gray-600 rounded-full transition-all duration-300 before:absolute before:h-4 before:w-4 before:left-1 before:bottom-1 before:bg-white before:rounded-full before:transition-all before:duration-300 peer-checked:bg-blue-500 peer-checked:before:translate-x-5"
@@ -566,7 +566,7 @@
                   <select
                     class="w-96 px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white"
                     bind:value={setting_model.llm.provider}
-                    on:change={handleLlmProviderChange}
+                    onchange={handleLlmProviderChange}
                   >
                     <option value="openai">OpenAI 兼容 API</option>
                     <option value="ollama">Ollama</option>
@@ -590,7 +590,7 @@
                     type="text"
                     class="w-96 px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white"
                     bind:value={setting_model.llm.endpoint}
-                    on:blur={saveLlmConfig}
+                    onblur={saveLlmConfig}
                     placeholder={setting_model.llm.provider === "ollama"
                       ? "http://localhost:11434"
                       : "https://api.openai.com/v1"}
@@ -613,7 +613,7 @@
                       type="password"
                       class="w-96 px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white"
                       bind:value={setting_model.llm.api_key}
-                      on:blur={saveLlmConfig}
+                      onblur={saveLlmConfig}
                       placeholder="sk-..."
                     />
                   </div>
@@ -635,7 +635,7 @@
                       type="text"
                       class="min-w-0 flex-1 px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white"
                       bind:value={setting_model.llm.model}
-                      on:blur={saveLlmConfig}
+                      onblur={saveLlmConfig}
                       list="llm-model-options"
                       placeholder={setting_model.llm.provider === "ollama"
                         ? "qwen3, llama3.2..."
@@ -648,7 +648,7 @@
                     </datalist>
                     <button
                       class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg border border-gray-200 bg-gray-100 text-gray-700 hover:bg-gray-200 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-                      on:click={loadLlmModels}
+                      onclick={loadLlmModels}
                       disabled={llmModelsLoading ||
                         !setting_model.llm.endpoint.trim() ||
                         (setting_model.llm.provider === "openai" &&
@@ -709,7 +709,7 @@
                       type="checkbox"
                       class="peer opacity-0 w-0 h-0"
                       bind:checked={setting_model.auto_subtitle}
-                      on:change={update_subtitle_setting}
+                      onchange={update_subtitle_setting}
                     />
                     <span
                       class="switch-slider absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-gray-300 dark:bg-gray-600 rounded-full transition-all duration-300 before:absolute before:h-4 before:w-4 before:left-1 before:bottom-1 before:bg-white before:rounded-full before:transition-all before:duration-300 peer-checked:bg-blue-500 peer-checked:before:translate-x-5"
@@ -739,7 +739,7 @@
                     <select
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white"
                       bind:value={setting_model.subtitle_generator_type}
-                      on:change={async () => {
+                      onchange={async () => {
                         try {
                           await invoke("update_subtitle_generator_type", {
                             subtitleGeneratorType:
@@ -776,7 +776,7 @@
                         type="password"
                         class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                         bind:value={setting_model.powerlive_key}
-                        on:change={async () => {
+                        onchange={async () => {
                           await invoke("update_powerlive_key", {
                             powerliveKey: setting_model.powerlive_key,
                           });
@@ -810,7 +810,7 @@
                       </div>
                       <button
                         class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-                        on:click={handleWhisperModelPathChange}>变更</button
+                        onclick={handleWhisperModelPathChange}>变更</button
                       >
                     </div>
                   </div>
@@ -834,7 +834,7 @@
                           type="text"
                           class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                           bind:value={setting_model.openai_api_endpoint}
-                          on:change={async () => {
+                          onchange={async () => {
                             await invoke("update_openai_api_endpoint", {
                               openaiApiEndpoint:
                                 setting_model.openai_api_endpoint,
@@ -862,7 +862,7 @@
                           type="password"
                           class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                           bind:value={setting_model.openai_api_key}
-                          on:change={async () => {
+                          onchange={async () => {
                             await invoke("update_openai_api_key", {
                               openaiApiKey: setting_model.openai_api_key,
                             });
@@ -891,7 +891,7 @@
                           type="text"
                           class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                           bind:value={setting_model.whisper_prompt}
-                          on:change={async () => {
+                          onchange={async () => {
                             await invoke("update_whisper_prompt", {
                               whisperPrompt: setting_model.whisper_prompt,
                             });
@@ -919,7 +919,7 @@
                         type="text"
                         class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                         bind:value={setting_model.whisper_language}
-                        on:change={async () => {
+                        onchange={async () => {
                           await invoke("update_whisper_language", {
                             whisperLanguage: setting_model.whisper_language,
                           });
@@ -965,14 +965,15 @@
                       </p>
                       <div
                         class="relative"
+                        role="presentation"
                         use:clickOutside={() => (show_clip_name_help = false)}
-                        on:mouseenter={() => (show_clip_name_help = true)}
-                        on:mouseleave={() => (show_clip_name_help = false)}
+                        onmouseenter={() => (show_clip_name_help = true)}
+                        onmouseleave={() => (show_clip_name_help = false)}
                       >
                         <button
                           type="button"
                           class="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
-                          on:click={() =>
+                          onclick={() =>
                             (show_clip_name_help = !show_clip_name_help)}
                         >
                           详情
@@ -1002,7 +1003,7 @@
                       type="text"
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-96"
                       bind:value={setting_model.clip_name_format}
-                      on:change={async () => {
+                      onchange={async () => {
                         await invoke("update_clip_name_format", {
                           clipNameFormat: setting_model.clip_name_format,
                         });
@@ -1043,7 +1044,7 @@
                       type="number"
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-24"
                       bind:value={setting_model.danmu_ass_options.font_size}
-                      on:blur={update_danmu_ass_options}
+                      onblur={update_danmu_ass_options}
                       min="12"
                       max="72"
                       step="1"
@@ -1070,7 +1071,7 @@
                       type="number"
                       class="px-3 py-2 bg-gray-100 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-white w-24"
                       bind:value={setting_model.danmu_ass_options.opacity}
-                      on:blur={update_danmu_ass_options}
+                      onblur={update_danmu_ass_options}
                       min="0.0"
                       max="1.0"
                       step="0.1"
@@ -1110,7 +1111,7 @@
                       type="checkbox"
                       class="peer opacity-0 w-0 h-0"
                       bind:checked={setting_model.auto_generate.enabled}
-                      on:change={async () => {
+                      onchange={async () => {
                         await invoke("update_auto_generate", {
                           enabled: setting_model.auto_generate.enabled,
                           encodeDanmu: setting_model.auto_generate.encode_danmu,
@@ -1141,7 +1142,7 @@
                       type="checkbox"
                       class="peer opacity-0 w-0 h-0"
                       bind:checked={setting_model.auto_generate.encode_danmu}
-                      on:change={async () => {
+                      onchange={async () => {
                         await invoke("update_auto_generate", {
                           enabled: setting_model.auto_generate.enabled,
                           encodeDanmu: setting_model.auto_generate.encode_danmu,
@@ -1188,13 +1189,13 @@
       <div class="flex justify-end space-x-4">
         <button
           class="px-4 py-2 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
-          on:click={() => (showModal = false)}
+          onclick={() => (showModal = false)}
         >
           取消
         </button>
         <button
           class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
-          on:click={confirmChange}
+          onclick={confirmChange}
         >
           确认
         </button>

--- a/src/page/Summary.svelte
+++ b/src/page/Summary.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+
   import { get_static_url, invoke } from "../lib/invoker";
   import type { RecorderList, DiskInfo } from "../lib/interface";
   import type { RecordItem } from "../lib/db";
@@ -21,24 +22,24 @@
     recorders: [],
   };
 
-  let disk_info: DiskInfo = {
+  let disk_info: DiskInfo = $state({
     disk: "",
     total: 0,
     free: 0,
-  };
+  });
 
-  let total = 0;
-  let online = 0;
-  let disk_usage = 0;
-  let account_count = 0;
-  let total_length = 0;
-  let today_record_count = 0;
-  let recent_records: RecordItem[] = [];
-  let activeDropdown = null;
-  let loading = false;
+  let total = $state(0);
+  let online = $state(0);
+  let disk_usage = $state(0);
+  let account_count = $state(0);
+  let total_length = $state(0);
+  let today_record_count = $state(0);
+  let recent_records: RecordItem[] = $state([]);
+  let activeDropdown = $state(null);
+  let loading = $state(false);
   let offset = 0;
-  let hasMore = true;
-  let hasNewRecords = false;
+  let hasMore = $state(true);
+  let hasNewRecords = $state(false);
   const RECORDS_PER_PAGE = 5;
 
   async function update_summary() {
@@ -229,11 +230,11 @@
   }
 </script>
 
-<svelte:window on:click={handleClickOutside} />
+<svelte:window onclick={handleClickOutside} />
 
 <div
   class="flex-1 p-6 overflow-y-auto custom-scrollbar-light bg-gray-50"
-  on:scroll={handleScroll}
+  onscroll={handleScroll}
 >
   <div class="space-y-6">
     <!-- Header -->
@@ -371,7 +372,7 @@
           </h2>
           <button
             class="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700/50 transition-colors text-gray-500 dark:text-gray-400"
-            on:click={refreshRecords}
+            onclick={refreshRecords}
           >
             <RefreshCw class="w-5 h-5 dark:icon-white" />
           </button>
@@ -379,7 +380,7 @@
         {#if hasNewRecords}
           <button
             class="px-3 py-1 text-sm text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 rounded-full hover:bg-blue-100 dark:hover:bg-blue-500/20 transition-colors"
-            on:click={loadMoreRecords}
+            onclick={loadMoreRecords}
           >
             记录有更新 • 点击刷新
           </button>
@@ -397,7 +398,7 @@
                   src={record.cover}
                   class="w-32 h-18 rounded-lg object-cover"
                   alt="Gaming stream thumbnail"
-                  on:error={(e) =>
+                  onerror={(e) =>
                     console.error("Image error in template:", record.cover, e)}
                 />
               {:else}
@@ -421,7 +422,7 @@
             <div class="flex items-center space-x-2">
               <button
                 class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700"
-                on:click={() => {
+                onclick={() => {
                   invoke("open_live", {
                     platform: record.platform,
                     roomId: record.room_id,
@@ -434,8 +435,10 @@
               <div class="relative dropdown-container">
                 <button
                   class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-red-600 dark:text-red-400"
-                  on:click|stopPropagation={() =>
-                    toggleDropdown(record.live_id)}
+                  onclick={(event) => {
+                    event.stopPropagation();
+                    toggleDropdown(record.live_id);
+                  }}
                 >
                   <Trash2 class="w-5 h-5 icon-danger" />
                 </button>
@@ -461,7 +464,7 @@
                     <div class="p-2 flex space-x-2">
                       <button
                         class="flex-1 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700/50 rounded-md transition-colors"
-                        on:click={() => {
+                        onclick={() => {
                           activeDropdown = null;
                         }}
                       >
@@ -469,7 +472,7 @@
                       </button>
                       <button
                         class="flex-1 px-3 py-1.5 text-sm text-white bg-red-600 hover:bg-red-700 rounded-md transition-colors"
-                        on:click={() => {
+                        onclick={() => {
                           deleteRecord(record);
                           activeDropdown = null;
                         }}

--- a/src/page/Task.svelte
+++ b/src/page/Task.svelte
@@ -14,11 +14,11 @@
   import type { TaskRow } from "../lib/db";
   import { onMount, onDestroy } from "svelte";
 
-  let tasks: TaskRow[] = [];
-  let loading = true;
-  let actionTaskId: string | null = null;
+  let tasks: TaskRow[] = $state([]);
+  let loading = $state(true);
+  let actionTaskId: string | null = $state(null);
   let refreshInterval = null;
-  let expandedTasks = new Set<string>();
+  let expandedTasks = $state(new Set<string>());
 
   async function update_tasks() {
     try {
@@ -321,7 +321,7 @@
         </p>
       </div>
       <button
-        on:click={update_tasks}
+        onclick={update_tasks}
         class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center space-x-2 disabled:opacity-50 disabled:cursor-not-allowed"
         disabled={loading}
         title="刷新任务列表"
@@ -412,7 +412,7 @@
                   <div class="flex items-center gap-2 min-w-0">
                     <button
                       class="shrink-0 p-1 -ml-1 rounded-md text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                      on:click={() => toggleMetadata(task.id)}
+                      onclick={() => toggleMetadata(task.id)}
                       title={expandedTasks.has(task.id)
                         ? "收起任务详情"
                         : "展开任务详情"}
@@ -466,8 +466,8 @@
                       {#if task.status.toLowerCase() === "pending" || task.status.toLowerCase() === "processing"}
                         <Loader2 class="w-3 h-3 animate-spin" />
                       {:else}
-                        <svelte:component
-                          this={get_status_icon(task.status)}
+                        {@const SvelteComponent = get_status_icon(task.status)}
+                        <SvelteComponent
                           class="w-3 h-3"
                         />
                       {/if}
@@ -489,7 +489,7 @@
                           ? "text-amber-600 hover:text-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/20"
                           : "text-gray-400 hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
                       } ${actionTaskId === task.id ? "cursor-wait" : ""}`}
-                      on:click={() =>
+                      onclick={() =>
                         is_cancelable_status(task.status)
                           ? cancel_task(task.id)
                           : delete_task(task.id)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,9 +1545,9 @@ camelcase@^5.0.0:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001702, caniuse-lite@^1.0.30001726:
-  version "1.0.30001766"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz"
-  integrity sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==
+  version "1.0.30001810"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz"
+  integrity sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==
 
 ccount@^2.0.0:
   version "2.0.1"
@@ -3469,10 +3469,10 @@ tslib@^2.4.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-typescript@^5.0.0:
-  version "5.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.2.tgz#d93450cddec5154a2d5cabe3b8102b83316fb2a6"
-  integrity sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==
+typescript@^5.5.0:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 ufo@^1.5.4:
   version "1.6.1"


### PR DESCRIPTION
## Summary
- migrate Svelte components from legacy syntax to Svelte 5 runes and callback props
- replace legacy event dispatching and slot usage with modern component APIs
- update TypeScript and refresh Browserslist data

## Validation
- `yarn svelte-check --tsconfig ./tsconfig.json`
- `yarn build`

Both commands pass.