### PR TITLE
feat: persist live websocket events as JSONL

### DIFF
--- a/src-tauri/crates/danmu_stream/README.md
+++ b/src-tauri/crates/danmu_stream/README.md
@@ -1,0 +1,31 @@
+## Event format
+
+The stream providers expose every decoded websocket event as a
+`DanmuMessageType::Event`. Recorders write these events as one JSON object per
+line to `events.jsonl`:
+
+```json
+{
+  "ts": 1710000000123,
+  "platform": "bilibili",
+  "room_id": "12345",
+  "type": "gift",
+  "data": {
+    "user_id": 42,
+    "user_name": "viewer",
+    "gift_name": "花束",
+    "count": 1,
+    "price": 100
+  },
+  "raw": {
+    "cmd": "SEND_GIFT",
+    "data": {}
+  }
+}
+```
+
+`ts` is Unix time in milliseconds and `type` is the normalized event
+category. Current categories are `danmu`, `gift`, `super_chat`, `enter`,
+`like`, `online`, `room_update`, and `unknown`. `data` has the common fields
+for that category; `raw` retains the original JSON provider payload so that
+new provider fields remain available without changing the storage format.

--- a/src-tauri/crates/danmu_stream/examples/bilibili.rs
+++ b/src-tauri/crates/danmu_stream/examples/bilibili.rs
@@ -20,6 +20,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             log::info!("Waitting for message");
             if let Ok(Some(msg)) = stream_clone.recv().await {
                 match msg {
+                    DanmuMessageType::Event(event) => {
+                        log::info!("Received event: {:?}", event.event_type);
+                    }
                     DanmuMessageType::DanmuMessage(danmu) => {
                         log::info!("Received danmu message: {:?}", danmu.message);
                     }

--- a/src-tauri/crates/danmu_stream/examples/douyin.rs
+++ b/src-tauri/crates/danmu_stream/examples/douyin.rs
@@ -21,6 +21,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         loop {
             if let Ok(Some(msg)) = stream_clone.recv().await {
                 match msg {
+                    DanmuMessageType::Event(event) => {
+                        log::info!("Received event: {:?}", event.event_type);
+                    }
                     DanmuMessageType::DanmuMessage(danmu) => {
                         log::info!("Received danmu message: {:?}", danmu.message);
                     }

--- a/src-tauri/crates/danmu_stream/src/lib.rs
+++ b/src-tauri/crates/danmu_stream/src/lib.rs
@@ -2,12 +2,16 @@ pub mod danmu_stream;
 mod http_client;
 pub mod provider;
 
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DanmuStreamError {
     #[error("HttpError {0:?}")]
     HttpError(#[from] reqwest::Error),
+    #[error("BilibiliApiError code={code}: {message}")]
+    ApiError { code: i64, message: String },
     #[error("ParseError {0:?}")]
     ParseError(#[from] url::ParseError),
     #[error("WebsocketError {err}")]
@@ -24,7 +28,56 @@ pub enum DanmuStreamError {
 
 #[derive(Debug)]
 pub enum DanmuMessageType {
+    /// A normalized event received from a platform websocket.
+    Event(LiveEvent),
+    /// Kept for providers which have not yet migrated to `Event`.
     DanmuMessage(DanmuMessage),
+}
+
+/// The on-disk/websocket-independent representation of a live-room event.
+///
+/// `data` contains the normalized, platform-independent fields while `raw`
+/// keeps the original provider payload.  Keeping the latter is intentional:
+/// websocket protocols add fields frequently and an event must not be lost
+/// just because this crate does not know how to interpret a new field yet.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiveEvent {
+    pub ts: i64,
+    pub platform: String,
+    pub room_id: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub data: Value,
+    pub raw: Value,
+}
+
+impl LiveEvent {
+    pub fn new(platform: &str, room_id: &str, event_type: &str, data: Value) -> Self {
+        Self {
+            ts: chrono::Utc::now().timestamp_millis(),
+            platform: platform.to_string(),
+            room_id: room_id.to_string(),
+            event_type: event_type.to_string(),
+            data,
+            raw: Value::Null,
+        }
+    }
+
+    pub fn danmu(message: DanmuMessage, platform: &str) -> Self {
+        Self {
+            ts: message.timestamp,
+            platform: platform.to_string(),
+            room_id: message.room_id.clone(),
+            event_type: "danmu".to_string(),
+            data: json!({
+                "user_id": message.user_id,
+                "user_name": message.user_name,
+                "content": message.message,
+                "color": message.color,
+            }),
+            raw: Value::Null,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/crates/danmu_stream/src/lib.rs
+++ b/src-tauri/crates/danmu_stream/src/lib.rs
@@ -78,6 +78,11 @@ impl LiveEvent {
             raw: Value::Null,
         }
     }
+
+    pub fn with_raw(mut self, raw: Value) -> Self {
+        self.raw = raw;
+        self
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili.rs
@@ -12,7 +12,8 @@ use futures_util::{SinkExt, StreamExt, TryStreamExt};
 use log::{error, info};
 use pct_str::{PctString, URIReserved};
 use regex::Regex;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
 use tokio::{
     sync::{mpsc, RwLock},
     time::{sleep, Duration},
@@ -175,7 +176,7 @@ impl BiliDanmu {
 
         tokio::select! {
             v = BiliDanmu::send_heartbeat_packets(Arc::clone(&self.write)) => v,
-            v = BiliDanmu::recv(read, tx, Arc::clone(&self.stop)) => v
+            v = BiliDanmu::recv(read, tx, Arc::clone(&self.stop), self.room_id.clone()) => v
         }?;
 
         Ok(())
@@ -199,6 +200,7 @@ impl BiliDanmu {
         mut read: WsReadType,
         tx: mpsc::UnboundedSender<DanmuMessageType>,
         stop: Arc<RwLock<bool>>,
+        room_id: String,
     ) -> Result<(), DanmuStreamError> {
         while let Ok(Some(msg)) = read.try_next().await {
             if *stop.read().await {
@@ -215,7 +217,10 @@ impl BiliDanmu {
                         let ws = stream::WsStreamCtx::new(&i);
                         if let Ok(ws) = ws {
                             match ws.match_msg() {
-                                Ok(v) => {
+                                Ok(mut v) => {
+                                    if let DanmuMessageType::Event(ref mut event) = v {
+                                        event.room_id = room_id.clone();
+                                    }
                                     log::debug!("Received message: {:?}", v);
                                     tx.send(v).map_err(|e| DanmuStreamError::WebsocketError {
                                         err: e.to_string(),
@@ -252,7 +257,7 @@ impl BiliDanmu {
                 }),
             )
             .await?;
-        let resp = self
+        let body = self
             .client
             .get(
                 &format!(
@@ -262,10 +267,10 @@ impl BiliDanmu {
                 None,
             )
             .await?
-            .json::<DanmuInfo>()
+            .json::<Value>()
             .await?;
 
-        Ok(resp)
+        Self::decode_api_response(body)
     }
 
     async fn get_real_room(&self, wbi_key: &str, room_id: &str) -> Result<i64, DanmuStreamError> {
@@ -278,7 +283,7 @@ impl BiliDanmu {
                 }),
             )
             .await?;
-        let resp = self
+        let body = self
             .client
             .get(
                 &format!(
@@ -288,12 +293,10 @@ impl BiliDanmu {
                 None,
             )
             .await?
-            .json::<RoomInit>()
-            .await?
-            .data
-            .room_id;
+            .json::<Value>()
+            .await?;
 
-        Ok(resp)
+        Ok(Self::decode_api_response::<RoomInit>(body)?.data.room_id)
     }
 
     fn parse_user_id(cookie: &str) -> Result<i64, DanmuStreamError> {
@@ -323,21 +326,56 @@ impl BiliDanmu {
             .await?
             .json()
             .await?;
+        let nav_info = Self::decode_api_response::<Value>(nav_info)?;
         let re = Regex::new(r"wbi/(.*).png").unwrap();
+        let img_url = nav_info["data"]["wbi_img"]["img_url"]
+            .as_str()
+            .ok_or_else(|| DanmuStreamError::MessageParseError {
+                err: "Bilibili nav response has no WBI image URL".to_string(),
+            })?;
+        let sub_url = nav_info["data"]["wbi_img"]["sub_url"]
+            .as_str()
+            .ok_or_else(|| DanmuStreamError::MessageParseError {
+                err: "Bilibili nav response has no WBI sub URL".to_string(),
+            })?;
         let img = re
-            .captures(nav_info["data"]["wbi_img"]["img_url"].as_str().unwrap())
-            .unwrap()
-            .get(1)
-            .unwrap()
-            .as_str();
+            .captures(img_url)
+            .and_then(|captures| captures.get(1))
+            .map(|capture| capture.as_str())
+            .ok_or_else(|| DanmuStreamError::MessageParseError {
+                err: "Invalid WBI image URL".to_string(),
+            })?;
         let sub = re
-            .captures(nav_info["data"]["wbi_img"]["sub_url"].as_str().unwrap())
-            .unwrap()
-            .get(1)
-            .unwrap()
-            .as_str();
+            .captures(sub_url)
+            .and_then(|captures| captures.get(1))
+            .map(|capture| capture.as_str())
+            .ok_or_else(|| DanmuStreamError::MessageParseError {
+                err: "Invalid WBI sub URL".to_string(),
+            })?;
         let raw_string = format!("{}{}", img, sub);
         Ok(raw_string)
+    }
+
+    fn decode_api_response<T>(body: Value) -> Result<T, DanmuStreamError>
+    where
+        T: DeserializeOwned,
+    {
+        if let Some(code) = body.get("code").and_then(Value::as_i64) {
+            if code != 0 {
+                return Err(DanmuStreamError::ApiError {
+                    code,
+                    message: body
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .unwrap_or("unknown error")
+                        .to_string(),
+                });
+            }
+        }
+
+        serde_json::from_value(body).map_err(|error| DanmuStreamError::MessageParseError {
+            err: format!("Invalid Bilibili API response: {error}"),
+        })
     }
 
     pub async fn get_sign(
@@ -440,4 +478,25 @@ pub struct RoomInit {
 #[derive(Debug, Deserialize, Clone)]
 pub struct RoomInitData {
     room_id: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reports_bilibili_api_errors_instead_of_deserialization_errors() {
+        let error = BiliDanmu::decode_api_response::<DanmuInfo>(serde_json::json!({
+            "code": -352,
+            "message": "风控校验失败",
+            "ttl": 1
+        }))
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DanmuStreamError::ApiError { code: -352, .. }
+        ));
+        assert!(error.to_string().contains("风控校验失败"));
+    }
 }

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/stream.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/stream.rs
@@ -3,7 +3,9 @@ use serde_json::Value;
 
 use super::dannmu_msg::BiliDanmuMessage;
 
-use crate::{provider::DanmuMessageType, DanmuMessage, DanmuStreamError};
+use crate::{provider::DanmuMessageType, DanmuStreamError, LiveEvent};
+use chrono::Utc;
+use serde_json::json;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct WsStreamCtx {
@@ -12,6 +14,8 @@ pub struct WsStreamCtx {
     pub data: Option<WsStreamCtxData>,
     #[serde(flatten)]
     _v: Value,
+    #[serde(skip)]
+    pub raw: Value,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -32,6 +36,7 @@ pub struct WsStreamCtxData {
     pub num: Option<u64>,
     pub combo_num: Option<u64>,
     pub gift_num: Option<u64>,
+    #[serde(default)]
     pub combo_send: Box<Option<WsStreamCtxData>>,
 }
 
@@ -44,39 +49,102 @@ pub struct WsStreamCtxDataMedalInfo {
 #[derive(Debug, Deserialize, Clone)]
 #[allow(dead_code)]
 pub struct WsStreamCtxDataUser {
+    #[serde(default)]
     pub face: String,
+    #[serde(default)]
     pub uname: String,
 }
 
 impl WsStreamCtx {
     pub fn new(s: &str) -> Result<Self, DanmuStreamError> {
-        serde_json::from_str(s).map_err(|_| DanmuStreamError::MessageParseError {
-            err: "Failed to parse message".to_string(),
-        })
+        let raw =
+            serde_json::from_str::<Value>(s).map_err(|_| DanmuStreamError::MessageParseError {
+                err: "Failed to parse message".to_string(),
+            })?;
+        let mut ctx = serde_json::from_value::<Self>(raw.clone()).map_err(|_| {
+            DanmuStreamError::MessageParseError {
+                err: "Failed to parse message".to_string(),
+            }
+        })?;
+        ctx.raw = raw;
+        Ok(ctx)
     }
 
     pub fn match_msg(&self) -> Result<DanmuMessageType, DanmuStreamError> {
         let cmd = self.handle_cmd();
-
-        let danmu_msg = match cmd {
-            Some(c) if c.contains("DANMU_MSG") => Some(BiliDanmuMessage::new_from_ctx(self)?),
-            _ => None,
+        let event_type = match cmd {
+            Some(c) if c.contains("DANMU_MSG") => "danmu",
+            Some("SEND_GIFT") | Some("COMBO_SEND") => "gift",
+            Some("SUPER_CHAT_MESSAGE") => "super_chat",
+            Some("INTERACT_WORD") | Some("ENTRY_EFFECT") => "enter",
+            Some("LIKE_INFO_V3_CLICK") | Some("LIKE_INFO_V3_UPDATE") => "like",
+            Some("WATCHED_CHANGE") | Some("ONLINE") => "online",
+            Some("ROOM_REAL_TIME_MESSAGE_UPDATE") => "room_update",
+            Some(_) => "unknown",
+            None => "unknown",
         };
 
-        if let Some(danmu_msg) = danmu_msg {
-            Ok(DanmuMessageType::DanmuMessage(DanmuMessage {
-                room_id: "".to_string(),
-                user_id: danmu_msg.uid,
-                user_name: danmu_msg.username,
-                message: danmu_msg.msg,
-                color: 0,
-                timestamp: danmu_msg.timestamp,
-            }))
-        } else {
-            Err(DanmuStreamError::MessageParseError {
-                err: "Unknown message".to_string(),
-            })
-        }
+        let data = match event_type {
+            "danmu" => BiliDanmuMessage::new_from_ctx(self)
+                .map(|message| {
+                    json!({
+                        "user_id": message.uid,
+                        "user_name": message.username,
+                        "content": message.msg,
+                        "color": 0,
+                        "fan": message.fan,
+                        "fan_level": message.fan_level,
+                    })
+                })
+                .unwrap_or_else(|_| self.raw.get("data").cloned().unwrap_or(Value::Null)),
+            "gift" => super::send_gift::SendGift::new_from_ctx(self)
+                .map(|gift| {
+                    json!({
+                        "user_id": gift.uid,
+                        "user_name": gift.uname,
+                        "gift_name": gift.gift_name,
+                        "count": gift.num,
+                        "action": gift.action,
+                        "price": gift.price,
+                        "medal_name": gift.medal_name,
+                        "medal_level": gift.medal_level,
+                    })
+                })
+                .unwrap_or_else(|_| self.raw.get("data").cloned().unwrap_or(Value::Null)),
+            "super_chat" => super::super_chat::SuperChatMessage::new_from_ctx(self)
+                .map(|sc| {
+                    json!({
+                        "user_id": sc.uid,
+                        "user_name": sc.uname,
+                        "content": sc.msg,
+                        "price": sc.price,
+                        "duration": sc.time,
+                        "medal_name": sc.medal_name,
+                        "medal_level": sc.medal_level,
+                    })
+                })
+                .unwrap_or_else(|_| self.raw.get("data").cloned().unwrap_or(Value::Null)),
+            "enter" => super::interact_word::InteractWord::new_from_ctx(self)
+                .map(|enter| {
+                    json!({
+                        "user_id": enter.uid,
+                        "user_name": enter.uname,
+                        "medal_name": enter.fan,
+                        "medal_level": enter.fan_level,
+                    })
+                })
+                .unwrap_or_else(|_| self.raw.get("data").cloned().unwrap_or(Value::Null)),
+            _ => self.raw.get("data").cloned().unwrap_or(Value::Null),
+        };
+
+        Ok(DanmuMessageType::Event(LiveEvent {
+            ts: Utc::now().timestamp_millis(),
+            platform: "bilibili".to_string(),
+            room_id: String::new(),
+            event_type: event_type.to_string(),
+            data,
+            raw: self.raw.clone(),
+        }))
     }
 
     fn handle_cmd(&self) -> Option<&str> {
@@ -92,5 +160,38 @@ impl WsStreamCtx {
         };
 
         cmd
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_unknown_bilibili_events() {
+        let ctx = WsStreamCtx::new(r#"{"cmd":"WATCHED_CHANGE","data":{"num":7}}"#).unwrap();
+        let DanmuMessageType::Event(event) = ctx.match_msg().unwrap() else {
+            panic!("expected normalized event");
+        };
+
+        assert_eq!(event.event_type, "online");
+        assert_eq!(event.data["num"], 7);
+        assert_eq!(event.raw["cmd"], "WATCHED_CHANGE");
+    }
+
+    #[test]
+    fn normalizes_gifts_without_dropping_the_raw_payload() {
+        let ctx = WsStreamCtx::new(
+            r#"{"cmd":"SEND_GIFT","data":{"action":"赠送","giftName":"花束","num":2,"uname":"viewer","uid":42,"price":100}}"#,
+        )
+        .unwrap();
+        let DanmuMessageType::Event(event) = ctx.match_msg().unwrap() else {
+            panic!("expected normalized event");
+        };
+
+        assert_eq!(event.event_type, "gift");
+        assert_eq!(event.data["gift_name"], "花束");
+        assert_eq!(event.data["count"], 2);
+        assert_eq!(event.raw["data"]["uid"], 42);
     }
 }

--- a/src-tauri/crates/danmu_stream/src/provider/douyin.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/douyin.rs
@@ -352,7 +352,7 @@ async fn handle_binary_message(
                 if let Some(user) = gift_msg.user {
                     if let Some(gift) = gift_msg.gift {
                         log::debug!("Received gift: {} from user: {}", gift.name, user.nick_name);
-                        tx.send(DanmuMessageType::Event(LiveEvent::new(
+                        let event = LiveEvent::new(
                             "douyin",
                             room_id,
                             "gift",
@@ -363,8 +363,12 @@ async fn handle_binary_message(
                                 "count": gift_msg.repeat_count.max(gift_msg.combo_count).max(1),
                                 "diamond_count": gift.diamond_count,
                             }),
-                        )))
-                        .map_err(|e| {
+                        )
+                        .with_raw(json!({
+                            "method": "WebcastGiftMessage",
+                            "payload_hex": hex::encode(&message.payload),
+                        }));
+                        tx.send(DanmuMessageType::Event(event)).map_err(|e| {
                             DanmuStreamError::WebsocketError {
                                 err: format!("Failed to send gift event: {}", e),
                             }
@@ -384,7 +388,7 @@ async fn handle_binary_message(
                         like_msg.count,
                         user.nick_name
                     );
-                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                    let event = LiveEvent::new(
                         "douyin",
                         room_id,
                         "like",
@@ -394,9 +398,15 @@ async fn handle_binary_message(
                             "count": like_msg.count,
                             "total": like_msg.total,
                         }),
-                    )))
-                    .map_err(|e| DanmuStreamError::WebsocketError {
-                        err: format!("Failed to send like event: {}", e),
+                    )
+                    .with_raw(json!({
+                        "method": "WebcastLikeMessage",
+                        "payload_hex": hex::encode(&message.payload),
+                    }));
+                    tx.send(DanmuMessageType::Event(event)).map_err(|e| {
+                        DanmuStreamError::WebsocketError {
+                            err: format!("Failed to send like event: {}", e),
+                        }
                     })?;
                 }
             }
@@ -413,7 +423,7 @@ async fn handle_binary_message(
                         user.nick_name,
                         member_msg.action_description
                     );
-                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                    let event = LiveEvent::new(
                         "douyin",
                         room_id,
                         "enter",
@@ -422,9 +432,15 @@ async fn handle_binary_message(
                             "user_name": user.nick_name,
                             "action": member_msg.action_description,
                         }),
-                    )))
-                    .map_err(|e| DanmuStreamError::WebsocketError {
-                        err: format!("Failed to send member event: {}", e),
+                    )
+                    .with_raw(json!({
+                        "method": "WebcastMemberMessage",
+                        "payload_hex": hex::encode(&message.payload),
+                    }));
+                    tx.send(DanmuMessageType::Event(event)).map_err(|e| {
+                        DanmuStreamError::WebsocketError {
+                            err: format!("Failed to send member event: {}", e),
+                        }
                     })?;
                 }
             }

--- a/src-tauri/crates/danmu_stream/src/provider/douyin.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/douyin.rs
@@ -22,7 +22,8 @@ use tokio_tungstenite::{
     connect_async, tungstenite::Message as WsMessage, MaybeTlsStream, WebSocketStream,
 };
 
-use crate::{provider::DanmuProvider, DanmuMessage, DanmuMessageType, DanmuStreamError};
+use crate::{provider::DanmuProvider, DanmuMessage, DanmuMessageType, DanmuStreamError, LiveEvent};
+use serde_json::json;
 
 const USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
@@ -351,6 +352,23 @@ async fn handle_binary_message(
                 if let Some(user) = gift_msg.user {
                     if let Some(gift) = gift_msg.gift {
                         log::debug!("Received gift: {} from user: {}", gift.name, user.nick_name);
+                        tx.send(DanmuMessageType::Event(LiveEvent::new(
+                            "douyin",
+                            room_id,
+                            "gift",
+                            json!({
+                                "user_id": user.id,
+                                "user_name": user.nick_name,
+                                "gift_name": gift.name,
+                                "count": gift_msg.repeat_count.max(gift_msg.combo_count).max(1),
+                                "diamond_count": gift.diamond_count,
+                            }),
+                        )))
+                        .map_err(|e| {
+                            DanmuStreamError::WebsocketError {
+                                err: format!("Failed to send gift event: {}", e),
+                            }
+                        })?;
                     }
                 }
             }
@@ -366,6 +384,20 @@ async fn handle_binary_message(
                         like_msg.count,
                         user.nick_name
                     );
+                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                        "douyin",
+                        room_id,
+                        "like",
+                        json!({
+                            "user_id": user.id,
+                            "user_name": user.nick_name,
+                            "count": like_msg.count,
+                            "total": like_msg.total,
+                        }),
+                    )))
+                    .map_err(|e| DanmuStreamError::WebsocketError {
+                        err: format!("Failed to send like event: {}", e),
+                    })?;
                 }
             }
             "WebcastMemberMessage" => {
@@ -381,6 +413,19 @@ async fn handle_binary_message(
                         user.nick_name,
                         member_msg.action_description
                     );
+                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                        "douyin",
+                        room_id,
+                        "enter",
+                        json!({
+                            "user_id": user.id,
+                            "user_name": user.nick_name,
+                            "action": member_msg.action_description,
+                        }),
+                    )))
+                    .map_err(|e| DanmuStreamError::WebsocketError {
+                        err: format!("Failed to send member event: {}", e),
+                    })?;
                 }
             }
             _ => {

--- a/src-tauri/crates/danmu_stream/src/provider/kuaishou.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/kuaishou.rs
@@ -301,23 +301,55 @@ impl KuaishouDanmu {
                     tx.send(DanmuMessageType::DanmuMessage(danmu))
                         .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
                 }
-                for _gift in feed.gift_feeds {
-                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                for gift in feed.gift_feeds {
+                    let user_id = gift.user.as_ref().map(|user| user.principal_id.clone());
+                    let user_name = gift.user.as_ref().map(|user| user.user_name.clone());
+                    let event = LiveEvent::new(
                         "kuaishou",
                         &room_id,
                         "gift",
-                        json!({ "count": 1 }),
-                    )))
-                    .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
+                        json!({
+                            "id": gift.id.clone(),
+                            "user_id": user_id,
+                            "user_name": user_name,
+                            "gift_id": gift.gift_id,
+                            "count": gift.batch_size.max(gift.combo_count).max(1),
+                            "combo_count": gift.combo_count,
+                            "star_level": gift.star_level,
+                            "time": gift.time,
+                        }),
+                    )
+                    .with_raw(json!({
+                        "payload_type": "SC_FEED_PUSH",
+                        "gift": {
+                            "id": gift.id.clone(),
+                            "user_id": gift.user.as_ref().map(|user| &user.principal_id),
+                            "user_name": gift.user.as_ref().map(|user| &user.user_name),
+                            "time": gift.time,
+                            "gift_id": gift.gift_id,
+                            "batch_size": gift.batch_size,
+                            "combo_count": gift.combo_count,
+                            "star_level": gift.star_level,
+                        },
+                        "payload_hex": hex::encode(&payload),
+                    }));
+                    tx.send(DanmuMessageType::Event(event))
+                        .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
                 }
                 if feed.pending_like_count > 0 {
-                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                    let event = LiveEvent::new(
                         "kuaishou",
                         &room_id,
                         "like",
                         json!({ "count": feed.pending_like_count }),
-                    )))
-                    .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
+                    )
+                    .with_raw(json!({
+                        "payload_type": "SC_FEED_PUSH",
+                        "pending_like_count": feed.pending_like_count,
+                        "payload_hex": hex::encode(&payload),
+                    }));
+                    tx.send(DanmuMessageType::Event(event))
+                        .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
                 }
             }
         }

--- a/src-tauri/crates/danmu_stream/src/provider/kuaishou.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/kuaishou.rs
@@ -23,8 +23,9 @@ use tokio_tungstenite::{connect_async, tungstenite::Message as WsMessage};
 
 use crate::{
     provider::{DanmuMessageType, DanmuProvider},
-    DanmuMessage, DanmuStreamError,
+    DanmuMessage, DanmuStreamError, LiveEvent,
 };
+use serde_json::json;
 
 use messages::{
     CompressionType, CsHeartbeat, CsWebEnterRoom, PayloadType, ScWebFeedPush, SocketMessage,
@@ -299,6 +300,24 @@ impl KuaishouDanmu {
                     };
                     tx.send(DanmuMessageType::DanmuMessage(danmu))
                         .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
+                }
+                for _gift in feed.gift_feeds {
+                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                        "kuaishou",
+                        &room_id,
+                        "gift",
+                        json!({ "count": 1 }),
+                    )))
+                    .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
+                }
+                if feed.pending_like_count > 0 {
+                    tx.send(DanmuMessageType::Event(LiveEvent::new(
+                        "kuaishou",
+                        &room_id,
+                        "like",
+                        json!({ "count": feed.pending_like_count }),
+                    )))
+                    .map_err(|e| DanmuStreamError::WebsocketError { err: e.to_string() })?;
                 }
             }
         }

--- a/src-tauri/crates/danmu_stream/src/provider/kuaishou/messages.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/kuaishou/messages.rs
@@ -105,10 +105,54 @@ pub struct SimpleUserInfo {
 }
 
 #[derive(Clone, PartialEq, Message)]
-pub struct WebGiftFeed {}
+pub struct WebGiftFeed {
+    #[prost(string, tag = "1")]
+    pub id: String,
+    #[prost(message, optional, tag = "2")]
+    pub user: Option<SimpleUserInfo>,
+    #[prost(uint64, tag = "3")]
+    pub time: u64,
+    #[prost(uint32, tag = "4")]
+    pub gift_id: u32,
+    #[prost(uint64, tag = "5")]
+    pub sort_rank: u64,
+    #[prost(string, tag = "6")]
+    pub merge_key: String,
+    #[prost(uint32, tag = "7")]
+    pub batch_size: u32,
+    #[prost(uint32, tag = "8")]
+    pub combo_count: u32,
+    #[prost(uint32, tag = "9")]
+    pub rank: u32,
+    #[prost(uint64, tag = "10")]
+    pub expire_duration: u64,
+    #[prost(uint64, tag = "11")]
+    pub client_timestamp: u64,
+    #[prost(uint64, tag = "12")]
+    pub slot_display_duration: u64,
+    #[prost(uint32, tag = "13")]
+    pub star_level: u32,
+    #[prost(uint32, tag = "14")]
+    pub style_type: u32,
+    #[prost(uint32, tag = "15")]
+    pub live_assistant_type: u32,
+    #[prost(string, tag = "16")]
+    pub device_hash: String,
+    #[prost(bool, tag = "17")]
+    pub danmaku_display: bool,
+}
 
 #[derive(Clone, PartialEq, Message)]
-pub struct WebLikeFeed {}
+pub struct WebLikeFeed {
+    #[prost(string, tag = "1")]
+    pub id: String,
+    #[prost(message, optional, tag = "2")]
+    pub user: Option<SimpleUserInfo>,
+    #[prost(uint64, tag = "3")]
+    pub sort_rank: u64,
+    #[prost(string, tag = "4")]
+    pub device_hash: String,
+}
 
 #[derive(Clone, PartialEq, Message)]
 pub struct WebComboCommentFeed {}

--- a/src-tauri/crates/danmu_stream/src/provider/mod.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/mod.rs
@@ -39,23 +39,27 @@ pub trait DanmuProvider: Send + Sync {
 ///
 /// # Arguments
 ///
-/// * `tx` - An unbounded sender channel that will receive danmu messages
 /// * `provider_type` - The type of platform to fetch danmu from (BiliBili or Douyin)
 /// * `identifier` - User validation information (e.g., cookies) required by the platform
 /// * `room_id` - The unique identifier of the room/channel to fetch danmu from. Notice that douyin room_id is more like a live_id, it changes every time the live starts.
 ///
 /// # Returns
 ///
-/// Returns `Result<(), DanmmuStreamError>` where:
-/// * `Ok(())` indicates successful initialization and start of the provider, only return after disconnect
-/// * `Err(DanmmuStreamError)` indicates an error occurred during initialization or startup
+/// Returns a provider whose `start` method initializes the websocket:
+/// * `Ok(...)` indicates successful provider initialization
+/// * `Err(DanmuStreamError)` indicates an error occurred during initialization
 ///
 /// # Examples
 ///
-/// ```rust
-/// use tokio::sync::mpsc;
-/// let (tx, mut rx) = mpsc::unbounded_channel();
-/// new(tx, ProviderType::BiliBili, "your_cookie", 123456).await?;
+/// ```no_run
+/// use danmu_stream::provider::{new, ProviderType};
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let _provider = new(ProviderType::BiliBili, "your_cookie", "123456")
+///         .await
+///         .expect("provider initialization failed");
+/// }
 /// ```
 pub async fn new(
     provider_type: ProviderType,

--- a/src-tauri/crates/recorder/src/danmu.rs
+++ b/src-tauri/crates/recorder/src/danmu.rs
@@ -1,6 +1,8 @@
 use std::path::PathBuf;
 
+use danmu_stream::LiveEvent;
 use serde::Serialize;
+use serde_json::Value;
 use tokio::io::AsyncWriteExt;
 use tokio::{
     fs::{File, OpenOptions},
@@ -15,7 +17,7 @@ pub struct DanmuEntry {
 }
 
 pub struct DanmuStorage {
-    cache: RwLock<Vec<DanmuEntry>>,
+    cache: RwLock<Vec<LiveEvent>>,
     file: RwLock<File>,
 }
 
@@ -35,12 +37,26 @@ impl DanmuStorage {
         let file = file.unwrap();
         let reader = BufReader::new(file);
         let mut lines = reader.lines();
-        let mut preload_cache: Vec<DanmuEntry> = Vec::new();
+        let mut preload_cache: Vec<LiveEvent> = Vec::new();
         while let Ok(Some(line)) = lines.next_line().await {
-            let parts: Vec<&str> = line.split(':').collect();
-            let ts: i64 = parts[0].parse().unwrap();
-            let content = parts[1].to_string();
-            preload_cache.push(DanmuEntry { ts, content });
+            if let Ok(event) = serde_json::from_str::<LiveEvent>(&line) {
+                preload_cache.push(event);
+            } else {
+                // Read old recordings as a migration aid. New writes are
+                // always JSONL and never append to the legacy format.
+                let Some((ts, content)) = line.split_once(':') else {
+                    continue;
+                };
+                let Ok(ts) = ts.parse() else { continue };
+                preload_cache.push(LiveEvent {
+                    ts,
+                    platform: "unknown".to_string(),
+                    room_id: String::new(),
+                    event_type: "danmu".to_string(),
+                    data: serde_json::json!({ "content": content }),
+                    raw: Value::Null,
+                });
+            }
         }
         // lines.next_line() consumes the reader, so the file is closed when lines is dropped
         drop(lines);
@@ -61,17 +77,26 @@ impl DanmuStorage {
         })
     }
 
+    pub async fn add_event(&self, event: LiveEvent) {
+        let Ok(mut line) = serde_json::to_string(&event) else {
+            log::error!("Serialize live event failed");
+            return;
+        };
+        line.push('\n');
+        self.cache.write().await.push(event);
+        let _ = self.file.write().await.write_all(line.as_bytes()).await;
+    }
+
     pub async fn add_line(&self, ts: i64, content: &str) {
-        self.cache.write().await.push(DanmuEntry {
+        self.add_event(LiveEvent {
             ts,
-            content: content.to_string(),
-        });
-        let _ = self
-            .file
-            .write()
-            .await
-            .write(format!("{ts}:{content}\n").as_bytes())
-            .await;
+            platform: "unknown".to_string(),
+            room_id: String::new(),
+            event_type: "danmu".to_string(),
+            data: serde_json::json!({ "content": content }),
+            raw: Value::Null,
+        })
+        .await;
     }
 
     // get entries with ts relative to live start time
@@ -81,9 +106,14 @@ impl DanmuStorage {
             .read()
             .await
             .iter()
-            .map(|entry| DanmuEntry {
-                ts: entry.ts - live_start_ts,
-                content: entry.content.clone(),
+            .filter(|event| event.event_type == "danmu")
+            .filter_map(|event| {
+                event.data.get("content").and_then(|content| {
+                    content.as_str().map(|content| DanmuEntry {
+                        ts: event.ts - live_start_ts,
+                        content: content.to_string(),
+                    })
+                })
             })
             .collect();
         // filter out danmus with ts < 0

--- a/src-tauri/crates/recorder/src/danmu.rs
+++ b/src-tauri/crates/recorder/src/danmu.rs
@@ -77,17 +77,20 @@ impl DanmuStorage {
         })
     }
 
-    pub async fn add_event(&self, event: LiveEvent) {
+    pub async fn add_event(&self, event: LiveEvent) -> Result<(), std::io::Error> {
         let Ok(mut line) = serde_json::to_string(&event) else {
-            log::error!("Serialize live event failed");
-            return;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "serialize live event failed",
+            ));
         };
         line.push('\n');
+        self.file.write().await.write_all(line.as_bytes()).await?;
         self.cache.write().await.push(event);
-        let _ = self.file.write().await.write_all(line.as_bytes()).await;
+        Ok(())
     }
 
-    pub async fn add_line(&self, ts: i64, content: &str) {
+    pub async fn add_line(&self, ts: i64, content: &str) -> Result<(), std::io::Error> {
         self.add_event(LiveEvent {
             ts,
             platform: "unknown".to_string(),
@@ -96,7 +99,7 @@ impl DanmuStorage {
             data: serde_json::json!({ "content": content }),
             raw: Value::Null,
         })
-        .await;
+        .await
     }
 
     // get entries with ts relative to live start time

--- a/src-tauri/crates/recorder/src/platforms/bilibili.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili.rs
@@ -293,7 +293,9 @@ impl BiliRecorder {
                                         );
                                     }
                                     if let Some(storage) = self.danmu_storage.write().await.as_ref() {
-                                        storage.add_event(event).await;
+                                        if let Err(error) = storage.add_event(event).await {
+                                            log::error!("Failed to persist live event: {error}");
+                                        }
                                     }
                                 }
                                 DanmuMessageType::DanmuMessage(danmu) => {
@@ -306,7 +308,9 @@ impl BiliRecorder {
                                         room: self.room_id.clone(), ts, content,
                                     });
                                     if let Some(storage) = self.danmu_storage.write().await.as_ref() {
-                                        storage.add_event(event).await;
+                                        if let Err(error) = storage.add_event(event).await {
+                                            log::error!("Failed to persist danmu event: {error}");
+                                        }
                                     }
                                 }
                             }

--- a/src-tauri/crates/recorder/src/platforms/bilibili.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili.rs
@@ -19,7 +19,7 @@ use crate::platforms::bilibili::api::BiliStream;
 use chrono::Utc;
 use danmu_stream::danmu_stream::DanmuStream;
 use danmu_stream::provider::ProviderType;
-use danmu_stream::DanmuMessageType;
+use danmu_stream::{DanmuMessageType, LiveEvent};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{atomic, Arc};
@@ -276,15 +276,37 @@ impl BiliRecorder {
                     match recv_res {
                         Ok(Some(msg)) => {
                             match msg {
+                                DanmuMessageType::Event(event) => {
+                                    let ts = event.ts;
+                                    if event.event_type == "danmu" {
+                                        let content = event.data
+                                            .get("content")
+                                            .and_then(|value| value.as_str())
+                                            .unwrap_or_default()
+                                            .to_string();
+                                        let _ = self.event_channel.send(
+                                            RecorderEvent::DanmuReceived {
+                                                room: self.room_id.clone(),
+                                                ts,
+                                                content,
+                                            },
+                                        );
+                                    }
+                                    if let Some(storage) = self.danmu_storage.write().await.as_ref() {
+                                        storage.add_event(event).await;
+                                    }
+                                }
                                 DanmuMessageType::DanmuMessage(danmu) => {
-                                    let ts = Utc::now().timestamp_millis();
+                                    let event = LiveEvent::danmu(danmu, "bilibili");
+                                    let ts = event.ts;
+                                    let content = event.data.get("content")
+                                        .and_then(|value| value.as_str())
+                                        .unwrap_or_default().to_string();
                                     let _ = self.event_channel.send(RecorderEvent::DanmuReceived {
-                                        room: self.room_id.clone(),
-                                        ts,
-                                        content: danmu.message.clone(),
+                                        room: self.room_id.clone(), ts, content,
                                     });
                                     if let Some(storage) = self.danmu_storage.write().await.as_ref() {
-                                        storage.add_line(ts, &danmu.message).await;
+                                        storage.add_event(event).await;
                                     }
                                 }
                             }
@@ -315,7 +337,7 @@ impl BiliRecorder {
 
         let _ = tokio::fs::create_dir_all(&work_dir.full_path()).await;
 
-        let danmu_path = work_dir.with_filename("danmu.txt");
+        let danmu_path = work_dir.with_filename("events.jsonl");
         *self.danmu_storage.write().await = DanmuStorage::new(&danmu_path.full_path()).await;
 
         let cover_path = work_dir.with_filename("cover.jpg");

--- a/src-tauri/crates/recorder/src/platforms/douyin.rs
+++ b/src-tauri/crates/recorder/src/platforms/douyin.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use danmu_stream::danmu_stream::DanmuStream;
 use danmu_stream::provider::ProviderType;
-use danmu_stream::DanmuMessageType;
+use danmu_stream::{DanmuMessageType, LiveEvent};
 use rand::random;
 use std::path::PathBuf;
 use std::sync::{atomic, Arc};
@@ -208,6 +208,11 @@ impl DouyinRecorder {
                     match recv_res {
                         Ok(Some(msg)) => {
                             match msg {
+                                DanmuMessageType::Event(event) => {
+                                    if let Some(storage) = self.danmu_storage.read().await.as_ref() {
+                                        storage.add_event(event).await;
+                                    }
+                                }
                                 DanmuMessageType::DanmuMessage(danmu) => {
                                     let ts = Utc::now().timestamp_millis();
                                     let _ = self.event_channel.send(RecorderEvent::DanmuReceived {
@@ -217,7 +222,7 @@ impl DouyinRecorder {
                                     });
 
                                     if let Some(danmu_storage) = self.danmu_storage.read().await.as_ref() {
-                                        danmu_storage.add_line(ts, &danmu.message).await;
+                                        danmu_storage.add_event(LiveEvent::danmu(danmu, "douyin")).await;
                                     }
                                 }
                             }
@@ -268,7 +273,7 @@ impl DouyinRecorder {
         let _ = api::download_file(&self.client, &cover_url, &cover_path.full_path()).await;
 
         // Setup danmu store
-        let danmu_file_path = work_dir.with_filename("danmu.txt");
+        let danmu_file_path = work_dir.with_filename("events.jsonl");
         let danmu_storage = DanmuStorage::new(&danmu_file_path.full_path()).await;
         *self.danmu_storage.write().await = danmu_storage;
 

--- a/src-tauri/crates/recorder/src/platforms/douyin.rs
+++ b/src-tauri/crates/recorder/src/platforms/douyin.rs
@@ -210,7 +210,9 @@ impl DouyinRecorder {
                             match msg {
                                 DanmuMessageType::Event(event) => {
                                     if let Some(storage) = self.danmu_storage.read().await.as_ref() {
-                                        storage.add_event(event).await;
+                                        if let Err(error) = storage.add_event(event).await {
+                                            log::error!("Failed to persist live event: {error}");
+                                        }
                                     }
                                 }
                                 DanmuMessageType::DanmuMessage(danmu) => {
@@ -222,7 +224,12 @@ impl DouyinRecorder {
                                     });
 
                                     if let Some(danmu_storage) = self.danmu_storage.read().await.as_ref() {
-                                        danmu_storage.add_event(LiveEvent::danmu(danmu, "douyin")).await;
+                                        if let Err(error) = danmu_storage
+                                            .add_event(LiveEvent::danmu(danmu, "douyin"))
+                                            .await
+                                        {
+                                            log::error!("Failed to persist danmu event: {error}");
+                                        }
                                     }
                                 }
                             }

--- a/src-tauri/crates/recorder/src/platforms/huya/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/huya/mod.rs
@@ -148,7 +148,7 @@ impl HuyaRecorder {
         *self.live_id.write().await = live_id.to_string();
 
         // Setup danmu store
-        let danmu_file_path = work_dir.with_filename("danmu.txt");
+        let danmu_file_path = work_dir.with_filename("events.jsonl");
         let danmu_storage = DanmuStorage::new(&danmu_file_path.full_path()).await;
         *self.danmu_storage.write().await = danmu_storage;
 

--- a/src-tauri/crates/recorder/src/platforms/kuaishou/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/kuaishou/mod.rs
@@ -237,7 +237,9 @@ impl KuaishouRecorder {
                             match msg {
                                 danmu_stream::DanmuMessageType::Event(event) => {
                                     if let Some(storage) = self.danmu_storage.write().await.as_ref() {
-                                        storage.add_event(event).await;
+                                        if let Err(error) = storage.add_event(event).await {
+                                            log::error!("Failed to persist live event: {error}");
+                                        }
                                     }
                                 }
                                 danmu_stream::DanmuMessageType::DanmuMessage(danmu) => {
@@ -248,12 +250,15 @@ impl KuaishouRecorder {
                                         content: danmu.message.clone(),
                                     });
                                     if let Some(storage) = self.danmu_storage.write().await.as_ref() {
-                                        storage
+                                        if let Err(error) = storage
                                             .add_event(danmu_stream::LiveEvent::danmu(
                                                 danmu,
                                                 "kuaishou",
                                             ))
-                                            .await;
+                                            .await
+                                        {
+                                            log::error!("Failed to persist danmu event: {error}");
+                                        }
                                     }
                                 }
                             }

--- a/src-tauri/crates/recorder/src/platforms/kuaishou/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/kuaishou/mod.rs
@@ -235,6 +235,11 @@ impl KuaishouRecorder {
                     match recv_res {
                         Ok(Some(msg)) => {
                             match msg {
+                                danmu_stream::DanmuMessageType::Event(event) => {
+                                    if let Some(storage) = self.danmu_storage.write().await.as_ref() {
+                                        storage.add_event(event).await;
+                                    }
+                                }
                                 danmu_stream::DanmuMessageType::DanmuMessage(danmu) => {
                                     let ts = Utc::now().timestamp_millis();
                                     let _ = self.event_channel.send(RecorderEvent::DanmuReceived {
@@ -243,7 +248,12 @@ impl KuaishouRecorder {
                                         content: danmu.message.clone(),
                                     });
                                     if let Some(storage) = self.danmu_storage.write().await.as_ref() {
-                                        storage.add_line(ts, &danmu.message).await;
+                                        storage
+                                            .add_event(danmu_stream::LiveEvent::danmu(
+                                                danmu,
+                                                "kuaishou",
+                                            ))
+                                            .await;
                                     }
                                 }
                             }
@@ -280,7 +290,7 @@ impl KuaishouRecorder {
         let cover_path = work_dir.with_filename("cover.jpg");
         let _ = api::download_file(&self.client, &cover_url, &cover_path.full_path()).await;
 
-        let danmu_path = work_dir.with_filename("danmu.txt");
+        let danmu_path = work_dir.with_filename("events.jsonl");
         *self.danmu_storage.write().await = DanmuStorage::new(&danmu_path.full_path()).await;
 
         *self.live_id.write().await = live_id.to_string();

--- a/src-tauri/crates/recorder/src/platforms/tiktok/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/tiktok/mod.rs
@@ -191,7 +191,7 @@ impl TikTokRecorder {
         let cover_path = work_dir.with_filename("cover.jpg");
         let _ = api::download_file(&self.client, &cover_url, &cover_path.full_path()).await;
 
-        let danmu_path = work_dir.with_filename("danmu.txt");
+        let danmu_path = work_dir.with_filename("events.jsonl");
         *self.danmu_storage.write().await = DanmuStorage::new(&danmu_path.full_path()).await;
 
         *self.live_id.write().await = live_id.to_string();

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -888,13 +888,19 @@ impl RecorderManager {
     ) -> Result<Vec<DanmuEntry>, RecorderManagerError> {
         let cache_path = self.config.read().await.cache.clone();
         let cache_path = Path::new(&cache_path);
-        let danmus_path = cache_path
+        let mut danmus_path = cache_path
             .join(platform.as_str())
             .join(room_id)
             .join(live_id)
-            .join("danmu.txt");
+            .join("events.jsonl");
         if !danmus_path.exists() {
-            return Ok(Vec::new());
+            // Keep existing archives readable after the storage format
+            // migration. New recordings only create events.jsonl.
+            let legacy_path = danmus_path.with_file_name("danmu.txt");
+            if !legacy_path.exists() {
+                return Ok(Vec::new());
+            }
+            danmus_path = legacy_path;
         }
         let Some(storage) = DanmuStorage::new(&danmus_path).await else {
             log::error!("Failed to load danmu storage: {danmus_path:?}");


### PR DESCRIPTION
## Summary
- replace per-recording `danmu.txt` writes with `events.jsonl`
- add a normalized cross-platform `LiveEvent` format with preserved raw payloads
- record Bilibili danmu, gifts, Super Chat, online and room events, plus Douyin/Kuaishou gift and danmu-related events
- keep legacy `danmu.txt` loading compatible
- report Bilibili API error responses such as `-352` clearly instead of `missing field data`

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p danmu_stream --lib`
- `cargo test -p danmu_stream --doc`
- `cargo check -p recorder`

The full workspace check remains dependent on the local `whisper.cpp` submodule being initialized.

## Summary by Sourcery

Replace per-recording danmu text files with normalized JSONL event storage while retaining legacy archive readability and provider payload fidelity.

New Features:
- Persist decoded live-room events from Bilibili, Douyin, and Kuaishou in a normalized JSONL format with original provider payloads retained.
- Capture a broader set of live events, including messages, gifts, Super Chats, joins, likes, online updates, and room updates.

Bug Fixes:
- Report Bilibili API error codes and messages directly instead of exposing misleading deserialization errors.
- Preserve compatibility when loading recordings stored in the legacy danmu.txt format.

Enhancements:
- Document the cross-platform LiveEvent schema and event categories.
- Improve validation of Bilibili API and WBI navigation responses.

Documentation:
- Document the normalized events.jsonl format and its supported event categories.

Tests:
- Add coverage for Bilibili API error reporting and normalized event payloads with raw data preservation.