### PR TITLE
fix: preserve live session for automatic full recordings

### DIFF
--- a/src-tauri/crates/recorder/src/platforms/bilibili.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili.rs
@@ -98,13 +98,31 @@ impl BiliRecorder {
         log::error!("[{}]{}", self.room_id, message);
     }
 
-    pub async fn reset(&self) {
+    // A recording attempt can end while the same live session is still running.
+    async fn reset_recording(&self) {
+        self.is_recording.store(false, Ordering::Relaxed);
         *self.extra.live_stream.write().await = None;
         self.last_update
             .store(Utc::now().timestamp(), atomic::Ordering::Relaxed);
         *self.danmu_storage.write().await = None;
-        *self.platform_live_id.write().await = String::new();
         *self.live_id.write().await = String::new();
+    }
+
+    async fn reset_live(&self) {
+        self.reset_recording().await;
+        self.platform_live_id.write().await.clear();
+        *self.extra.pre_live_id.write().await = None;
+        self.extra.should_continue.store(false, Ordering::Relaxed);
+    }
+
+    async fn end_live(&self) {
+        // The event owns a snapshot, so the session can be cleared after sending it.
+        let _ = self.event_channel.send(RecorderEvent::LiveEnd {
+            platform: PlatformType::BiliBili,
+            room_id: self.room_id.to_string(),
+            recorder: self.info().await,
+        });
+        self.reset_live().await;
     }
 
     async fn check_status(&self) -> bool {
@@ -143,6 +161,13 @@ impl BiliRecorder {
                 }
                 let live_status = room_info.live_status == 1;
 
+                if live_status {
+                    if !pre_live_status {
+                        self.reset_live().await;
+                    }
+                    *self.platform_live_id.write().await = room_info.live_start_time.to_string();
+                }
+
                 // handle live notification
                 if pre_live_status != live_status {
                     self.log_info(&format!(
@@ -172,19 +197,9 @@ impl BiliRecorder {
                             recorder: self.info().await,
                         });
                     } else {
-                        let _ = self.event_channel.send(RecorderEvent::LiveEnd {
-                            platform: PlatformType::BiliBili,
-                            room_id: self.room_id.to_string(),
-                            recorder: self.info().await,
-                        });
-                        *self.live_id.write().await = String::new();
+                        self.end_live().await;
                     }
-
-                    // just doing reset, cuz live status is changed
-                    self.reset().await;
                 }
-
-                *self.platform_live_id.write().await = room_info.live_start_time.to_string();
 
                 if !live_status {
                     return false;
@@ -466,11 +481,7 @@ impl crate::traits::RecorderTrait<BiliExtra> for BiliRecorder {
                         });
                     }
 
-                    self_clone
-                        .is_recording
-                        .store(false, atomic::Ordering::Relaxed);
-
-                    self_clone.reset().await;
+                    self_clone.reset_recording().await;
                     // if should continue with previous recording, no need to sleep
                     if self_clone.extra.should_continue.load(Ordering::Relaxed) {
                         continue;
@@ -492,6 +503,99 @@ impl crate::traits::RecorderTrait<BiliExtra> for BiliRecorder {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    struct UnusedUserInfoCache;
+
+    #[async_trait]
+    impl UserInfoCache for UnusedUserInfoCache {
+        async fn get_user_info(&self, _: &str) -> Result<Option<UserInfo>, String> {
+            panic!("lifecycle tests must not request user info")
+        }
+
+        async fn save_user_info(&self, _: &UserInfo) -> Result<(), String> {
+            panic!("lifecycle tests must not save user info")
+        }
+    }
+
+    async fn recording_fixture() -> (BiliRecorder, broadcast::Receiver<RecorderEvent>) {
+        let (tx, rx) = broadcast::channel(10);
+        let recorder = BiliRecorder::new(
+            "10220184",
+            &Account::default(),
+            std::env::temp_dir().join(format!("bsr-lifecycle-{}", uuid::Uuid::new_v4())),
+            tx,
+            Arc::new(atomic::AtomicU64::new(30)),
+            true,
+            Arc::new(UnusedUserInfoCache),
+        )
+        .await
+        .unwrap();
+        *recorder.platform_live_id.write().await = "session-1".into();
+        *recorder.live_id.write().await = "segment-1".into();
+        *recorder.extra.pre_live_id.write().await = Some("segment-1".into());
+        recorder.extra.should_continue.store(true, Ordering::Relaxed);
+        recorder.is_recording.store(true, Ordering::Relaxed);
+        *recorder.extra.live_stream.write().await = Some(BiliStream::new(
+            Format::TS,
+            Codec::Avc,
+            "/expired.m3u8",
+            vec![],
+            false,
+            None,
+        ));
+        (recorder, rx)
+    }
+
+    #[tokio::test]
+    async fn recording_reset_preserves_session_and_expiry_resume_state() {
+        let (recorder, _) = recording_fixture().await;
+        tokio::fs::create_dir_all(&recorder.cache_dir).await.unwrap();
+        *recorder.danmu_storage.write().await =
+            DanmuStorage::new(&recorder.cache_dir.join("events.jsonl")).await;
+        assert!(recorder.danmu_storage.read().await.is_some());
+
+        recorder.reset_recording().await;
+
+        let info = recorder.info().await;
+        assert_eq!(info.platform_live_id, "session-1");
+        assert!(info.live_id.is_empty());
+        assert!(!info.recording);
+        assert!(recorder.extra.live_stream.read().await.is_none());
+        assert!(recorder.danmu_storage.read().await.is_none());
+        assert_eq!(
+            recorder.extra.pre_live_id.read().await.as_deref(),
+            Some("segment-1")
+        );
+        assert!(recorder.extra.should_continue.load(Ordering::Relaxed));
+        tokio::fs::remove_dir_all(&recorder.cache_dir).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn live_end_after_recording_error_keeps_session_snapshot_and_clears_resume() {
+        let (recorder, mut rx) = recording_fixture().await;
+        recorder.reset_recording().await;
+
+        // A failed restart must not expose the previous segment as the current recording.
+        assert!(matches!(
+            recorder.update_entries("failed-segment").await,
+            Err(RecorderError::NoStreamAvailable)
+        ));
+        assert!(recorder.info().await.live_id.is_empty());
+
+        recorder.end_live().await;
+
+        let RecorderEvent::LiveEnd { recorder: ended, .. } = rx.try_recv().unwrap() else {
+            panic!("expected a live end event")
+        };
+        assert_eq!(ended.platform_live_id, "session-1");
+        assert!(ended.live_id.is_empty());
+        assert!(!ended.recording);
+        assert!(recorder.info().await.platform_live_id.is_empty());
+        assert!(recorder.extra.pre_live_id.read().await.is_none());
+        assert!(!recorder.extra.should_continue.load(Ordering::Relaxed));
+    }
+
     #[test]
     fn parse_fmp4_playlist() {
         let content = r#"#EXTM3U

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -200,6 +200,29 @@ impl From<RecorderManagerError> for String {
     }
 }
 
+/// Resolve the session even when the last recording attempt produced no archive.
+async fn live_end_parent_id(
+    db: &Database,
+    platform: PlatformType,
+    room_id: &str,
+    recorder: &RecorderInfo,
+) -> Result<Option<String>, DatabaseError> {
+    let parent_id = if !recorder.platform_live_id.is_empty() {
+        recorder.platform_live_id.clone()
+    } else if !recorder.live_id.is_empty() {
+        // Keep compatibility with recorders that only retain their current archive ID.
+        db.get_record(room_id, &recorder.live_id).await?.parent_id
+    } else {
+        return Ok(None);
+    };
+
+    let records = db.get_archives_by_parent_id(room_id, &parent_id).await?;
+    Ok(records
+        .iter()
+        .any(|record| record.platform == platform.as_str() && record.size > 0)
+        .then_some(parent_id))
+}
+
 impl RecorderManager {
     pub fn new(
         #[cfg(not(feature = "headless"))] app_handle: AppHandle,
@@ -408,14 +431,17 @@ impl RecorderManager {
 
         let recorder_id = format!("{}:{}", platform.as_str(), room_id);
         log::info!("Start auto generate for {recorder_id}");
-        let live_id = recorder.live_id.clone();
-        let live_record = self.db.get_record(room_id, &live_id).await;
-        if live_record.is_err() {
-            log::error!("Live not found in record: {room_id} {live_id}");
-            return;
-        }
-
-        let live_record = live_record.unwrap();
+        let parent_id = match live_end_parent_id(&self.db, platform, room_id, recorder).await {
+            Ok(Some(parent_id)) => parent_id,
+            Ok(None) => {
+                log::info!("No recorded archives for ended live: {recorder_id}");
+                return;
+            }
+            Err(error) => {
+                log::error!("Failed to find ended live archives for {recorder_id}: {error}");
+                return;
+            }
+        };
 
         let Ok(task) = self
             .db
@@ -425,7 +451,7 @@ impl RecorderManager {
                 &serde_json::json!({
                     "platform": platform.as_str(),
                     "room_id": room_id,
-                    "parent_id": live_record.parent_id,
+                    "parent_id": parent_id,
                 })
                 .to_string(),
             )
@@ -468,7 +494,7 @@ impl RecorderManager {
                                     .encode_danmu,
                                 platform: platform.as_str().to_string(),
                                 room_id,
-                                parent_id: live_record.parent_id,
+                                parent_id,
                                 selected_live_ids: None,
                                 output_name: None,
                             },
@@ -1707,5 +1733,127 @@ impl RecorderManager {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod live_end_tests {
+    use super::*;
+
+    async fn database() -> Database {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE records (
+                live_id TEXT PRIMARY KEY, platform TEXT, parent_id TEXT,
+                room_id TEXT, title TEXT, length REAL, size INTEGER,
+                created_at TEXT, cover TEXT
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let db = Database::new();
+        db.set(pool).await;
+        db
+    }
+
+    fn ended_recorder(parent_id: &str, live_id: &str) -> RecorderInfo {
+        RecorderInfo {
+            platform_live_id: parent_id.into(),
+            live_id: live_id.into(),
+            room_info: RoomInfo::default(),
+            user_info: UserInfo::default(),
+            recording: false,
+            enabled: true,
+        }
+    }
+
+    async fn add_archive(db: &Database, platform: PlatformType, parent: &str, live: &str) {
+        db.add_record(platform, parent, live, "10220184", "test", None)
+            .await
+            .unwrap();
+        db.update_record_delta(live, 4.0, 1024).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolves_entire_session_without_a_last_archive() {
+        let db = database().await;
+        add_archive(&db, PlatformType::BiliBili, "session-1", "segment-1").await;
+        add_archive(&db, PlatformType::BiliBili, "session-1", "segment-2").await;
+        add_archive(&db, PlatformType::BiliBili, "old-session", "old-segment").await;
+
+        // Covers both a reset current ID and a removed zero-byte final segment.
+        for live_id in ["", "removed-empty-segment"] {
+            let parent = live_end_parent_id(
+                &db,
+                PlatformType::BiliBili,
+                "10220184",
+                &ended_recorder("session-1", live_id),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+            assert_eq!(parent, "session-1");
+            let archives = db
+                .get_archives_by_parent_id("10220184", &parent)
+                .await
+                .unwrap();
+            assert_eq!(archives.len(), 2);
+            assert!(archives
+                .iter()
+                .all(|archive| archive.live_id.starts_with("segment-")));
+        }
+    }
+
+    #[tokio::test]
+    async fn skips_unrecorded_sessions_instead_of_using_another_live() {
+        let db = database().await;
+        add_archive(&db, PlatformType::BiliBili, "old-session", "old-segment").await;
+        add_archive(&db, PlatformType::Douyin, "session-1", "other-platform").await;
+        db.add_record(
+            PlatformType::BiliBili,
+            "session-1",
+            "empty-segment",
+            "10220184",
+            "test",
+            None,
+        )
+        .await
+        .unwrap();
+
+        for parent_id in ["", "session-1", "unrecorded-session"] {
+            assert_eq!(
+                live_end_parent_id(
+                    &db,
+                    PlatformType::BiliBili,
+                    "10220184",
+                    &ended_recorder(parent_id, ""),
+                )
+                .await
+                .unwrap(),
+                None
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn supports_recorders_that_only_provide_an_archive_id() {
+        let db = database().await;
+        add_archive(&db, PlatformType::Douyin, "session-1", "segment-1").await;
+        assert_eq!(
+            live_end_parent_id(
+                &db,
+                PlatformType::Douyin,
+                "10220184",
+                &ended_recorder("", "segment-1"),
+            )
+            .await
+            .unwrap(),
+            Some("session-1".into())
+        );
     }
 }


### PR DESCRIPTION
A Bilibili recording error cleared the session identifiers before the next status check emitted `LiveEnd`. Automatic full-recording generation then queried an empty archive ID and never created a task, even when earlier recording segments were available.

Preserve the live session ID across recording attempts while still clearing the stream URL, danmu storage, and current archive ID after each attempt. Emit the session snapshot before clearing it on live end, and clear expiry-resume state at session boundaries so it cannot carry into the next broadcast.

Automatic generation now resolves archives by session (`parent_id`), including when the final segment is missing or was removed as empty. Sessions without recorded data are skipped; recorders that only provide an archive ID retain a compatibility fallback.

Validation:
- Added five regression tests covering recording cleanup, expiry-resume state, the live-end snapshot, missing final archives, empty sessions, and the archive-ID fallback.
- Bilibili recorder lifecycle tests passed.
- Desktop and headless application tests passed.
- Desktop and headless Clippy checks, formatting, and whitespace checks passed.

Fixes #315

## Summary by Sourcery

Preserve live session context through recording failures and use it to reliably generate full recordings when a broadcast ends.

Bug Fixes:
- Preserve Bilibili live session identifiers across recording attempts so automatic full recordings are generated after recording errors or missing final segments.
- Prevent ended sessions without non-empty recorded archives from creating automatic generation tasks.

Enhancements:
- Emit live-end events with the final session snapshot before clearing live and expiry-resume state.
- Resolve automatic recording generation by session while retaining compatibility with recorders that provide only an archive identifier.

Tests:
- Add regression coverage for recording cleanup, live-end snapshots, session resolution with missing or empty final segments, unrecorded sessions, and archive-ID compatibility fallback.