### PR TITLE
ci: cache Rust and Docker builds

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,12 @@ jobs:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+          key: ${{ matrix.target || matrix.features || 'native' }}
+
       - name: Install CUDA toolkit (Windows CUDA only)
         if: matrix.features == 'cuda'
         uses: Jimver/cuda-toolkit@v0.2.24

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set cache image
+        id: cache
+        shell: bash
+        run: echo "image=${REGISTRY}/${IMAGE_NAME,,}:buildcache" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -58,6 +63,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ steps.cache.outputs.image }}
+          cache-to: type=registry,ref=${{ steps.cache.outputs.image }},mode=max
           build-args: |
             SENTRY_ENDPOINT=${{ secrets.SENTRY_ENDPOINT }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ COPY . .
 # Build frontend
 RUN yarn build
 
-# Build Rust backend
-FROM rust:1.90-slim AS rust-builder
+# Build Rust backend. cargo-chef keeps third-party dependencies in a separate
+# Docker layer, so application source changes do not force a full rebuild.
+FROM rust:1.90-slim AS rust-base
 
-WORKDIR /app
+WORKDIR /app/src-tauri
 
 # Install required system dependencies
 RUN apt-get update && apt-get install -y \
@@ -40,10 +41,23 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Rust project files
-COPY src-tauri/Cargo.toml src-tauri/Cargo.lock ./src-tauri/
-COPY src-tauri/src ./src-tauri/src
-COPY src-tauri/crates ./src-tauri/crates
+RUN cargo install cargo-chef --version 0.1.78 --locked
+
+FROM rust-base AS rust-planner
+
+COPY src-tauri .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM rust-base AS rust-builder
+
+COPY --from=rust-planner /app/src-tauri/recipe.json recipe.json
+RUN cargo chef cook \
+    --no-default-features \
+    --features headless \
+    --release \
+    --recipe-path recipe.json
+
+COPY src-tauri .
 
 # Sentry DSN baked into the binary at build time (option_env! in main.rs).
 # Empty by default so Sentry stays disabled unless a DSN is provided.
@@ -51,8 +65,6 @@ ARG SENTRY_ENDPOINT=""
 ENV SENTRY_ENDPOINT=${SENTRY_ENDPOINT}
 
 # Build Rust backend
-WORKDIR /app/src-tauri
-RUN rustup component add rustfmt
 RUN cargo build --no-default-features --features headless --release
 
 # Final stage


### PR DESCRIPTION
## Summary
- cache Cargo dependencies and target artifacts in lint and release workflows
- add GHCR-backed BuildKit cache for the multi-arch Docker build
- split Docker Rust dependency compilation with cargo-chef

## Validation
- parsed all GitHub Actions YAML files with PyYAML
- `docker buildx build --check .`
- built the Docker `rust-planner` stage successfully

The existing untracked change removing the `whisper.cpp` submodule was intentionally excluded.