### PR TITLE
feat: persist Bilibili user profiles

### DIFF
--- a/src-tauri/crates/recorder/src/platforms/bilibili.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili.rs
@@ -6,6 +6,7 @@ use crate::account::Account;
 use crate::core::hls_recorder::HlsRecorder;
 use crate::errors::RecorderError;
 use crate::events::RecorderEvent;
+use crate::platforms::bilibili::api::UserInfoCache;
 use crate::platforms::bilibili::api::{Protocol, Qn};
 use crate::platforms::PlatformType;
 use crate::traits::RecorderTrait;
@@ -37,6 +38,7 @@ pub struct BiliExtra {
     live_stream: Arc<RwLock<Option<BiliStream>>>,
     pre_live_id: Arc<RwLock<Option<String>>>,
     should_continue: Arc<AtomicBool>,
+    user_info_cache: Arc<dyn UserInfoCache>,
 }
 
 pub type BiliRecorder = Recorder<BiliExtra>;
@@ -49,6 +51,7 @@ impl BiliRecorder {
         event_channel: broadcast::Sender<RecorderEvent>,
         update_interval: Arc<atomic::AtomicU64>,
         enabled: bool,
+        user_info_cache: Arc<dyn UserInfoCache>,
     ) -> Result<Self, crate::errors::RecorderError> {
         let client = reqwest::Client::new();
         let extra = BiliExtra {
@@ -56,6 +59,7 @@ impl BiliRecorder {
             live_stream: Arc::new(RwLock::new(None)),
             pre_live_id: Arc::new(RwLock::new(None)),
             should_continue: Arc::new(AtomicBool::new(false)),
+            user_info_cache,
         };
 
         let recorder = Self {
@@ -117,12 +121,18 @@ impl BiliRecorder {
                 // Only update user info once
                 if self.user_info.read().await.user_id != room_info.user_id {
                     let user_id = room_info.user_id;
-                    let user_info = api::get_user_info(&self.client, &self.account, &user_id).await;
+                    let user_info = api::get_user_info_cached(
+                        &self.client,
+                        &self.account,
+                        &user_id,
+                        self.extra.user_info_cache.as_ref(),
+                    )
+                    .await;
                     if let Ok(user_info) = user_info {
                         *self.user_info.write().await = UserInfo {
                             user_id: user_id.to_string(),
                             user_name: user_info.user_name,
-                            user_avatar: user_info.user_avatar_url,
+                            user_avatar: user_info.user_avatar,
                         }
                     } else {
                         self.log_error(&format!(

--- a/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
@@ -10,6 +10,8 @@ use crate::core::Codec;
 use crate::core::Format;
 use crate::errors::RecorderError;
 use crate::utils::user_agent_generator;
+use crate::UserInfo as RecorderUserInfo;
+use async_trait::async_trait;
 use chrono::TimeZone;
 use pct_str::PctString;
 use pct_str::URIReserved;
@@ -56,6 +58,16 @@ pub struct UserInfo {
     pub user_name: String,
     pub user_sign: String,
     pub user_avatar_url: String,
+}
+
+/// Persistent cache for Bilibili broadcaster profiles.
+///
+/// This is intentionally Bilibili-specific because the other supported
+/// platforms include the broadcaster profile in their room response.
+#[async_trait]
+pub trait UserInfoCache: Send + Sync {
+    async fn get_user_info(&self, user_id: &str) -> Result<Option<RecorderUserInfo>, String>;
+    async fn save_user_info(&self, user_info: &RecorderUserInfo) -> Result<(), String>;
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -437,6 +449,72 @@ pub async fn get_user_info(
         user_sign: res["data"]["sign"].as_str().unwrap_or("").to_string(),
         user_avatar_url: res["data"]["face"].as_str().unwrap_or("").to_string(),
     })
+}
+
+/// Get Bilibili user information, using the persistent profile cache first.
+pub async fn get_user_info_cached(
+    client: &Client,
+    account: &Account,
+    user_id: &str,
+    cache: &dyn UserInfoCache,
+) -> Result<RecorderUserInfo, RecorderError> {
+    match cache.get_user_info(user_id).await {
+        Ok(Some(user_info)) => return Ok(user_info),
+        Ok(None) => {}
+        Err(error) => {
+            // Cache availability must not prevent the recorder from fetching
+            // the profile from Bilibili.
+            log::warn!("Failed to read cached Bilibili user info: {error}");
+        }
+    }
+
+    let user_info = get_user_info(client, account, user_id).await?;
+    let user_info = RecorderUserInfo {
+        user_id: user_info.user_id,
+        user_name: user_info.user_name,
+        user_avatar: user_info.user_avatar_url,
+    };
+
+    // A cache write failure should not make an otherwise successful profile
+    // request fail. The next lookup can fetch the profile again.
+    if let Err(error) = cache.save_user_info(&user_info).await {
+        log::warn!("Failed to persist Bilibili user info: {error}");
+    }
+
+    Ok(user_info)
+}
+
+#[cfg(test)]
+mod user_info_cache_tests {
+    use super::*;
+
+    struct HitCache;
+
+    #[async_trait]
+    impl UserInfoCache for HitCache {
+        async fn get_user_info(&self, user_id: &str) -> Result<Option<RecorderUserInfo>, String> {
+            Ok(Some(RecorderUserInfo {
+                user_id: user_id.to_string(),
+                user_name: "cached name".to_string(),
+                user_avatar: "https://example.com/avatar.jpg".to_string(),
+            }))
+        }
+
+        async fn save_user_info(&self, _user_info: &RecorderUserInfo) -> Result<(), String> {
+            panic!("a cache hit must not be written again");
+        }
+    }
+
+    #[tokio::test]
+    async fn cached_user_info_does_not_require_a_network_request() {
+        let info = get_user_info_cached(&Client::new(), &Account::default(), "123", &HitCache)
+            .await
+            .unwrap();
+
+        assert_eq!(info.user_id, "123");
+        assert_eq!(info.user_name, "cached name");
+        assert_eq!(info.user_avatar, "https://example.com/avatar.jpg");
+    }
 }
 
 pub async fn get_room_info(

--- a/src-tauri/src/database/bilibili_user.rs
+++ b/src-tauri/src/database/bilibili_user.rs
@@ -1,0 +1,70 @@
+use recorder::platforms::bilibili::api::UserInfoCache;
+use recorder::UserInfo;
+use sqlx::FromRow;
+
+use super::{Database, DatabaseError};
+
+#[derive(Debug, FromRow)]
+struct BilibiliUserInfoRow {
+    user_id: String,
+    user_name: String,
+    user_avatar: String,
+}
+
+impl Database {
+    async fn get_bilibili_user_info(
+        &self,
+        user_id: &str,
+    ) -> Result<Option<UserInfo>, DatabaseError> {
+        let lock = self.db.read().await.clone().unwrap();
+        let row = sqlx::query_as::<_, BilibiliUserInfoRow>(
+            "SELECT user_id, user_name, user_avatar
+             FROM bilibili_user_profiles
+             WHERE user_id = $1",
+        )
+        .bind(user_id)
+        .fetch_optional(&lock)
+        .await?;
+
+        Ok(row.map(|row| UserInfo {
+            user_id: row.user_id,
+            user_name: row.user_name,
+            user_avatar: row.user_avatar,
+        }))
+    }
+
+    async fn save_bilibili_user_info(&self, user_info: &UserInfo) -> Result<(), DatabaseError> {
+        let lock = self.db.read().await.clone().unwrap();
+        sqlx::query(
+            "INSERT INTO bilibili_user_profiles
+                (user_id, user_name, user_avatar, updated_at)
+             VALUES ($1, $2, $3, datetime('now'))
+             ON CONFLICT(user_id) DO UPDATE SET
+                user_name = excluded.user_name,
+                user_avatar = excluded.user_avatar,
+                updated_at = excluded.updated_at",
+        )
+        .bind(&user_info.user_id)
+        .bind(&user_info.user_name)
+        .bind(&user_info.user_avatar)
+        .execute(&lock)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl UserInfoCache for Database {
+    async fn get_user_info(&self, user_id: &str) -> Result<Option<UserInfo>, String> {
+        self.get_bilibili_user_info(user_id)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn save_user_info(&self, user_info: &UserInfo) -> Result<(), String> {
+        self.save_bilibili_user_info(user_info)
+            .await
+            .map_err(|error| error.to_string())
+    }
+}

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 
 pub mod account;
+pub mod bilibili_user;
 pub mod message;
 pub mod record;
 pub mod recorder;

--- a/src-tauri/src/handlers/account.rs
+++ b/src-tauri/src/handlers/account.rs
@@ -4,6 +4,7 @@ use crate::database::account::AccountRow;
 use crate::state::State;
 use crate::state_type;
 use chrono::Utc;
+use recorder::platforms::bilibili::api::UserInfoCache;
 use recorder::platforms::bilibili::api::{QrInfo, QrStatus};
 use recorder::platforms::{bilibili, douyin, huya, kuaishou, tiktok, PlatformType};
 use recorder::UserInfo;
@@ -199,6 +200,12 @@ pub async fn add_account(
             return Err("Unsupported platform".to_string());
         }
     };
+
+    if platform == PlatformType::BiliBili {
+        if let Err(error) = state.db.save_user_info(&user_info).await {
+            log::warn!("Failed to persist Bilibili user info: {error}");
+        }
+    }
 
     let account = AccountRow {
         platform: platform.as_str().to_string(),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -477,6 +477,19 @@ fn get_migrations() -> Vec<Migration> {
             "#,
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 15,
+            description: "add_bilibili_user_profiles_cache",
+            sql: r"
+                CREATE TABLE bilibili_user_profiles (
+                    user_id TEXT PRIMARY KEY,
+                    user_name TEXT NOT NULL,
+                    user_avatar TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+            ",
+            kind: MigrationKind::Up,
+        },
     ]
 }
 

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -616,6 +616,7 @@ impl RecorderManager {
                     event_tx,
                     update_interval,
                     enabled,
+                    self.db.clone(),
                 )
                 .await?,
             ),


### PR DESCRIPTION
## Summary
- add a persistent SQLite cache for Bilibili broadcaster profiles
- reuse cached profiles in Bilibili recorders across restarts
- share the cache with Bilibili account setup

## Verification
- `cargo check -p recorder`
- `cargo test -p recorder cached_user_info_does_not_require_a_network_request`

The full recorder test suite still has an unrelated Huya network-dependent test failure, and the full application build is blocked by the missing `whisper.cpp` submodule in the workspace.