### PR TITLE
fix: prevent preview effect update loops

### DIFF
--- a/src/AppLive.svelte
+++ b/src/AppLive.svelte
@@ -536,7 +536,12 @@
         // 否则直接复制所有弹幕
         filtered_danmu = [...danmu_records];
       }
-      // 重新计算可见区域
+    }
+  });
+  // 过滤结果变化后重新计算可见区域。与过滤 effect 分开，避免读取并写入
+  // filtered_danmu 的同一个 effect 触发无限更新。
+  $effect(() => {
+    if (container_ref && filtered_danmu.length > 0) {
       calculate_visible_danmu();
     }
   });

--- a/src/lib/components/CoverEditor.svelte
+++ b/src/lib/components/CoverEditor.svelte
@@ -360,6 +360,7 @@
         content: text.content,
         fontSize: text.fontSize,
         color: text.color,
+        strokeColor: text.strokeColor,
         position: text.position,
       }));
       scheduleRedraw();

--- a/src/lib/components/CoverEditor.svelte
+++ b/src/lib/components/CoverEditor.svelte
@@ -353,18 +353,15 @@
   $effect(() => {
     // 当文本内容或样式改变时重绘
     if (ctx) {
-      texts = texts.map((text) => {
-        if (text.id === selectedTextId) {
-          return {
-            ...text,
-            content: text.content,
-            fontSize: text.fontSize,
-            color: text.color,
-            position: text.position,
-          };
-        }
-        return text;
-      });
+      // Read the fields that affect the canvas so nested $state changes
+      // invalidate this effect without writing back to the same state.
+      texts.map((text) => ({
+        id: text.id,
+        content: text.content,
+        fontSize: text.fontSize,
+        color: text.color,
+        position: text.position,
+      }));
       scheduleRedraw();
     }
   });

--- a/src/lib/components/VideoPreview.svelte
+++ b/src/lib/components/VideoPreview.svelte
@@ -1357,17 +1357,20 @@
     timelineTotalHeight = 148 + subtitleTrackHeight;
   });
   $effect(() => {
-    currentSubtitleIndices = subtitles
+    const activeSubtitleIndices = subtitles
       .map((subtitle, index) => ({ subtitle, index }))
       .filter(
         ({ subtitle }) =>
           currentTime >= subtitle.startTime && currentTime < subtitle.endTime
       )
       .map(({ index }) => index);
-    currentSubtitleIndex = currentSubtitleIndices[0] ?? -1;
-    currentSubtitles = currentSubtitleIndices
+    const activeSubtitles = activeSubtitleIndices
       .map((index) => subtitles[index])
       .sort((a, b) => a.layerOrder - b.layerOrder);
+
+    currentSubtitleIndices = activeSubtitleIndices;
+    currentSubtitleIndex = activeSubtitleIndices[0] ?? -1;
+    currentSubtitles = activeSubtitles;
   });
   $effect(() => {
     window.localStorage.setItem("profile-" + roomId, JSON.stringify(profile));


### PR DESCRIPTION
## Summary
- avoid self-triggering Svelte effects when deriving subtitle state
- stop the cover editor from rewriting its own text state during redraw
- separate live danmu filtering from viewport calculations

## Validation
- `yarn run check`
- `yarn build`

## Summary by Sourcery

Prevent reactive preview updates from looping while keeping subtitle, cover-editor, and live danmu state synchronized.

Bug Fixes:
- Prevent preview and cover-editor reactive effects from triggering unnecessary self-updates or update loops.
- Ensure subtitle filtering and visible danmu recalculation update independently without recursive state changes.

Enhancements:
- Improve reactive state derivation for subtitle, canvas text, and live danmu updates.