### PR TITLE
refactor: remove panic-prone unwraps from production code

### DIFF
--- a/src-tauri/crates/danmu_stream/src/http_client.rs
+++ b/src-tauri/crates/danmu_stream/src/http_client.rs
@@ -49,7 +49,12 @@ impl ApiClient {
     ) -> Result<reqwest::Response, DanmuStreamError> {
         let cookie = self.get_current_cookie().await;
         let mut header = HeaderMap::new();
-        header.insert("cookie", cookie.parse().unwrap());
+        let cookie_value = cookie
+            .parse()
+            .map_err(|_| DanmuStreamError::MessageParseError {
+                err: "Invalid cookie header value".to_string(),
+            })?;
+        header.insert("cookie", cookie_value);
 
         let resp = self
             .client

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili.rs
@@ -303,10 +303,10 @@ impl BiliDanmu {
         let mut user_id = None;
 
         // find DedeUserID=<user_id> in cookie str
-        let re = Regex::new(r"DedeUserID=(\d+)").unwrap();
+        let re = Regex::new(r"DedeUserID=(\d+)").expect("DedeUserID regex is a valid literal");
         if let Some(captures) = re.captures(cookie) {
             if let Some(user) = captures.get(1) {
-                user_id = Some(user.as_str().parse::<i64>().unwrap());
+                user_id = user.as_str().parse::<i64>().ok();
             }
         }
 
@@ -327,7 +327,7 @@ impl BiliDanmu {
             .json()
             .await?;
         let nav_info = Self::decode_api_response::<Value>(nav_info)?;
-        let re = Regex::new(r"wbi/(.*).png").unwrap();
+        let re = Regex::new(r"wbi/(.*).png").expect("wbi regex is a valid literal");
         let img_url = nav_info["data"]["wbi_img"]["img_url"]
             .as_str()
             .ok_or_else(|| DanmuStreamError::MessageParseError {
@@ -396,35 +396,40 @@ impl BiliDanmu {
             }
         });
         // only keep 32 bytes of encoded
-        encoded = encoded[0..32].to_vec();
-        let encoded = String::from_utf8(encoded).unwrap();
+        let encoded = encoded
+            .get(0..32)
+            .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+            .ok_or_else(|| DanmuStreamError::MessageParseError {
+                err: "Bilibili WBI image URLs are too short".to_string(),
+            })?;
         // Timestamp in seconds
         let wts = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_secs();
-        parameters
-            .as_object_mut()
-            .unwrap()
-            .insert("wts".to_owned(), serde_json::Value::String(wts.to_string()));
+        let parameters =
+            parameters
+                .as_object_mut()
+                .ok_or_else(|| DanmuStreamError::MessageParseError {
+                    err: "Bilibili WBI parameters are not an object".to_string(),
+                })?;
+        parameters.insert("wts".to_owned(), serde_json::Value::String(wts.to_string()));
         // Get all keys from parameters into vec
         let mut keys = parameters
-            .as_object()
-            .unwrap()
             .keys()
             .map(|x| x.to_owned())
             .collect::<Vec<String>>();
         // sort keys
         keys.sort();
         let mut params = String::new();
-        keys.iter().for_each(|x| {
+        for (index, x) in keys.iter().enumerate() {
             params.push_str(x);
             params.push('=');
             // Convert value to string based on its type
-            let value = match parameters.get(x).unwrap() {
-                serde_json::Value::String(s) => s.clone(),
-                serde_json::Value::Number(n) => n.to_string(),
-                serde_json::Value::Bool(b) => b.to_string(),
+            let value = match parameters.get(x) {
+                Some(serde_json::Value::String(s)) => s.clone(),
+                Some(serde_json::Value::Number(n)) => n.to_string(),
+                Some(serde_json::Value::Bool(b)) => b.to_string(),
                 _ => "".to_string(),
             };
             // Value filters !'()* characters
@@ -432,10 +437,10 @@ impl BiliDanmu {
             let value = PctString::encode(value.chars(), URIReserved);
             params.push_str(value.as_str());
             // add & if not last
-            if x != keys.last().unwrap() {
+            if index != keys.len() - 1 {
                 params.push('&');
             }
-        });
+        }
         // md5 params+encoded
         let w_rid = md5::compute(params.to_string() + encoded.as_str());
         let params = params + format!("&w_rid={:x}", w_rid).as_str();

--- a/src-tauri/crates/danmu_stream/src/provider/douyin.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/douyin.rs
@@ -86,7 +86,9 @@ impl DouyinDanmu {
                 "V1Yza5x1zcfkembl6u/0Pg==",
             )
             .body(())
-            .unwrap();
+            .map_err(|e| DanmuStreamError::WebsocketError {
+                err: format!("Failed to build douyin websocket request: {e}"),
+            })?;
 
         let (ws_stream, response) =
             connect_async(request)
@@ -137,7 +139,12 @@ impl DouyinDanmu {
         // Get the result from the V8 runtime
         let scope = &mut runtime.handle_scope();
         let local = v8::Local::new(scope, result);
-        let url = local.to_string(scope).unwrap().to_rust_string_lossy(scope);
+        let url = local
+            .to_string(scope)
+            .ok_or_else(|| DanmuStreamError::WebsocketError {
+                err: "Failed to read douyin websocket URL from JavaScript result".to_string(),
+            })?
+            .to_rust_string_lossy(scope);
 
         debug!("Douyin wss url: {}", url);
 

--- a/src-tauri/crates/recorder/src/core/hls_recorder.rs
+++ b/src-tauri/crates/recorder/src/core/hls_recorder.rs
@@ -64,9 +64,14 @@ impl HlsRecorder {
         let user_agent =
             crate::utils::user_agent_generator::UserAgentGenerator::new().generate(false);
         let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert("user-agent", user_agent.parse().unwrap());
+        headers.insert(
+            "user-agent",
+            user_agent
+                .parse()
+                .expect("generated user agent is a valid header value"),
+        );
         if let Some(cookies) = cookies {
-            headers.insert("cookie", cookies.parse().unwrap());
+            headers.insert("cookie", crate::utils::header_value("cookie", &cookies)?);
         }
 
         let sequence_path = work_dir.join(".sequence");
@@ -275,8 +280,14 @@ impl HlsRecorder {
                     continue;
                 }
 
-                let last_segment = playlist.last_segment().await;
-                let last_segment_uri = last_segment.unwrap().uri.clone();
+                let Some(last_segment) = playlist.last_segment().await else {
+                    log::error!(
+                        "Playlist has no last segment, ignore: {}",
+                        segment_path.display()
+                    );
+                    continue;
+                };
+                let last_segment_uri = last_segment.uri.clone();
                 let last_segment_path = segment_path.with_file_name(last_segment_uri);
                 // append segment data behind last segment data
                 let mut last_segment_file = OpenOptions::new()
@@ -460,7 +471,8 @@ pub async fn construct_stream_from_variant(
     };
 
     // try to match expire from extra with regex
-    let expire_regex = regex::Regex::new(r"expires=(\d+)").unwrap();
+    let expire_regex =
+        regex::Regex::new(r"expires=(\d+)").expect("expires regex is a valid literal");
     let expire = if let Some(captures) = expire_regex.captures(extra) {
         captures[1].parse::<i64>().unwrap_or(0)
     } else {

--- a/src-tauri/crates/recorder/src/core/mod.rs
+++ b/src-tauri/crates/recorder/src/core/mod.rs
@@ -99,7 +99,7 @@ impl HlsStream {
 
         // Segment URI is relative, resolve it relative to m3u8 base URL
         let base = self.base.clone();
-        let m3u8_filename = base.split('/').next_back().unwrap();
+        let m3u8_filename = base.rsplit('/').next().unwrap_or(&base);
         let base_url = base.replace(m3u8_filename, seg_name);
 
         // Check if seg_name already contains query parameters

--- a/src-tauri/crates/recorder/src/core/playlist.rs
+++ b/src-tauri/crates/recorder/src/core/playlist.rs
@@ -40,19 +40,16 @@ impl HlsPlaylist {
         &mut self,
         segment: MediaSegment,
     ) -> Result<(), RecorderError> {
-        if self.is_empty().await {
+        let Some(last) = self.playlist.segments.last_mut() else {
             self.add_segment(segment).await?;
             return Ok(());
-        }
+        };
 
-        {
-            let last = self.playlist.segments.last_mut().unwrap();
-            let new_duration = last.duration + segment.duration;
-            last.duration = new_duration;
-            self.playlist.target_duration =
-                std::cmp::max(self.playlist.target_duration, new_duration as u64);
-            self.flush().await?;
-        }
+        let new_duration = last.duration + segment.duration;
+        last.duration = new_duration;
+        self.playlist.target_duration =
+            std::cmp::max(self.playlist.target_duration, new_duration as u64);
+        self.flush().await?;
 
         Ok(())
     }

--- a/src-tauri/crates/recorder/src/core/stream_info.rs
+++ b/src-tauri/crates/recorder/src/core/stream_info.rs
@@ -192,7 +192,7 @@ pub trait PlatformStreamInfo: Clone + Send + Sync + Debug {
         if let Some(expires_at) = self.expires_at() {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
+                .unwrap_or_default()
                 .as_secs() as i64;
             now >= expires_at
         } else {

--- a/src-tauri/crates/recorder/src/danmu.rs
+++ b/src-tauri/crates/recorder/src/danmu.rs
@@ -24,18 +24,20 @@ pub struct DanmuStorage {
 
 impl DanmuStorage {
     pub async fn new(file_path: &PathBuf) -> Option<DanmuStorage> {
-        let file = OpenOptions::new()
+        let file = match OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
             .open(file_path)
-            .await;
-        if file.is_err() {
-            log::error!("Open danmu file failed: {}", file.err().unwrap());
-            return None;
-        }
-        let file = file.unwrap();
+            .await
+        {
+            Ok(file) => file,
+            Err(e) => {
+                log::error!("Open danmu file failed: {e}");
+                return None;
+            }
+        };
         let reader = BufReader::new(file);
         let mut lines = reader.lines();
         let mut preload_cache: Vec<LiveEvent> = Vec::new();

--- a/src-tauri/crates/recorder/src/entry.rs
+++ b/src-tauri/crates/recorder/src/entry.rs
@@ -58,7 +58,8 @@ impl TsEntry {
     pub fn date_time(&self) -> String {
         let date_str = Utc
             .timestamp_opt(self.ts_seconds(), 0)
-            .unwrap()
+            .single()
+            .unwrap_or_default()
             .to_rfc3339();
         format!("#EXT-X-PROGRAM-DATE-TIME:{date_str}\n")
     }
@@ -102,7 +103,9 @@ impl EntryStore {
     pub async fn new(work_dir: &str) -> Self {
         // if work_dir is not exists, create it
         if !Path::new(work_dir).exists() {
-            std::fs::create_dir_all(work_dir).unwrap();
+            if let Err(e) = std::fs::create_dir_all(work_dir) {
+                log::error!("Failed to create work dir {work_dir}: {e}");
+            }
         }
 
         let mut entry_store = Self {
@@ -139,13 +142,13 @@ impl EntryStore {
         };
         let mut lines = BufReader::new(file_handle).lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            let entry = TsEntry::from(line.as_str());
-            if let Err(e) = entry {
-                log::error!("Failed to parse entry: {e} {line}");
-                continue;
-            }
-
-            let entry = entry.unwrap();
+            let entry = match TsEntry::from(line.as_str()) {
+                Ok(entry) => entry,
+                Err(e) => {
+                    log::error!("Failed to parse entry: {e} {line}");
+                    continue;
+                }
+            };
 
             self.last_sequence = std::cmp::max(self.last_sequence, entry.sequence);
 
@@ -189,14 +192,14 @@ impl EntryStore {
         };
         let end_content = if vod { "#EXT-X-ENDLIST" } else { "" };
 
-        if self.entries.is_empty() {
+        let Some(first_entry) = self.entries.first() else {
             m3u8_content += end_content;
             return m3u8_content;
-        }
+        };
 
         m3u8_content += &format!(
             "#EXT-X-TARGETDURATION:{}\n",
-            (0.5 + self.entries.first().unwrap().length).floor()
+            (0.5 + first_entry.length).floor()
         );
 
         // add header, FMP4 need this
@@ -205,7 +208,6 @@ impl EntryStore {
         }
 
         // Collect entries in range
-        let first_entry = self.entries.first().unwrap();
         let first_entry_ts = first_entry.ts_seconds();
         let mut entries_in_range = vec![];
         for e in &self.entries {
@@ -219,13 +221,13 @@ impl EntryStore {
             }
         }
 
-        if entries_in_range.is_empty() {
+        let Some(first_in_range) = entries_in_range.first() else {
             m3u8_content += end_content;
             log::warn!("No entries in range, return empty manifest");
             return m3u8_content;
-        }
+        };
 
-        let mut previous_seq = entries_in_range.first().unwrap().sequence;
+        let mut previous_seq = first_in_range.sequence;
         for (i, e) in entries_in_range.iter().enumerate() {
             let discontinuous = e.sequence < previous_seq || e.sequence - previous_seq > 1;
             if discontinuous {

--- a/src-tauri/crates/recorder/src/errors.rs
+++ b/src-tauri/crates/recorder/src/errors.rs
@@ -52,6 +52,8 @@ pub enum RecorderError {
     CodecNotFound { codecs: String },
     #[error("Invalid cookies")]
     InvalidCookies,
+    #[error("Invalid header value for {name}")]
+    InvalidHeaderValue { name: String },
     #[error("API error: {error}")]
     ApiError { error: String },
     #[error("Invalid value")]

--- a/src-tauri/crates/recorder/src/platforms/bilibili.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili.rs
@@ -146,17 +146,17 @@ impl BiliRecorder {
                         self.extra.user_info_cache.as_ref(),
                     )
                     .await;
-                    if let Ok(user_info) = user_info {
-                        *self.user_info.write().await = UserInfo {
-                            user_id: user_id.to_string(),
-                            user_name: user_info.user_name,
-                            user_avatar: user_info.user_avatar,
+                    match user_info {
+                        Ok(user_info) => {
+                            *self.user_info.write().await = UserInfo {
+                                user_id: user_id.to_string(),
+                                user_name: user_info.user_name,
+                                user_avatar: user_info.user_avatar,
+                            }
                         }
-                    } else {
-                        self.log_error(&format!(
-                            "Failed to get user info: {}",
-                            user_info.err().unwrap()
-                        ));
+                        Err(e) => {
+                            self.log_error(&format!("Failed to get user info: {e}"));
+                        }
                     }
                 }
                 let live_status = room_info.live_status == 1;
@@ -191,7 +191,7 @@ impl BiliRecorder {
                             .is_ok()
                         {
                             *self.extra.cover.write().await =
-                                Some(room_cover_path.to_str().unwrap().to_string());
+                                Some(room_cover_path.to_string_lossy().into_owned());
                         }
                         let _ = self.event_channel.send(RecorderEvent::LiveStart {
                             recorder: self.info().await,
@@ -263,13 +263,14 @@ impl BiliRecorder {
     async fn danmu(&self) -> Result<(), crate::errors::RecorderError> {
         let cookies = self.account.cookies.clone();
         let room_id = self.room_id.clone();
-        let danmu_stream = DanmuStream::new(ProviderType::BiliBili, &cookies, &room_id).await;
-        if danmu_stream.is_err() {
-            let err = danmu_stream.err().unwrap();
-            log::error!("[{}]Failed to create danmu stream: {}", self.room_id, err);
-            return Err(crate::errors::RecorderError::DanmuStreamError(err));
-        }
-        let danmu_stream = danmu_stream.unwrap();
+        let danmu_stream = match DanmuStream::new(ProviderType::BiliBili, &cookies, &room_id).await
+        {
+            Ok(danmu_stream) => danmu_stream,
+            Err(e) => {
+                log::error!("[{}]Failed to create danmu stream: {}", self.room_id, e);
+                return Err(crate::errors::RecorderError::DanmuStreamError(e));
+            }
+        };
 
         let mut start_fut = Box::pin(danmu_stream.start());
 
@@ -379,7 +380,9 @@ impl BiliRecorder {
 
         self.is_recording.store(true, atomic::Ordering::Relaxed);
 
-        let first_url_info = current_stream.url_info.first().unwrap();
+        let Some(first_url_info) = current_stream.url_info.first() else {
+            return Err(crate::errors::RecorderError::NoStreamAvailable);
+        };
         let expire = first_url_info.get_expire();
 
         let stream = Arc::new(HlsStream::new(
@@ -402,12 +405,13 @@ impl BiliRecorder {
             self.enabled.clone(),
         )
         .await;
-        if let Err(e) = hls_recorder {
-            log::error!("[{}]Hls recorder creation error: {}", self.room_id, e);
-            return Err(e);
-        }
-
-        let hls_recorder = hls_recorder.unwrap();
+        let hls_recorder = match hls_recorder {
+            Ok(hls_recorder) => hls_recorder,
+            Err(e) => {
+                log::error!("[{}]Hls recorder creation error: {}", self.room_id, e);
+                return Err(e);
+            }
+        };
         if let Err(e) = hls_recorder.start().await {
             log::error!("[{}]Hls recorder quit with error: {}", self.room_id, e);
             return Err(e);
@@ -433,25 +437,30 @@ impl crate::traits::RecorderTrait<BiliExtra> for BiliRecorder {
                 if self_clone.check_status().await {
                     // Live status is ok, start recording.
                     if self_clone.should_record().await {
-                        let live_id;
                         // if should continue with previous recording, using the same live id
-                        if self_clone.extra.should_continue.load(Ordering::Relaxed)
-                            && self_clone.extra.pre_live_id.read().await.is_some()
-                        {
-                            live_id = self_clone.extra.pre_live_id.read().await.clone().unwrap();
-                            self_clone
-                                .extra
-                                .should_continue
-                                .store(false, Ordering::Relaxed);
-                        } else {
-                            live_id = Utc::now().timestamp_millis().to_string();
-                            self_clone
-                                .extra
-                                .pre_live_id
-                                .write()
-                                .await
-                                .replace(live_id.clone());
-                        }
+                        let previous_live_id = self_clone.extra.pre_live_id.read().await.clone();
+                        let live_id = match (
+                            self_clone.extra.should_continue.load(Ordering::Relaxed),
+                            previous_live_id,
+                        ) {
+                            (true, Some(previous_live_id)) => {
+                                self_clone
+                                    .extra
+                                    .should_continue
+                                    .store(false, Ordering::Relaxed);
+                                previous_live_id
+                            }
+                            _ => {
+                                let live_id = Utc::now().timestamp_millis().to_string();
+                                self_clone
+                                    .extra
+                                    .pre_live_id
+                                    .write()
+                                    .await
+                                    .replace(live_id.clone());
+                                live_id
+                            }
+                        };
 
                         if let Err(e) = self_clone.update_entries(&live_id).await {
                             match e {
@@ -534,7 +543,10 @@ mod tests {
         *recorder.platform_live_id.write().await = "session-1".into();
         *recorder.live_id.write().await = "segment-1".into();
         *recorder.extra.pre_live_id.write().await = Some("segment-1".into());
-        recorder.extra.should_continue.store(true, Ordering::Relaxed);
+        recorder
+            .extra
+            .should_continue
+            .store(true, Ordering::Relaxed);
         recorder.is_recording.store(true, Ordering::Relaxed);
         *recorder.extra.live_stream.write().await = Some(BiliStream::new(
             Format::TS,
@@ -550,7 +562,9 @@ mod tests {
     #[tokio::test]
     async fn recording_reset_preserves_session_and_expiry_resume_state() {
         let (recorder, _) = recording_fixture().await;
-        tokio::fs::create_dir_all(&recorder.cache_dir).await.unwrap();
+        tokio::fs::create_dir_all(&recorder.cache_dir)
+            .await
+            .unwrap();
         *recorder.danmu_storage.write().await =
             DanmuStorage::new(&recorder.cache_dir.join("events.jsonl")).await;
         assert!(recorder.danmu_storage.read().await.is_some());
@@ -568,7 +582,9 @@ mod tests {
             Some("segment-1")
         );
         assert!(recorder.extra.should_continue.load(Ordering::Relaxed));
-        tokio::fs::remove_dir_all(&recorder.cache_dir).await.unwrap();
+        tokio::fs::remove_dir_all(&recorder.cache_dir)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -585,7 +601,10 @@ mod tests {
 
         recorder.end_live().await;
 
-        let RecorderEvent::LiveEnd { recorder: ended, .. } = rx.try_recv().unwrap() else {
+        let RecorderEvent::LiveEnd {
+            recorder: ended, ..
+        } = rx.try_recv().unwrap()
+        else {
             panic!("expected a live end event")
         };
         assert_eq!(ended.platform_live_id, "session-1");

--- a/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/bilibili/api.rs
@@ -103,7 +103,8 @@ pub struct UrlInfo {
 impl UrlInfo {
     pub fn get_expire(&self) -> i64 {
         // try to match expire from extra with regex
-        let expire_regex = regex::Regex::new(r"expires=(\d+)").unwrap();
+        let expire_regex =
+            regex::Regex::new(r"expires=(\d+)").expect("expires regex is a valid literal");
         if let Some(captures) = expire_regex.captures(&self.extra) {
             captures[1].parse::<i64>().unwrap_or(0)
         } else {
@@ -187,14 +188,20 @@ impl BiliStream {
     }
 
     pub fn index(&self) -> String {
-        let url_info = self.url_info.choose(&mut rand::rng()).unwrap();
+        let Some(url_info) = self.url_info.choose(&mut rand::rng()) else {
+            log::error!("No URL info available for Bilibili stream, using base URL");
+            return self.base_url.clone();
+        };
         format!("{}{}{}", url_info.host, self.base_url, url_info.extra)
     }
 
     pub fn ts_url(&self, seg_name: &str) -> String {
-        let m3u8_filename = self.base_url.split('/').next_back().unwrap();
+        let m3u8_filename = self.base_url.rsplit('/').next().unwrap_or(&self.base_url);
         let base_url = self.base_url.replace(m3u8_filename, seg_name);
-        let url_info = self.url_info.choose(&mut rand::rng()).unwrap();
+        let Some(url_info) = self.url_info.choose(&mut rand::rng()) else {
+            log::error!("No URL info available for Bilibili stream, using base URL");
+            return base_url;
+        };
         format!("{}{}?{}", url_info.host, base_url, url_info.extra)
     }
 }
@@ -202,7 +209,12 @@ impl BiliStream {
 fn generate_user_agent_header() -> reqwest::header::HeaderMap {
     let user_agent = user_agent_generator::UserAgentGenerator::new().generate(false);
     let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("user-agent", user_agent.parse().unwrap());
+    headers.insert(
+        "user-agent",
+        user_agent
+            .parse()
+            .expect("generated user agent is a valid header value"),
+    );
     headers
 }
 
@@ -769,18 +781,25 @@ pub async fn get_sign(client: &Client, mut parameters: Value) -> Result<String, 
         .await?
         .json()
         .await?;
-    let re = Regex::new(r"wbi/(.*).png").unwrap();
+    let invalid_response = || RecorderError::InvalidResponseJson {
+        resp: nav_info.clone(),
+    };
+    let re = Regex::new(r"wbi/(.*).png").expect("wbi regex is a valid literal");
+    let img_url = nav_info["data"]["wbi_img"]["img_url"]
+        .as_str()
+        .ok_or_else(invalid_response)?;
     let img = re
-        .captures(nav_info["data"]["wbi_img"]["img_url"].as_str().unwrap())
-        .unwrap()
-        .get(1)
-        .unwrap()
+        .captures(img_url)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(invalid_response)?
         .as_str();
+    let sub_url = nav_info["data"]["wbi_img"]["sub_url"]
+        .as_str()
+        .ok_or_else(invalid_response)?;
     let sub = re
-        .captures(nav_info["data"]["wbi_img"]["sub_url"].as_str().unwrap())
-        .unwrap()
-        .get(1)
-        .unwrap()
+        .captures(sub_url)
+        .and_then(|captures| captures.get(1))
+        .ok_or_else(invalid_response)?
         .as_str();
     let raw_string = format!("{img}{sub}");
     let mut encoded = Vec::new();
@@ -790,41 +809,40 @@ pub async fn get_sign(client: &Client, mut parameters: Value) -> Result<String, 
         }
     }
     // only keep 32 bytes of encoded
-    encoded = encoded[0..32].to_vec();
-    let encoded = String::from_utf8(encoded).unwrap();
+    let encoded = encoded
+        .get(0..32)
+        .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+        .ok_or_else(invalid_response)?;
     // Timestamp in seconds
     let wts = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_default()
         .as_secs();
-    parameters
+    let parameters = parameters
         .as_object_mut()
-        .unwrap()
-        .insert("wts".to_owned(), serde_json::Value::String(wts.to_string()));
+        .ok_or_else(|| RecorderError::InvalidValue)?;
+    parameters.insert("wts".to_owned(), serde_json::Value::String(wts.to_string()));
     // Get all keys from parameters into vec
     let mut keys = parameters
-        .as_object()
-        .unwrap()
         .keys()
         .map(std::borrow::ToOwned::to_owned)
         .collect::<Vec<String>>();
     // sort keys
     keys.sort();
     let mut params = String::new();
-    for x in &keys {
+    for (index, x) in keys.iter().enumerate() {
         params.push_str(x);
         params.push('=');
         // Value filters !'()* characters
         let value = parameters
             .get(x)
-            .unwrap()
-            .as_str()
-            .unwrap()
+            .and_then(|value| value.as_str())
+            .ok_or_else(|| RecorderError::InvalidValue)?
             .replace(['!', '\'', '(', ')', '*'], "");
         let value = PctString::encode(value.chars(), URIReserved);
         params.push_str(value.as_str());
         // add & if not last
-        if x != keys.last().unwrap() {
+        if index != keys.len() - 1 {
             params.push('&');
         }
     }
@@ -845,9 +863,13 @@ async fn preupload_video(
     } else {
         return Err(RecorderError::InvalidCookies);
     }
+    let file_name = video_file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| RecorderError::InvalidValue)?;
     let url = format!(
         "https://member.bilibili.com/preupload?name={}&r=upos&profile=ugcfx/bup",
-        video_file.file_name().unwrap().to_str().unwrap()
+        file_name
     );
     let response = client
         .get(&url)
@@ -1010,7 +1032,7 @@ pub async fn prepare_video(
     account: &Account,
     video_file: &Path,
 ) -> Result<profile::Video, RecorderError> {
-    log::info!("Start Preparing Video: {}", video_file.to_str().unwrap());
+    log::info!("Start Preparing Video: {}", video_file.display());
     let preupload = preupload_video(client, account, video_file).await?;
     log::info!("Preupload Response: {preupload:?}");
     let metaposted = post_video_meta(client, &preupload, video_file).await?;
@@ -1028,9 +1050,8 @@ pub async fn prepare_video(
     end_upload(client, &preupload, &metaposted, uploaded).await?;
     let filename = Path::new(&metaposted.key)
         .file_stem()
-        .unwrap()
-        .to_str()
-        .unwrap();
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| RecorderError::InvalidValue)?;
     Ok(profile::Video {
         title: filename.to_string(),
         filename: filename.to_string(),

--- a/src-tauri/crates/recorder/src/platforms/douyin.rs
+++ b/src-tauri/crates/recorder/src/platforms/douyin.rs
@@ -181,12 +181,13 @@ impl DouyinRecorder {
             .unwrap_or(0);
         let danmu_stream =
             DanmuStream::new(ProviderType::Douyin, &cookies, &danmu_room_id.to_string()).await;
-        if danmu_stream.is_err() {
-            let err = danmu_stream.err().unwrap();
-            log::error!("Failed to create danmu stream: {err}");
-            return Err(crate::errors::RecorderError::DanmuStreamError(err));
-        }
-        let danmu_stream = danmu_stream.unwrap();
+        let danmu_stream = match danmu_stream {
+            Ok(danmu_stream) => danmu_stream,
+            Err(e) => {
+                log::error!("Failed to create danmu stream: {e}");
+                return Err(crate::errors::RecorderError::DanmuStreamError(e));
+            }
+        };
 
         let mut start_fut = Box::pin(danmu_stream.start());
 
@@ -311,12 +312,13 @@ impl DouyinRecorder {
             self.enabled.clone(),
         )
         .await;
-        if let Err(e) = hls_recorder {
-            log::error!("[{}]Hls recorder creation error: {}", self.room_id, e);
-            return Err(e);
-        }
-
-        let hls_recorder = hls_recorder.unwrap();
+        let hls_recorder = match hls_recorder {
+            Ok(hls_recorder) => hls_recorder,
+            Err(e) => {
+                log::error!("[{}]Hls recorder creation error: {}", self.room_id, e);
+                return Err(e);
+            }
+        };
         if let Err(e) = hls_recorder.start().await {
             log::error!("[{}]Error from hls recorder: {}", self.room_id, e);
             return Err(e);

--- a/src-tauri/crates/recorder/src/platforms/douyin/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/douyin/api.rs
@@ -52,7 +52,7 @@ async fn generate_a_bogus(params: &str, user_agent: &str) -> Result<String, Reco
     let local = deno_core::v8::Local::new(&mut scope, result);
     let url = local
         .to_string(&mut scope)
-        .unwrap()
+        .ok_or_else(|| RecorderError::JsRuntimeError("a_bogus is not a string".to_string()))?
         .to_rust_string_lossy(&mut scope);
     Ok(url)
 }
@@ -66,7 +66,12 @@ async fn generate_ms_token() -> String {
 pub fn generate_user_agent_header() -> reqwest::header::HeaderMap {
     let user_agent = user_agent_generator::UserAgentGenerator::new().generate(false);
     let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("user-agent", user_agent.parse().unwrap());
+    headers.insert(
+        "user-agent",
+        user_agent
+            .parse()
+            .expect("generated user agent is a valid header value"),
+    );
     headers
 }
 
@@ -123,10 +128,19 @@ pub async fn get_room_info(
     sec_user_id: &str,
 ) -> Result<DouyinBasicRoomInfo, RecorderError> {
     let mut headers = generate_user_agent_header();
-    headers.insert("Referer", "https://live.douyin.com/".parse().unwrap());
-    headers.insert("Cookie", account.cookies.clone().parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://live.douyin.com/"),
+    );
+    headers.insert(
+        "Cookie",
+        crate::utils::header_value("Cookie", &account.cookies)?,
+    );
     let ms_token = generate_ms_token().await;
-    let user_agent = headers.get("user-agent").unwrap().to_str().unwrap();
+    let user_agent = headers
+        .get("user-agent")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
     let params = format!(
             "aid=6383&app_name=douyin_web&live_id=1&device_platform=web&language=zh-CN&enter_from=web_live&cookie_enabled=true&screen_width=1920&screen_height=1080&browser_language=zh-CN&browser_platform=MacIntel&browser_name=Chrome&browser_version=122.0.0.0&web_rid={room_id}&ms_token={ms_token}");
     let a_bogus = generate_a_bogus(&params, user_agent).await?;
@@ -194,8 +208,14 @@ pub async fn get_room_info_h5(
     let url = format!("https://webcast.amemv.com/webcast/room/reflow/info/?{query_string}");
 
     let mut headers = generate_user_agent_header();
-    headers.insert("Referer", "https://live.douyin.com/".parse().unwrap());
-    headers.insert("Cookie", account.cookies.clone().parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://live.douyin.com/"),
+    );
+    headers.insert(
+        "Cookie",
+        crate::utils::header_value("Cookie", &account.cookies)?,
+    );
 
     let resp = client.get(&url).headers(headers).send().await?;
 
@@ -303,8 +323,14 @@ pub async fn get_user_info(
     // Use the IM spotlight relation API to get user info
     let url = "https://www.douyin.com/aweme/v1/web/im/spotlight/relation/";
     let mut headers = generate_user_agent_header();
-    headers.insert("Referer", "https://www.douyin.com/".parse().unwrap());
-    headers.insert("Cookie", account.cookies.clone().parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://www.douyin.com/"),
+    );
+    headers.insert(
+        "Cookie",
+        crate::utils::header_value("Cookie", &account.cookies)?,
+    );
 
     let resp = client.get(url).headers(headers).send().await?;
 
@@ -367,7 +393,10 @@ pub async fn get_room_owner_sec_uid(
 ) -> Result<String, RecorderError> {
     let url = format!("https://live.douyin.com/{room_id}");
     let mut headers = generate_user_agent_header();
-    headers.insert("Referer", "https://live.douyin.com/".parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://live.douyin.com/"),
+    );
     let resp = client.get(url).headers(headers).send().await?;
     let status = resp.status();
     let text = resp.text().await?;
@@ -378,7 +407,7 @@ pub async fn get_room_owner_sec_uid(
     }
     // match to get sec_uid from text like \"sec_uid\":\"MS4wLjABAAAAdFmmud36bynPjXOvoMjatb42856_zryHsGmlkpIECDA\"
     let sec_uid = Regex::new(r#"\\"sec_uid\\":\\"(.*?)\\""#)
-        .unwrap()
+        .expect("sec_uid regex is a valid literal")
         .captures(&text)
         .and_then(|c| c.get(1))
         .ok_or_else(|| RecorderError::ApiError {
@@ -391,8 +420,10 @@ pub async fn get_room_owner_sec_uid(
 
 /// Download file from url to path
 pub async fn download_file(client: &Client, url: &str, path: &Path) -> Result<(), RecorderError> {
-    if !path.parent().unwrap().exists() {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
     let response = client.get(url).send().await?;
     let bytes = response.bytes().await?;

--- a/src-tauri/crates/recorder/src/platforms/douyin/stream_info.rs
+++ b/src-tauri/crates/recorder/src/platforms/douyin/stream_info.rs
@@ -85,7 +85,13 @@ impl PlatformStreamInfo for DouyinStream {
     }
 
     fn all_variants(&self) -> Vec<StreamVariant> {
-        vec![self.primary_variant().unwrap()]
+        match self.primary_variant() {
+            Ok(variant) => vec![variant],
+            Err(e) => {
+                log::warn!("Failed to build primary stream variant: {e}");
+                Vec::new()
+            }
+        }
     }
 
     fn expires_at(&self) -> Option<i64> {

--- a/src-tauri/crates/recorder/src/platforms/huya/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/huya/api.rs
@@ -14,7 +14,12 @@ use std::path::Path;
 fn generate_user_agent_header() -> reqwest::header::HeaderMap {
     let user_agent = user_agent_generator::UserAgentGenerator::new().generate(true);
     let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("user-agent", user_agent.parse().unwrap());
+    headers.insert(
+        "user-agent",
+        user_agent
+            .parse()
+            .expect("generated user agent is a valid header value"),
+    );
     headers
 }
 
@@ -43,8 +48,10 @@ pub async fn get_user_info(
     // </div>
     let document = Html::parse_document(&raw_content);
 
-    let avatar_selector = Selector::parse(".video-list-info .podcast-box img").unwrap();
-    let name_selector = Selector::parse(".video-list-info .podcast-info-intro h2").unwrap();
+    let avatar_selector = Selector::parse(".video-list-info .podcast-box img")
+        .expect("avatar selector is a valid literal");
+    let name_selector = Selector::parse(".video-list-info .podcast-info-intro h2")
+        .expect("name selector is a valid literal");
 
     // 提取 avatar (img src)
     let avatar = document
@@ -78,7 +85,10 @@ pub async fn get_room_info(
     } else {
         return Err(HuyaClientError::InvalidCookie);
     }
-    headers.insert("Referer", "https://m.huya.com/".parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://m.huya.com/"),
+    );
     let url = format!("https://m.huya.com/{room_id}");
     let response = client.get(url).headers(headers).send().await?;
     let raw_content = response.text().await?;
@@ -90,8 +100,10 @@ pub async fn get_room_info(
 
 /// Download file from url to path
 pub async fn download_file(client: &Client, url: &str, path: &Path) -> Result<(), HuyaClientError> {
-    if !path.parent().unwrap().exists() {
-        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    if let Some(parent) = path.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)?;
+        }
     }
     let response = client.get(url).send().await?;
     let bytes = response.bytes().await?;

--- a/src-tauri/crates/recorder/src/platforms/huya/extractor.rs
+++ b/src-tauri/crates/recorder/src/platforms/huya/extractor.rs
@@ -1,7 +1,6 @@
 use base64::{engine::general_purpose, Engine as _};
 use rand::seq::IndexedRandom;
 use regex::Regex;
-use reqwest::Url;
 use serde_json::{Map, Value};
 
 use crate::core::stream_info::{
@@ -22,10 +21,8 @@ impl StreamInfo {
     // https://hs.hls.huya.com/huyalive/156976698-156976698-674209784144068608-314076852-10057-A-0-1.m3u8?ratio=200
     // 156976698-156976698-674209784144068608-314076852-10057-A-0-1
     pub fn id(&self) -> String {
-        let url = Url::parse(&self.hls_url).unwrap();
-        let path = url.path();
-        let segments = path.split('/').collect::<Vec<&str>>();
-        let filename = segments[segments.len() - 1];
+        let path = self.hls_url.split('?').next().unwrap_or(&self.hls_url);
+        let filename = path.rsplit('/').next().unwrap_or(path);
         // 去掉 .m3u8 后缀
         filename
             .strip_suffix(".m3u8")
@@ -372,7 +369,10 @@ impl LiveStreamExtractor {
                     // 继续读取完整的键名
                     while let Some(&next_ch) = chars.peek() {
                         if next_ch.is_alphanumeric() || next_ch == '_' {
-                            result.push(chars.next().unwrap());
+                            let Some(next_ch) = chars.next() else {
+                                break;
+                            };
+                            result.push(next_ch);
                         } else {
                             break;
                         }
@@ -1707,7 +1707,13 @@ impl PlatformStreamInfo for StreamInfo {
     }
 
     fn all_variants(&self) -> Vec<StreamVariant> {
-        vec![self.primary_variant().unwrap()]
+        match self.primary_variant() {
+            Ok(variant) => vec![variant],
+            Err(e) => {
+                log::warn!("Failed to build primary stream variant: {e}");
+                Vec::new()
+            }
+        }
     }
 
     fn expires_at(&self) -> Option<i64> {

--- a/src-tauri/crates/recorder/src/platforms/huya/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/huya/mod.rs
@@ -181,11 +181,13 @@ impl HuyaRecorder {
             self.enabled.clone(),
         )
         .await;
-        if let Err(e) = hls_recorder {
-            log::error!("[{}]Hls recorder creation error: {}", self.room_id, e);
-            return Err(e);
-        }
-        let hls_recorder = hls_recorder.unwrap();
+        let hls_recorder = match hls_recorder {
+            Ok(hls_recorder) => hls_recorder,
+            Err(e) => {
+                log::error!("[{}]Hls recorder creation error: {}", self.room_id, e);
+                return Err(e);
+            }
+        };
 
         if let Err(e) = hls_recorder.start().await {
             log::error!("[{}]Failed to start hls recorder: {}", self.room_id, e);

--- a/src-tauri/crates/recorder/src/platforms/huya/url_builder.rs
+++ b/src-tauri/crates/recorder/src/platforms/huya/url_builder.rs
@@ -21,7 +21,7 @@ impl UrlBuilder {
     fn generate_uid() -> u64 {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_millis();
         let random = fastrand::u32(0..1000000);
         timestamp as u64 * 1000 + random as u64
@@ -30,7 +30,7 @@ impl UrlBuilder {
     fn generate_s_guid() -> String {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_millis();
         let random = fastrand::u32(0..1000000);
         format!("{}_{}", timestamp, random)
@@ -92,7 +92,7 @@ impl UrlBuilder {
         // 添加动态参数
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_millis();
         base_url.push_str(&format!("&t={}", timestamp));
 
@@ -164,7 +164,7 @@ impl UrlBuilder {
     fn generate_seq_id() -> String {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
+            .unwrap_or_default()
             .as_millis();
         let random = fastrand::u32(0..1000000);
         format!("{}_{}", timestamp, random)

--- a/src-tauri/crates/recorder/src/platforms/kuaishou/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/kuaishou/api.rs
@@ -1,4 +1,4 @@
-﻿use super::response::LiveStreamResponse;
+use super::response::LiveStreamResponse;
 use crate::core::stream_info::{
     CdnNode, Codec, Format, PlatformStreamInfo, PlatformType, Quality, StreamVariant,
 };
@@ -12,7 +12,12 @@ use serde_json::{json, Map, Value};
 fn generate_user_agent_header() -> reqwest::header::HeaderMap {
     let user_agent = user_agent_generator::UserAgentGenerator::new().generate(false);
     let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("user-agent", user_agent.parse().unwrap());
+    headers.insert(
+        "user-agent",
+        user_agent
+            .parse()
+            .expect("generated user agent is a valid header value"),
+    );
     headers
 }
 
@@ -306,21 +311,21 @@ async fn fetch_web_html(
     let mut headers = generate_user_agent_header();
     headers.insert(
         "Accept",
-        "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-            .parse()
-            .unwrap(),
+        reqwest::header::HeaderValue::from_static(
+            "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        ),
     );
     headers.insert(
         "Accept-Language",
-        "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2"
-            .parse()
-            .unwrap(),
+        reqwest::header::HeaderValue::from_static(
+            "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
+        ),
     );
 
     if !account.cookies.is_empty() {
         let cookie = normalize_cookie_header(&account.cookies);
         if !cookie.is_empty() {
-            headers.insert("Cookie", cookie.parse().unwrap());
+            headers.insert("Cookie", crate::utils::header_value("Cookie", &cookie)?);
         }
     }
 
@@ -334,7 +339,10 @@ async fn fetch_web_html(
             "https://live.kuaishou.com/"
         };
         let mut req_headers = headers.clone();
-        req_headers.insert("Referer", referer.parse().unwrap());
+        req_headers.insert(
+            "Referer",
+            reqwest::header::HeaderValue::from_static(referer),
+        );
 
         let response = client.get(&candidate).headers(req_headers).send().await?;
         let status = response.status();
@@ -890,8 +898,14 @@ pub async fn get_stream_urls(
 /// Get QR code for login
 pub async fn get_qr(client: &Client) -> Result<QrInfo, RecorderError> {
     let mut headers = generate_user_agent_header();
-    headers.insert("Content-Type", "application/json".parse().unwrap());
-    headers.insert("Referer", "https://www.kuaishou.com/".parse().unwrap());
+    headers.insert(
+        "Content-Type",
+        reqwest::header::HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://www.kuaishou.com/"),
+    );
 
     let response = client
         .post("https://id.kuaishou.com/rest/c/infra/ks/qr/start")
@@ -1012,15 +1026,15 @@ pub async fn get_user_info(
     let mut headers = generate_user_agent_header();
     headers.insert(
         "Accept-Language",
-        "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2"
-            .parse()
-            .unwrap(),
+        reqwest::header::HeaderValue::from_static(
+            "zh-CN,zh;q=0.8,zh-TW;q=0.7,zh-HK;q=0.5,en-US;q=0.3,en;q=0.2",
+        ),
     );
 
     if !account.cookies.is_empty() {
         let cookie = normalize_cookie_header(&account.cookies);
         if !cookie.is_empty() {
-            headers.insert("Cookie", cookie.parse().unwrap());
+            headers.insert("Cookie", crate::utils::header_value("Cookie", &cookie)?);
         }
     }
 
@@ -1099,8 +1113,14 @@ pub async fn get_qr_status(
     qr_login_signature: &str,
 ) -> Result<QrStatus, RecorderError> {
     let mut headers = generate_user_agent_header();
-    headers.insert("Content-Type", "application/json".parse().unwrap());
-    headers.insert("Referer", "https://www.kuaishou.com/".parse().unwrap());
+    headers.insert(
+        "Content-Type",
+        reqwest::header::HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://www.kuaishou.com/"),
+    );
 
     let payload = json!({
         "qrLoginToken": qr_login_token,
@@ -1238,7 +1258,13 @@ impl PlatformStreamInfo for StreamInfo {
     }
 
     fn all_variants(&self) -> Vec<StreamVariant> {
-        vec![self.primary_variant().unwrap()]
+        match self.primary_variant() {
+            Ok(variant) => vec![variant],
+            Err(e) => {
+                log::warn!("Failed to build primary stream variant: {e}");
+                Vec::new()
+            }
+        }
     }
 
     fn expires_at(&self) -> Option<i64> {

--- a/src-tauri/crates/recorder/src/platforms/kuaishou/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/kuaishou/mod.rs
@@ -352,25 +352,30 @@ impl RecorderTrait<KuaishouExtra> for KuaishouRecorder {
                 if self_clone.check_status().await {
                     // Live status is ok, start recording
                     if self_clone.should_record().await {
-                        let live_id;
                         // If should continue with previous recording, use the same live id
-                        if self_clone.extra.should_continue.load(Ordering::Relaxed)
-                            && self_clone.extra.pre_live_id.read().await.is_some()
-                        {
-                            live_id = self_clone.extra.pre_live_id.read().await.clone().unwrap();
-                            self_clone
-                                .extra
-                                .should_continue
-                                .store(false, Ordering::Relaxed);
-                        } else {
-                            live_id = Utc::now().timestamp_millis().to_string();
-                            self_clone
-                                .extra
-                                .pre_live_id
-                                .write()
-                                .await
-                                .replace(live_id.clone());
-                        }
+                        let previous_live_id = self_clone.extra.pre_live_id.read().await.clone();
+                        let live_id = match (
+                            self_clone.extra.should_continue.load(Ordering::Relaxed),
+                            previous_live_id,
+                        ) {
+                            (true, Some(previous_live_id)) => {
+                                self_clone
+                                    .extra
+                                    .should_continue
+                                    .store(false, Ordering::Relaxed);
+                                previous_live_id
+                            }
+                            _ => {
+                                let live_id = Utc::now().timestamp_millis().to_string();
+                                self_clone
+                                    .extra
+                                    .pre_live_id
+                                    .write()
+                                    .await
+                                    .replace(live_id.clone());
+                                live_id
+                            }
+                        };
 
                         if let Err(e) = self_clone.update_entries(&live_id).await {
                             match e {

--- a/src-tauri/crates/recorder/src/platforms/tiktok/api.rs
+++ b/src-tauri/crates/recorder/src/platforms/tiktok/api.rs
@@ -31,7 +31,12 @@ pub struct StreamInfo {
 fn generate_user_agent_header() -> reqwest::header::HeaderMap {
     let user_agent = user_agent_generator::UserAgentGenerator::new().generate(false);
     let mut headers = reqwest::header::HeaderMap::new();
-    headers.insert("user-agent", user_agent.parse().unwrap());
+    headers.insert(
+        "user-agent",
+        user_agent
+            .parse()
+            .expect("generated user agent is a valid header value"),
+    );
     headers
 }
 
@@ -675,10 +680,19 @@ pub async fn get_room_info(
     room_id: &str,
 ) -> Result<RoomInfo, RecorderError> {
     let mut headers = generate_user_agent_header();
-    headers.insert("Referer", "https://www.tiktok.com/".parse().unwrap());
-    headers.insert("accept-language", "en-US,en;q=0.9".parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://www.tiktok.com/"),
+    );
+    headers.insert(
+        "accept-language",
+        reqwest::header::HeaderValue::from_static("en-US,en;q=0.9"),
+    );
     if !account.cookies.is_empty() {
-        headers.insert("Cookie", account.cookies.parse().unwrap());
+        headers.insert(
+            "Cookie",
+            crate::utils::header_value("Cookie", &account.cookies)?,
+        );
     }
 
     // TikTok URLs are typically like: https://www.tiktok.com/@username/live
@@ -788,10 +802,19 @@ pub async fn get_stream_url(
     room_id: &str,
 ) -> Result<StreamInfo, RecorderError> {
     let mut headers = generate_user_agent_header();
-    headers.insert("Referer", "https://www.tiktok.com/".parse().unwrap());
-    headers.insert("accept-language", "en-US,en;q=0.9".parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://www.tiktok.com/"),
+    );
+    headers.insert(
+        "accept-language",
+        reqwest::header::HeaderValue::from_static("en-US,en;q=0.9"),
+    );
     if !account.cookies.is_empty() {
-        headers.insert("Cookie", account.cookies.parse().unwrap());
+        headers.insert(
+            "Cookie",
+            crate::utils::header_value("Cookie", &account.cookies)?,
+        );
     }
 
     // TikTok URLs are typically like: https://www.tiktok.com/@username/live
@@ -900,10 +923,19 @@ pub async fn get_user_info(
     account: &Account,
 ) -> Result<crate::UserInfo, RecorderError> {
     let mut headers = generate_user_agent_header();
-    headers.insert("Referer", "https://www.tiktok.com/".parse().unwrap());
-    headers.insert("accept-language", "en-US,en;q=0.9".parse().unwrap());
+    headers.insert(
+        "Referer",
+        reqwest::header::HeaderValue::from_static("https://www.tiktok.com/"),
+    );
+    headers.insert(
+        "accept-language",
+        reqwest::header::HeaderValue::from_static("en-US,en;q=0.9"),
+    );
     if !account.cookies.is_empty() {
-        headers.insert("Cookie", account.cookies.parse().unwrap());
+        headers.insert(
+            "Cookie",
+            crate::utils::header_value("Cookie", &account.cookies)?,
+        );
     }
 
     // Access TikTok homepage to get user info from state

--- a/src-tauri/crates/recorder/src/platforms/tiktok/mod.rs
+++ b/src-tauri/crates/recorder/src/platforms/tiktok/mod.rs
@@ -238,24 +238,29 @@ impl RecorderTrait<TikTokExtra> for TikTokRecorder {
             while !self_clone.quit.load(atomic::Ordering::Relaxed) {
                 if self_clone.check_status().await {
                     if self_clone.should_record().await {
-                        let live_id;
-                        if self_clone.extra.should_continue.load(Ordering::Relaxed)
-                            && self_clone.extra.pre_live_id.read().await.is_some()
-                        {
-                            live_id = self_clone.extra.pre_live_id.read().await.clone().unwrap();
-                            self_clone
-                                .extra
-                                .should_continue
-                                .store(false, Ordering::Relaxed);
-                        } else {
-                            live_id = Utc::now().timestamp_millis().to_string();
-                            self_clone
-                                .extra
-                                .pre_live_id
-                                .write()
-                                .await
-                                .replace(live_id.clone());
-                        }
+                        let previous_live_id = self_clone.extra.pre_live_id.read().await.clone();
+                        let live_id = match (
+                            self_clone.extra.should_continue.load(Ordering::Relaxed),
+                            previous_live_id,
+                        ) {
+                            (true, Some(previous_live_id)) => {
+                                self_clone
+                                    .extra
+                                    .should_continue
+                                    .store(false, Ordering::Relaxed);
+                                previous_live_id
+                            }
+                            _ => {
+                                let live_id = Utc::now().timestamp_millis().to_string();
+                                self_clone
+                                    .extra
+                                    .pre_live_id
+                                    .write()
+                                    .await
+                                    .replace(live_id.clone());
+                                live_id
+                            }
+                        };
 
                         if let Err(e) = self_clone.update_entries(&live_id).await {
                             match e {

--- a/src-tauri/crates/recorder/src/utils/mod.rs
+++ b/src-tauri/crates/recorder/src/utils/mod.rs
@@ -1,1 +1,14 @@
 pub mod user_agent_generator;
+
+use crate::errors::RecorderError;
+use reqwest::header::HeaderValue;
+
+/// Build a header value from user-provided data without panicking.
+///
+/// Cookie strings, referers and user agents come from accounts or config, so an
+/// invalid byte must surface as a typed error instead of a panic.
+pub fn header_value(name: &str, value: &str) -> Result<HeaderValue, RecorderError> {
+    HeaderValue::from_str(value).map_err(|_| RecorderError::InvalidHeaderValue {
+        name: name.to_string(),
+    })
+}

--- a/src-tauri/crates/recorder/src/utils/user_agent_generator.rs
+++ b/src-tauri/crates/recorder/src/utils/user_agent_generator.rs
@@ -38,6 +38,14 @@ impl UserAgentGenerator {
         }
     }
 
+    /// Pick a random entry from a constant list.
+    ///
+    /// Every caller passes a non-empty literal, and the empty fallback keeps the
+    /// generator panic-free if that ever stops being true.
+    fn pick<'a>(&mut self, items: &[&'a str]) -> &'a str {
+        items.choose(&mut self.rng).copied().unwrap_or_default()
+    }
+
     fn generate_mobile(&mut self) -> String {
         let mobile_versions = [
             "120.0.0.0",
@@ -48,13 +56,13 @@ impl UserAgentGenerator {
             "115.0.0.0",
             "114.0.0.0",
         ];
-        let mobile_version = mobile_versions.choose(&mut self.rng).unwrap();
+        let mobile_version = self.pick(&mobile_versions);
 
         // 随机选择 Android 或 iOS
         if self.rng.random_bool(0.7) {
             // Android User-Agent
             let android_versions = ["13", "12", "11", "10", "9"];
-            let android_version = android_versions.choose(&mut self.rng).unwrap();
+            let android_version = self.pick(&android_versions);
             let device_models = [
                 "SM-G991B",
                 "SM-G996B",
@@ -67,15 +75,15 @@ impl UserAgentGenerator {
                 "OnePlus 9",
                 "OnePlus 10",
             ];
-            let device_model = device_models.choose(&mut self.rng).unwrap();
+            let device_model = self.pick(&device_models);
 
             format!("Mozilla/5.0 (Linux; Android {android_version}; {device_model}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{mobile_version} Mobile Safari/537.36")
         } else {
             // iOS User-Agent
             let ios_versions = ["17_1", "16_7", "16_6", "15_7", "14_8"];
-            let ios_version = ios_versions.choose(&mut self.rng).unwrap();
+            let ios_version = self.pick(&ios_versions);
             let device_types = ["iPhone; CPU iPhone OS", "iPad; CPU OS"];
-            let device_type = device_types.choose(&mut self.rng).unwrap();
+            let device_type = self.pick(&device_types);
 
             format!("Mozilla/5.0 ({device_type} {ios_version} like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Mobile/15E148 Safari/604.1")
         }
@@ -94,8 +102,8 @@ impl UserAgentGenerator {
         let webkit_versions = ["537.36", "537.35", "537.34"];
 
         let os = self.get_random_os();
-        let chrome_version = chrome_versions.choose(&mut self.rng).unwrap();
-        let webkit_version = webkit_versions.choose(&mut self.rng).unwrap();
+        let chrome_version = self.pick(&chrome_versions);
+        let webkit_version = self.pick(&webkit_versions);
 
         format!(
             "Mozilla/5.0 ({os}) AppleWebKit/{webkit_version} (KHTML, like Gecko) Chrome/{chrome_version} Safari/{webkit_version}"
@@ -106,7 +114,7 @@ impl UserAgentGenerator {
         let firefox_versions = ["121.0", "120.0", "119.0", "118.0", "117.0", "116.0"];
 
         let os = self.get_random_os_firefox();
-        let firefox_version = firefox_versions.choose(&mut self.rng).unwrap();
+        let firefox_version = self.pick(&firefox_versions);
 
         format!("Mozilla/5.0 ({os}; rv:{firefox_version}) Gecko/20100101 Firefox/{firefox_version}")
     }
@@ -115,25 +123,23 @@ impl UserAgentGenerator {
         let safari_versions = ["17.1", "17.0", "16.6", "16.5", "16.4", "16.3"];
         let webkit_versions = ["605.1.15", "605.1.14", "605.1.13"];
 
-        let safari_version = safari_versions.choose(&mut self.rng).unwrap();
-        let webkit_version = webkit_versions.choose(&mut self.rng).unwrap();
+        let safari_version = self.pick(&safari_versions);
+        let webkit_version = self.pick(&webkit_versions);
 
         // Safari 只在 macOS 和 iOS 上
         let is_mobile = self.rng.random_bool(0.3);
 
         if is_mobile {
             let ios_versions = ["17_1", "16_7", "16_6", "15_7"];
-            let ios_version = ios_versions.choose(&mut self.rng).unwrap();
-            let device = ["iPhone; CPU iPhone OS", "iPad; CPU OS"]
-                .choose(&mut self.rng)
-                .unwrap();
+            let ios_version = self.pick(&ios_versions);
+            let device = self.pick(&["iPhone; CPU iPhone OS", "iPad; CPU OS"]);
 
             format!(
                 "Mozilla/5.0 ({device} {ios_version} like Mac OS X) AppleWebKit/{webkit_version} (KHTML, like Gecko) Version/{safari_version} Mobile/15E148 Safari/{webkit_version}"
             )
         } else {
             let macos_versions = ["14_1", "13_6", "12_7"];
-            let macos_version = macos_versions.choose(&mut self.rng).unwrap();
+            let macos_version = self.pick(&macos_versions);
 
             format!(
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X {macos_version}) AppleWebKit/{webkit_version} (KHTML, like Gecko) Version/{safari_version} Safari/{webkit_version}"
@@ -146,8 +152,8 @@ impl UserAgentGenerator {
         let chrome_versions = ["119.0.0.0", "118.0.0.0", "117.0.0.0", "116.0.0.0"];
 
         let os = self.get_random_os();
-        let edge_version = edge_versions.choose(&mut self.rng).unwrap();
-        let chrome_version = chrome_versions.choose(&mut self.rng).unwrap();
+        let edge_version = self.pick(&edge_versions);
+        let chrome_version = self.pick(&chrome_versions);
 
         format!(
             "Mozilla/5.0 ({os}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/{chrome_version} Safari/537.36 Edg/{edge_version}"
@@ -164,7 +170,7 @@ impl UserAgentGenerator {
             "X11; Ubuntu; Linux x86_64",
         ];
 
-        os_list.choose(&mut self.rng).unwrap()
+        self.pick(&os_list)
     }
 
     fn get_random_os_firefox(&mut self) -> &'static str {
@@ -176,7 +182,7 @@ impl UserAgentGenerator {
             "X11; Ubuntu; Linux i686",
         ];
 
-        os_list.choose(&mut self.rng).unwrap()
+        self.pick(&os_list)
     }
 }
 

--- a/src-tauri/crates/whisper-cpp-rs/build.rs
+++ b/src-tauri/crates/whisper-cpp-rs/build.rs
@@ -59,7 +59,7 @@ fn cuda_root() -> Option<PathBuf> {
 }
 
 fn main() {
-    let crate_dir = env::current_dir().unwrap();
+    let crate_dir = env::current_dir().expect("build script has a current directory");
     let whisper_dir = crate_dir.join("whisper.cpp");
 
     let mut config = cmake::Config::new(&whisper_dir);
@@ -71,7 +71,7 @@ fn main() {
     config.define("WHISPER_BUILD_SERVER", "OFF");
 
     // Platform-specific GPU acceleration
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").expect("cargo sets CARGO_CFG_TARGET_OS");
     let cuda_enabled = env::var("CARGO_FEATURE_CUDA").is_ok();
     let metal_enabled = target_os == "macos";
 

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -250,6 +250,16 @@ impl BsrTool {
         format!("bsr-{timestamp}-{sequence}")
     }
 
+    /// Lock the tool-call log, recovering from a poisoned mutex.
+    ///
+    /// The log is append-only diagnostic data, so a panic in another thread must
+    /// not turn every later tool call into a panic.
+    fn lock_calls(&self) -> std::sync::MutexGuard<'_, Vec<ExecutedToolCall>> {
+        self.calls
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     fn requires_confirmation(action: &str) -> bool {
         matches!(
             action,
@@ -811,7 +821,7 @@ impl Tool for BsrTool {
         let args = args.normalize()?;
         let id = Self::tool_call_id();
         let record_index = {
-            let mut calls = self.calls.lock().expect("tool call log mutex poisoned");
+            let mut calls = self.lock_calls();
             calls.push(ExecutedToolCall {
                 id: id.clone(),
                 name: args.action.clone(),
@@ -833,7 +843,7 @@ impl Tool for BsrTool {
         }
 
         let result = self.execute(args).await;
-        let mut calls = self.calls.lock().expect("tool call log mutex poisoned");
+        let mut calls = self.lock_calls();
         let record = &mut calls[record_index];
         record.executed = true;
         if let Err(error) = &result {
@@ -935,10 +945,9 @@ fn rig_messages(message: &AgentMessage) -> Result<Vec<Message>, String> {
             if content.is_empty() {
                 content.push(AssistantContent::text(""));
             }
-            Ok(vec![Message::Assistant {
-                id: None,
-                content: OneOrMany::many(content).expect("assistant content is not empty"),
-            }])
+            let content = OneOrMany::many(content)
+                .map_err(|e| format!("Assistant message has no content: {e}"))?;
+            Ok(vec![Message::Assistant { id: None, content }])
         }
         "tool" => {
             let id = message
@@ -974,12 +983,11 @@ fn rig_messages(message: &AgentMessage) -> Result<Vec<Message>, String> {
             ));
             image_content.extend(images.into_iter().map(UserContent::Image));
 
+            let content = OneOrMany::many(image_content)
+                .map_err(|e| format!("Image tool result has no content: {e}"))?;
             Ok(vec![
                 Message::tool_result(id.clone(), result_text),
-                Message::User {
-                    content: OneOrMany::many(image_content)
-                        .expect("image tool result always has content"),
-                },
+                Message::User { content },
             ])
         }
         "system" => Ok(vec![Message::system(message.content.clone())]),
@@ -1076,7 +1084,10 @@ pub async fn agent_chat(
         "openai" => openai_chat(&config, tool, prompt, history).await,
         _ => return Err("Unsupported AI provider".into()),
     };
-    let tool_calls = calls.lock().expect("tool call log mutex poisoned").clone();
+    let tool_calls = calls
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
     match result {
         Ok(content) => Ok(AgentResponse {
             content,

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -132,9 +132,13 @@ impl Config {
         default_cache: &Path,
         default_output: &Path,
     ) -> Result<Self, String> {
+        let config_path_str = config_path
+            .to_str()
+            .ok_or_else(|| format!("Config path is not valid UTF-8: {}", config_path.display()))?
+            .to_string();
         if let Ok(content) = std::fs::read_to_string(config_path) {
             if let Ok(mut config) = toml::from_str::<Config>(&content) {
-                config.config_path = config_path.to_str().unwrap().into();
+                config.config_path = config_path_str;
                 config.update_interval = Arc::new(AtomicU64::new(config.status_check_interval));
                 return Ok(config);
             }
@@ -147,8 +151,8 @@ impl Config {
         }
 
         let config = Config {
-            cache: default_cache.to_str().unwrap().into(),
-            output: default_output.to_str().unwrap().into(),
+            cache: default_cache.to_string_lossy().into_owned(),
+            output: default_output.to_string_lossy().into_owned(),
             live_start_notify: true,
             live_end_notify: true,
             clip_notify: true,
@@ -162,7 +166,7 @@ impl Config {
             clip_name_format: default_clip_name_format(),
             auto_generate: default_auto_generate_config(),
             status_check_interval: default_status_check_interval(),
-            config_path: config_path.to_str().unwrap().into(),
+            config_path: config_path_str,
             whisper_language: default_whisper_language(),
             webhook_url: default_webhook_url(),
             danmu_ass_options: default_danmu_ass_options(),
@@ -177,7 +181,13 @@ impl Config {
     }
 
     pub fn save(&self) {
-        let content = toml::to_string(&self).unwrap();
+        let content = match toml::to_string(&self) {
+            Ok(content) => content,
+            Err(e) => {
+                log::error!("Failed to serialize config: {e}");
+                return;
+            }
+        };
         if let Err(e) = std::fs::write(self.config_path.clone(), content) {
             log::error!("Failed to save config: {} {}", e, self.config_path);
         }

--- a/src-tauri/src/danmu2ass.rs
+++ b/src-tauri/src/danmu2ass.rs
@@ -190,7 +190,7 @@ fn normal_danmaku() -> impl FnMut(f64, f64, f64, bool) -> Option<DanmakuPosition
         }
 
         // Sort suggestions by position
-        suggestions.sort_by(|a, b| a.p.partial_cmp(&b.p).unwrap());
+        suggestions.sort_by(|a, b| a.p.total_cmp(&b.p));
 
         // Filter out suggestions with too much delay
         let mut mr = MAX_DELAY;
@@ -219,9 +219,8 @@ fn normal_danmaku() -> impl FnMut(f64, f64, f64, bool) -> Option<DanmakuPosition
                 };
                 (score, s)
             })
-            .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap())
-            .unwrap()
-            .1;
+            .max_by(|a, b| a.0.total_cmp(&b.0))
+            .map(|(_, s)| s)?;
 
         let ts = t0s + best.r;
         let tf = (wv / (wv + PLAY_RES_X)) * R2L_TIME + ts;

--- a/src-tauri/src/database/account.rs
+++ b/src-tauri/src/database/account.rs
@@ -32,14 +32,14 @@ impl AccountRow {
 impl Database {
     // CREATE TABLE accounts (uid INTEGER PRIMARY KEY, name TEXT, avatar TEXT, csrf TEXT, cookies TEXT, created_at TEXT);
     pub async fn add_account(&self, account: &AccountRow) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("INSERT INTO accounts (uid, platform, name, avatar, csrf, cookies, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7)").bind(&account.uid).bind(&account.platform).bind(&account.name).bind(&account.avatar).bind(&account.csrf).bind(&account.cookies).bind(&account.created_at).execute(&lock).await?;
 
         Ok(())
     }
 
     pub async fn remove_account(&self, platform: &str, uid: &str) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let sql = sqlx::query("DELETE FROM accounts WHERE uid = $1 and platform = $2")
             .bind(uid)
             .bind(platform)
@@ -52,7 +52,7 @@ impl Database {
     }
 
     pub async fn get_accounts(&self) -> Result<Vec<AccountRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, AccountRow>("SELECT * FROM accounts")
             .fetch_all(&lock)
             .await?)
@@ -63,7 +63,7 @@ impl Database {
         platform: &str,
         uid: &str,
     ) -> Result<AccountRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, AccountRow>(
             "SELECT * FROM accounts WHERE uid = $1 and platform = $2",
         )
@@ -77,7 +77,7 @@ impl Database {
         &self,
         platform: &str,
     ) -> Result<AccountRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let accounts =
             sqlx::query_as::<_, AccountRow>("SELECT * FROM accounts WHERE platform = $1")
                 .bind(platform)
@@ -87,7 +87,9 @@ impl Database {
             return Err(DatabaseError::NotFound);
         }
         // randomly select one account
-        let account = accounts.choose(&mut rand::thread_rng()).unwrap();
+        let account = accounts
+            .choose(&mut rand::thread_rng())
+            .ok_or(DatabaseError::NotFound)?;
         Ok(account.clone())
     }
 }

--- a/src-tauri/src/database/bilibili_user.rs
+++ b/src-tauri/src/database/bilibili_user.rs
@@ -16,7 +16,7 @@ impl Database {
         &self,
         user_id: &str,
     ) -> Result<Option<UserInfo>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let row = sqlx::query_as::<_, BilibiliUserInfoRow>(
             "SELECT user_id, user_name, user_avatar
              FROM bilibili_user_profiles
@@ -34,7 +34,7 @@ impl Database {
     }
 
     async fn save_bilibili_user_info(&self, user_info: &UserInfo) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "INSERT INTO bilibili_user_profiles
                 (user_id, user_name, user_avatar, updated_at)

--- a/src-tauri/src/database/message.rs
+++ b/src-tauri/src/database/message.rs
@@ -15,7 +15,7 @@ pub struct MessageRow {
 // CREATE TABLE messages (id INTEGER PRIMARY KEY, title TEXT, content TEXT, read INTEGER, created_at TEXT);
 impl Database {
     pub async fn new_message(&self, title: &str, content: &str) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "INSERT INTO messages (title, content, read, created_at) VALUES ($1, $2, 0, $3)",
         )
@@ -28,7 +28,7 @@ impl Database {
     }
 
     pub async fn read_message(&self, id: i64) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("UPDATE messages SET read = $1 WHERE id = $2")
             .bind(1)
             .bind(id)
@@ -38,7 +38,7 @@ impl Database {
     }
 
     pub async fn delete_message(&self, id: i64) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("DELETE FROM messages WHERE id = $1")
             .bind(id)
             .execute(&lock)
@@ -47,7 +47,7 @@ impl Database {
     }
 
     pub async fn get_messages(&self) -> Result<Vec<MessageRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, MessageRow>("SELECT * FROM messages;")
             .fetch_all(&lock)
             .await?)

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -26,6 +26,8 @@ pub enum DatabaseError {
     InvalidCookies,
     #[error("Number exceed i64 range")]
     NumberExceedI64Range,
+    #[error("Database has not been initialized")]
+    NotInitialized,
     #[error("DB error: {0}")]
     DB(#[from] sqlx::Error),
     #[error("SQL is incorret: {sql}")]
@@ -48,5 +50,18 @@ impl Database {
     /// db *must* be set in tauri setup
     pub async fn set(&self, p: Pool<Sqlite>) {
         *self.db.write().await = Some(p);
+    }
+
+    /// Borrow the connection pool.
+    ///
+    /// Every query goes through this helper so a query issued before
+    /// [`Database::set`] returns a typed [`DatabaseError::NotInitialized`]
+    /// instead of panicking.
+    async fn pool(&self) -> Result<Pool<Sqlite>, DatabaseError> {
+        self.db
+            .read()
+            .await
+            .clone()
+            .ok_or(DatabaseError::NotInitialized)
     }
 }

--- a/src-tauri/src/database/record.rs
+++ b/src-tauri/src/database/record.rs
@@ -25,7 +25,7 @@ impl Database {
         offset: i64,
         limit: i64,
     ) -> Result<Vec<RecordRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, RecordRow>(
             "SELECT * FROM records WHERE room_id = $1 ORDER BY created_at DESC LIMIT $2 OFFSET $3",
         )
@@ -41,7 +41,7 @@ impl Database {
         room_id: &str,
         live_id: &str,
     ) -> Result<RecordRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, RecordRow>(
             "SELECT * FROM records WHERE room_id = $1 and live_id = $2",
         )
@@ -56,7 +56,7 @@ impl Database {
         room_id: &str,
         parent_id: &str,
     ) -> Result<Vec<RecordRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, RecordRow>(
             "SELECT * FROM records WHERE room_id = $1 and parent_id = $2",
         )
@@ -75,7 +75,7 @@ impl Database {
         title: &str,
         cover: Option<String>,
     ) -> Result<RecordRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let record = RecordRow {
             platform: platform.as_str().to_string(),
             parent_id: parent_id.to_string(),
@@ -98,7 +98,7 @@ impl Database {
     }
 
     pub async fn remove_record(&self, live_id: &str) -> Result<RecordRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let to_delete = sqlx::query_as::<_, RecordRow>("SELECT * FROM records WHERE live_id = $1")
             .bind(live_id)
             .fetch_one(&lock)
@@ -124,7 +124,7 @@ impl Database {
         length: f64,
         size: u64,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let size = i64::try_from(size).map_err(|_| DatabaseError::NumberExceedI64Range)?;
         sqlx::query("UPDATE records SET length = length + $1, size = size + $2 WHERE live_id = $3")
             .bind(length)
@@ -140,7 +140,7 @@ impl Database {
         live_id: &str,
         parent_id: &str,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("UPDATE records SET parent_id = $1 WHERE live_id = $2")
             .bind(parent_id)
             .bind(live_id)
@@ -154,7 +154,7 @@ impl Database {
         live_id: &str,
         cover: Option<String>,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("UPDATE records SET cover = $1 WHERE live_id = $2")
             .bind(cover)
             .bind(live_id)
@@ -164,7 +164,7 @@ impl Database {
     }
 
     pub async fn get_total_length(&self) -> Result<f64, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let result: (f64,) = sqlx::query_as("SELECT SUM(length) FROM records;")
             .fetch_one(&lock)
             .await?;
@@ -172,15 +172,9 @@ impl Database {
     }
 
     pub async fn get_today_record_count(&self) -> Result<i64, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let result: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM records WHERE created_at >= $1;")
-            .bind(
-                Utc::now()
-                    .date_naive()
-                    .and_hms_opt(0, 0, 0)
-                    .unwrap()
-                    .to_string(),
-            )
+            .bind(Utc::now().format("%Y-%m-%d 00:00:00").to_string())
             .fetch_one(&lock)
             .await?;
         Ok(result.0)
@@ -192,7 +186,7 @@ impl Database {
         offset: i64,
         limit: i64,
     ) -> Result<Vec<RecordRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         if room_id.is_empty() {
             Ok(sqlx::query_as::<_, RecordRow>(
                 "SELECT * FROM records ORDER BY created_at DESC LIMIT $1 OFFSET $2",
@@ -214,7 +208,7 @@ impl Database {
     }
 
     pub async fn get_record_disk_usage(&self) -> Result<i64, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let result: (i64,) = sqlx::query_as("SELECT SUM(size) FROM records;")
             .fetch_one(&lock)
             .await?;

--- a/src-tauri/src/database/recorder.rs
+++ b/src-tauri/src/database/recorder.rs
@@ -21,7 +21,7 @@ impl Database {
         room_id: &str,
         extra: &str,
     ) -> Result<RecorderRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let recorder = RecorderRow {
             room_id: room_id.to_string(),
             created_at: Utc::now().to_rfc3339(),
@@ -43,7 +43,7 @@ impl Database {
     }
 
     pub async fn remove_recorder(&self, room_id: &str) -> Result<RecorderRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let recorder =
             sqlx::query_as::<_, RecorderRow>("SELECT * FROM recorders WHERE room_id = $1")
                 .bind(room_id)
@@ -63,7 +63,7 @@ impl Database {
     }
 
     pub async fn get_recorders(&self) -> Result<Vec<RecorderRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, RecorderRow>(
             "SELECT room_id, created_at, platform, auto_start, extra FROM recorders",
         )
@@ -72,7 +72,7 @@ impl Database {
     }
 
     pub async fn remove_archive(&self, room_id: &str) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let _ = sqlx::query("DELETE FROM records WHERE room_id = $1")
             .bind(room_id)
             .execute(&lock)
@@ -86,7 +86,7 @@ impl Database {
         room_id: &str,
         auto_start: bool,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let _ = sqlx::query(
             "UPDATE recorders SET auto_start = $1 WHERE platform = $2 AND room_id = $3",
         )

--- a/src-tauri/src/database/summary.rs
+++ b/src-tauri/src/database/summary.rs
@@ -37,7 +37,7 @@ impl Database {
     pub async fn get_record_summary_statuses(
         &self,
     ) -> Result<Vec<RecordSummaryStatusRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, RecordSummaryStatusRow>(
             "SELECT platform, room_id, live_id, status, stage FROM record_summaries",
         )
@@ -46,7 +46,7 @@ impl Database {
     }
 
     pub async fn finish_pending_record_summaries(&self) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "UPDATE record_summaries SET status = 'failed', error_message = '任务因应用退出而中断', updated_at = $1 WHERE status = 'processing'",
         )
@@ -62,7 +62,7 @@ impl Database {
         room_id: &str,
         live_id: &str,
     ) -> Result<Option<RecordSummaryRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(sqlx::query_as::<_, RecordSummaryRow>(
             "SELECT * FROM record_summaries WHERE platform = $1 AND room_id = $2 AND live_id = $3",
         )
@@ -81,7 +81,7 @@ impl Database {
         task_id: &str,
         force: bool,
     ) -> Result<RecordSummaryRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let now = Utc::now().to_rfc3339();
         if force {
             sqlx::query(
@@ -138,7 +138,7 @@ impl Database {
         live_id: &str,
         stage: &str,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "UPDATE record_summaries SET status = 'processing', stage = $1, updated_at = $2 WHERE platform = $3 AND room_id = $4 AND live_id = $5",
         )
@@ -162,7 +162,7 @@ impl Database {
         subtitle_text: &str,
         source_duration: f64,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "UPDATE record_summaries SET subtitle_srt = $1, subtitle_text = $2, source_duration = $3, stage = 'summarizing', updated_at = $4 WHERE platform = $5 AND room_id = $6 AND live_id = $7",
         )
@@ -189,7 +189,7 @@ impl Database {
         model_provider: &str,
         model_name: &str,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "UPDATE record_summaries SET status = 'success', stage = 'completed', summary_markdown = $1, highlights_json = $2, model_provider = $3, model_name = $4, error_message = NULL, updated_at = $5 WHERE platform = $6 AND room_id = $7 AND live_id = $8",
         )
@@ -213,7 +213,7 @@ impl Database {
         live_id: &str,
         error: &str,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "UPDATE record_summaries SET status = 'failed', error_message = $1, updated_at = $2 WHERE platform = $3 AND room_id = $4 AND live_id = $5",
         )
@@ -233,7 +233,7 @@ impl Database {
         room_id: &str,
         live_id: &str,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query(
             "DELETE FROM record_summaries WHERE platform = $1 AND room_id = $2 AND live_id = $3",
         )

--- a/src-tauri/src/database/task.rs
+++ b/src-tauri/src/database/task.rs
@@ -35,7 +35,7 @@ impl Database {
     }
 
     pub async fn add_task(&self, task: &TaskRow) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let _ = sqlx::query(
             "INSERT INTO tasks (id, type, status, message, metadata, created_at) VALUES ($1, $2, $3, $4, $5, $6)",
         )
@@ -51,7 +51,7 @@ impl Database {
     }
 
     pub async fn get_tasks(&self) -> Result<Vec<TaskRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let tasks = sqlx::query_as::<_, TaskRow>("SELECT * FROM tasks")
             .fetch_all(&lock)
             .await?;
@@ -59,7 +59,7 @@ impl Database {
     }
 
     pub async fn get_task(&self, id: &str) -> Result<TaskRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let task = sqlx::query_as::<_, TaskRow>("SELECT * FROM tasks WHERE id = $1")
             .bind(id)
             .fetch_one(&lock)
@@ -74,7 +74,7 @@ impl Database {
         message: &str,
         metadata: Option<&str>,
     ) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         if let Some(metadata) = metadata {
             let _ = sqlx::query(
                 "UPDATE tasks SET status = $1, message = $2, metadata = $3 WHERE id = $4",
@@ -98,7 +98,7 @@ impl Database {
     }
 
     pub async fn delete_task(&self, id: &str) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let _ = sqlx::query("DELETE FROM tasks WHERE id = $1")
             .bind(id)
             .execute(&lock)
@@ -107,7 +107,7 @@ impl Database {
     }
 
     pub async fn finish_pending_tasks(&self) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let _ = sqlx::query(
             "UPDATE tasks SET status = 'failed' WHERE status = 'pending' or status = 'processing'",
         )

--- a/src-tauri/src/database/video.rs
+++ b/src-tauri/src/database/video.rs
@@ -23,7 +23,7 @@ pub struct VideoRow {
 
 impl Database {
     pub async fn get_videos(&self, room_id: &str) -> Result<Vec<VideoRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let videos = sqlx::query_as::<_, VideoRow>("SELECT * FROM videos WHERE room_id = $1;")
             .bind(room_id)
             .fetch_all(&lock)
@@ -32,7 +32,7 @@ impl Database {
     }
 
     pub async fn get_video(&self, id: i64) -> Result<VideoRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         Ok(
             sqlx::query_as::<_, VideoRow>("SELECT * FROM videos WHERE id = $1")
                 .bind(id)
@@ -42,7 +42,7 @@ impl Database {
     }
 
     pub async fn update_video(&self, video_row: &VideoRow) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("UPDATE videos SET status = $1, bvid = $2, title = $3, desc = $4, tags = $5, area = $6, note = $7 WHERE id = $8")
             .bind(video_row.status)
             .bind(&video_row.bvid)
@@ -58,7 +58,7 @@ impl Database {
     }
 
     pub async fn delete_video(&self, id: i64) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("DELETE FROM videos WHERE id = $1")
             .bind(id)
             .execute(&lock)
@@ -67,7 +67,7 @@ impl Database {
     }
 
     pub async fn add_video(&self, video: &VideoRow) -> Result<VideoRow, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let sql = sqlx::query("INSERT INTO videos (room_id, cover, file, note, length, size, status, bvid, title, desc, tags, area, created_at, platform) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)")
             .bind(&video.room_id)
             .bind(&video.cover)
@@ -93,7 +93,7 @@ impl Database {
     }
 
     pub async fn update_video_cover(&self, id: i64, cover: &str) -> Result<(), DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         sqlx::query("UPDATE videos SET cover = $1 WHERE id = $2")
             .bind(cover)
             .bind(id)
@@ -103,7 +103,7 @@ impl Database {
     }
 
     pub async fn get_all_videos(&self) -> Result<Vec<VideoRow>, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let videos =
             sqlx::query_as::<_, VideoRow>("SELECT * FROM videos ORDER BY created_at DESC;")
                 .fetch_all(&lock)
@@ -112,7 +112,7 @@ impl Database {
     }
 
     pub async fn get_video_cover(&self, id: i64) -> Result<String, DatabaseError> {
-        let lock = self.db.read().await.clone().unwrap();
+        let lock = self.pool().await?;
         let video = sqlx::query_as::<_, VideoRow>("SELECT * FROM videos WHERE id = $1")
             .bind(id)
             .fetch_one(&lock)

--- a/src-tauri/src/ffmpeg/general.rs
+++ b/src-tauri/src/ffmpeg/general.rs
@@ -51,15 +51,15 @@ pub async fn handle_ffmpeg_process(
     ffmpeg_process: &mut tokio::process::Command,
 ) -> Result<(), String> {
     log::info!("[FFmpeg] {:?}", ffmpeg_process);
-    let child = ffmpeg_process
+    let mut child = ffmpeg_process
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
-        .spawn();
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
     while let Ok(event) = parser.parse_next_event().await {

--- a/src-tauri/src/ffmpeg/hwaccel.rs
+++ b/src-tauri/src/ffmpeg/hwaccel.rs
@@ -394,13 +394,9 @@ pub async fn get_x264_encoder() -> &'static str {
 
     // 存入缓存，如果设置成功则从缓存返回，否则返回刚才得到的值
     // 注意：set() 可能被其他线程抢先，但每个线程都会得到相同的 encoder 值
-    match ENCODER_CACHE.set(encoder.clone()) {
-        Ok(_) => ENCODER_CACHE.get().unwrap().as_str(),
-        Err(_) => {
-            // 其他线程已经设置了，返回缓存的值
-            ENCODER_CACHE.get().unwrap().as_str()
-        }
-    }
+    let _ = ENCODER_CACHE.set(encoder);
+    // 其他线程可能抢先设置，但每个线程都会得到相同的 encoder 值
+    ENCODER_CACHE.get().map(String::as_str).unwrap_or("libx264")
 }
 
 #[cfg(test)]

--- a/src-tauri/src/ffmpeg/mod.rs
+++ b/src-tauri/src/ffmpeg/mod.rs
@@ -51,6 +51,19 @@ async fn wait_ffmpeg_exit(child: &mut tokio::process::Child, context: &str) -> R
     Ok(())
 }
 
+/// Render a path as a UTF-8 string for an ffmpeg argument.
+fn path_str(path: &Path) -> Result<&str, String> {
+    path.to_str()
+        .ok_or_else(|| format!("Path is not valid UTF-8: {}", path.display()))
+}
+
+/// File name of `path` as UTF-8, for display and ffmpeg filter strings.
+fn file_name_str(path: &Path) -> Result<&str, String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid file name: {}", path.display()))
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Range {
     pub start: f64,
@@ -109,7 +122,7 @@ pub async fn transcode(
     #[cfg(target_os = "windows")]
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
-    ffmpeg_process.args(["-i", file.to_str().unwrap()]);
+    ffmpeg_process.args(["-i", path_str(file)?]);
 
     if copy_codecs {
         ffmpeg_process.args(["-c:v", "copy"]).args(["-c:a", "copy"]);
@@ -126,29 +139,26 @@ pub async fn transcode(
     }
 
     let child = ffmpeg_process
-        .args([output_path.to_str().unwrap()])
+        .args([path_str(output_path)?])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
         .stderr(Stdio::piped())
         .spawn();
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
     while let Ok(event) = parser.parse_next_event().await {
         match event {
             FfmpegEvent::Progress(p) => {
-                if reporter.is_none() {
-                    continue;
+                if let Some(reporter) = reporter {
+                    reporter
+                        .update(format!("压制中：{}", p.time).as_str())
+                        .await;
                 }
-                reporter
-                    .unwrap()
-                    .update(format!("压制中：{}", p.time).as_str())
-                    .await;
             }
             FfmpegEvent::LogEOF => break,
             FfmpegEvent::Error(e) => {
@@ -178,33 +188,30 @@ pub async fn trim_video(
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
     ffmpeg_process.args(["-ss", &start_time.to_string()]);
-    ffmpeg_process.args(["-i", file.to_str().unwrap()]);
+    ffmpeg_process.args(["-i", path_str(file)?]);
     ffmpeg_process.args(["-t", &duration.to_string()]);
     ffmpeg_process.args(["-c", "copy"]);
-    ffmpeg_process.args([output_path.to_str().unwrap()]);
+    ffmpeg_process.args([path_str(output_path)?]);
     ffmpeg_process.args(["-y"]);
     ffmpeg_process.args(["-progress", "pipe:2"]);
     ffmpeg_process.stderr(Stdio::piped());
     let child = ffmpeg_process.spawn();
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
     while let Ok(event) = parser.parse_next_event().await {
         match event {
             FfmpegEvent::Progress(p) => {
-                if reporter.is_none() {
-                    continue;
+                if let Some(reporter) = reporter {
+                    reporter
+                        .update(format!("切片中：{}", p.time).as_str())
+                        .await;
                 }
-                reporter
-                    .unwrap()
-                    .update(format!("切片中：{}", p.time).as_str())
-                    .await;
             }
             FfmpegEvent::LogEOF => break,
             FfmpegEvent::Error(e) => {
@@ -237,7 +244,7 @@ pub async fn extract_audio_sample(file: &Path) -> Result<PathBuf, String> {
     ffmpeg_process.kill_on_drop(true);
 
     let child = ffmpeg_process
-        .args(["-i", file.to_str().unwrap()])
+        .args(["-i", path_str(file)?])
         .args(["-c:a", "libopus"])
         .args(["-ar", "16000"])
         .args(["-ac", "1"])
@@ -245,18 +252,17 @@ pub async fn extract_audio_sample(file: &Path) -> Result<PathBuf, String> {
         .args(["-b:a", "64k"])
         .args(["-vbr", "on"])
         .args(["-compression_level", "10"])
-        .args([output_path.to_str().unwrap()])
+        .args([path_str(&output_path)?])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
         .stderr(Stdio::piped())
         .spawn();
 
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
     while let Ok(event) = parser.parse_next_event().await {
@@ -307,8 +313,13 @@ pub async fn extract_audio_chunks(file: &Path, format: &str) -> Result<PathBuf, 
     log::info!("Splitting into {chunk_count} chunks of {chunk_duration} seconds each");
 
     // Create output directory for chunks
-    let output_dir = output_path.parent().unwrap();
-    let base_name = output_path.file_stem().unwrap().to_str().unwrap();
+    let output_dir = output_path
+        .parent()
+        .ok_or_else(|| format!("Output path has no parent: {}", output_path.display()))?;
+    let base_name = output_path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid output file name: {}", output_path.display()))?;
     let chunk_dir = output_dir.join(format!("{base_name}_chunks"));
 
     if !chunk_dir.exists() {
@@ -320,9 +331,9 @@ pub async fn extract_audio_chunks(file: &Path, format: &str) -> Result<PathBuf, 
     let segment_pattern = chunk_dir.join(format!("{base_name}_%03d.{format}"));
 
     // 构建优化的ffmpeg命令参数
-    let file_str = file.to_str().unwrap();
+    let file_str = path_str(file)?;
     let chunk_duration_str = chunk_duration.to_string();
-    let segment_pattern_str = segment_pattern.to_str().unwrap();
+    let segment_pattern_str = path_str(&segment_pattern)?;
 
     let mut args = vec![
         "-i",
@@ -373,12 +384,11 @@ pub async fn extract_audio_chunks(file: &Path, format: &str) -> Result<PathBuf, 
 
     let child = ffmpeg_process.args(&args).stderr(Stdio::piped()).spawn();
 
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -437,7 +447,10 @@ pub async fn extract_full_audio(file: &Path) -> Result<PathBuf, String> {
         .spawn();
 
     let mut child = child.map_err(|e| format!("Failed to spawn ffmpeg: {e}"))?;
-    let stderr = child.stderr.take().unwrap();
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -496,7 +509,10 @@ pub async fn extract_audio_segment(
         .spawn();
 
     let mut child = child.map_err(|e| format!("Failed to spawn ffmpeg: {e}"))?;
-    let stderr = child.stderr.take().unwrap();
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -533,17 +549,16 @@ async fn get_audio_duration(file: &Path) -> Result<u64, String> {
         .args(["-v", "quiet"])
         .args(["-show_entries", "format=duration"])
         .args(["-of", "csv=p=0"])
-        .args(["-i", file.to_str().unwrap()])
+        .args(["-i", path_str(file)?])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn();
 
-    if let Err(e) = child {
-        return Err(format!("Failed to spawn ffprobe process: {e}"));
-    }
-
-    let mut child = child.unwrap();
-    let stdout = child.stdout.take().unwrap();
+    let mut child = child.map_err(|e| format!("Failed to spawn ffprobe process: {e}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("ffprobe stdout pipe unavailable")?;
     let reader = BufReader::new(stdout);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -593,11 +608,7 @@ pub async fn encode_video_subtitle(
         }
     }
     // output path is file with prefix [subtitle]
-    let output_filename = format!(
-        "{}{}",
-        constants::PREFIX_SUBTITLE,
-        file.file_name().unwrap().to_str().unwrap()
-    );
+    let output_filename = format!("{}{}", constants::PREFIX_SUBTITLE, file_name_str(file)?);
     let output_path = file.with_file_name(&output_filename);
 
     // check output path exists - log but allow overwrite
@@ -613,9 +624,7 @@ pub async fn encode_video_subtitle(
     // if windows
     let subtitle = if cfg!(target_os = "windows") {
         // escape characters in subtitle path
-        let subtitle = subtitle
-            .to_str()
-            .unwrap()
+        let subtitle = path_str(subtitle)?
             .replace('\\', "\\\\")
             .replace(':', "\\:");
         format!("'{subtitle}'")
@@ -634,23 +643,22 @@ pub async fn encode_video_subtitle(
 
     let video_encoder = hwaccel::get_x264_encoder().await;
 
-    ffmpeg_process.args(["-i", file.to_str().unwrap()]);
+    ffmpeg_process.args(["-i", path_str(file)?]);
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
     ffmpeg_process.args(["-c:a", "copy"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
     let child = ffmpeg_process
-        .args([output_path.to_str().unwrap()])
+        .args([path_str(&output_path)?])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
         .stderr(Stdio::piped())
         .spawn();
 
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -693,11 +701,7 @@ pub async fn encode_video_danmu(
 ) -> Result<PathBuf, String> {
     // ffmpeg -i fixed_\[30655190\]1742887114_0325084106_81.5.mp4 -vf ass=subtitle.ass -c:v libx264 -c:a copy output.mp4
     log::info!("Encode video danmu task start: {}", file.display());
-    let danmu_filename = format!(
-        "{}{}",
-        constants::PREFIX_DANMAKU,
-        file.file_name().unwrap().to_str().unwrap()
-    );
+    let danmu_filename = format!("{}{}", constants::PREFIX_DANMAKU, file_name_str(file)?);
     let output_file_path = file.with_file_name(danmu_filename);
 
     // check output path exists - log but allow overwrite
@@ -713,9 +717,7 @@ pub async fn encode_video_danmu(
     // if windows
     let subtitle = if cfg!(target_os = "windows") {
         // escape characters in subtitle path
-        let subtitle = subtitle
-            .to_str()
-            .unwrap()
+        let subtitle = path_str(subtitle)?
             .replace('\\', "\\\\")
             .replace(':', "\\:");
         format!("'{subtitle}'")
@@ -730,23 +732,22 @@ pub async fn encode_video_danmu(
     let video_encoder = hwaccel::get_x264_encoder().await;
 
     let vf = format!("{},ass={subtitle}", hwaccel::H264_SCALE_PAD_FILTER);
-    ffmpeg_process.args(["-i", file.to_str().unwrap()]);
+    ffmpeg_process.args(["-i", path_str(file)?]);
     hwaccel::apply_x264_encoder_args(&mut ffmpeg_process, video_encoder, Some(vf.as_str()));
     ffmpeg_process.args(["-c:a", "copy"]);
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
     let child = ffmpeg_process
-        .args([output_file_path.to_str().unwrap()])
+        .args([path_str(&output_file_path)?])
         .args(["-y"])
         .args(["-progress", "pipe:2"])
         .stderr(Stdio::piped())
         .spawn();
 
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -758,13 +759,11 @@ pub async fn encode_video_danmu(
             }
             FfmpegEvent::Progress(p) => {
                 log::debug!("Encode video danmu progress: {}", p.time);
-                if reporter.is_none() {
-                    continue;
+                if let Some(reporter) = reporter {
+                    reporter
+                        .update(format!("压制中：{}", p.time).as_str())
+                        .await;
                 }
-                reporter
-                    .unwrap()
-                    .update(format!("压制中：{}", p.time).as_str())
-                    .await;
             }
             FfmpegEvent::Log(_level, _content) => {}
             FfmpegEvent::LogEOF => break,
@@ -795,12 +794,11 @@ pub async fn generic_ffmpeg_command(args: &[&str]) -> Result<String, String> {
     ffmpeg_process.creation_flags(CREATE_NO_WINDOW);
 
     let child = ffmpeg_process.args(args).stderr(Stdio::piped()).spawn();
-    if let Err(e) = child {
-        return Err(e.to_string());
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| e.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -1036,8 +1034,11 @@ pub async fn generate_video_subtitle(
                     chunk_paths.push(path);
                 }
                 // sort chunk paths by name
-                chunk_paths
-                    .sort_by_key(|path| path.file_name().unwrap().to_str().unwrap().to_string());
+                chunk_paths.sort_by_key(|path| {
+                    path.file_name()
+                        .map(|name| name.to_string_lossy().into_owned())
+                        .unwrap_or_default()
+                });
 
                 let mut results = Vec::new();
                 for path in chunk_paths {
@@ -1097,24 +1098,19 @@ pub async fn generate_video_subtitle(
 
 /// Trying to run ffmpeg for version
 pub async fn check_ffmpeg() -> Result<String, String> {
-    let child = tokio::process::Command::new(ffmpeg_path())
+    let mut child = tokio::process::Command::new(ffmpeg_path())
         .arg("-version")
         .stdout(Stdio::piped())
-        .spawn();
-    if let Err(e) = child {
-        log::error!("Failed to spawn ffmpeg process: {e}");
-        return Err(e.to_string());
-    }
+        .spawn()
+        .map_err(|e| {
+            log::error!("Failed to spawn ffmpeg process: {e}");
+            e.to_string()
+        })?;
 
-    let mut child = child.unwrap();
-
-    let stdout = child.stdout.take();
-    if stdout.is_none() {
+    let stdout = child.stdout.take().ok_or_else(|| {
         log::error!("Failed to take ffmpeg output");
-        return Err("Failed to take ffmpeg output".into());
-    }
-
-    let stdout = stdout.unwrap();
+        "Failed to take ffmpeg output".to_string()
+    })?;
     let reader = BufReader::new(stdout);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -1166,9 +1162,12 @@ pub async fn clip_from_video_file(
     start_time: f64,
     duration: f64,
 ) -> Result<(), String> {
-    let output_folder = output_path.parent().unwrap();
+    let output_folder = output_path
+        .parent()
+        .ok_or_else(|| format!("Output path has no parent: {}", output_path.display()))?;
     if !output_folder.exists() {
-        std::fs::create_dir_all(output_folder).unwrap();
+        std::fs::create_dir_all(output_folder)
+            .map_err(|e| format!("Failed to create output directory: {e}"))?;
     }
 
     let mut ffmpeg_process = ffmpeg_command();
@@ -1186,17 +1185,16 @@ pub async fn clip_from_video_file(
     hwaccel::apply_x264_quality_args(&mut ffmpeg_process, video_encoder);
     let child = ffmpeg_process
         .args(["-avoid_negative_ts", "make_zero"])
-        .args(["-y", output_path.to_str().unwrap()])
+        .args(["-y", path_str(output_path)?])
         .args(["-progress", "pipe:2"])
         .stderr(Stdio::piped())
         .spawn();
 
-    if let Err(e) = child {
-        return Err(format!("启动ffmpeg进程失败: {e}"));
-    }
-
-    let mut child = child.unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let mut child = child.map_err(|e| format!("启动ffmpeg进程失败: {e}"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -1324,7 +1322,7 @@ pub async fn generate_thumbnail(video_full_path: &Path, timestamp: f64) -> Resul
         .args(["-i", &format!("{}", video_full_path.display())])
         .args(["-ss", &timestamp.to_string()])
         .args(["-vframes", "1"])
-        .args(["-y", thumbnail_full_path.to_str().unwrap()])
+        .args(["-y", path_str(&thumbnail_full_path)?])
         .output()
         .await
         .map_err(|e| format!("生成缩略图失败: {e}"))?;
@@ -1365,7 +1363,10 @@ pub async fn execute_ffmpeg_conversion(
         .spawn()
         .map_err(|e| format!("启动FFmpeg进程失败: {e}"))?;
 
-    let stderr = child.stderr.take().unwrap();
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or("ffmpeg stderr pipe unavailable")?;
     let reader = BufReader::new(stderr);
     let mut parser = FfmpegLogParser::new(reader);
 
@@ -1907,7 +1908,7 @@ mod tests {
         let subtitle_filename = format!(
             "{}{}",
             constants::PREFIX_SUBTITLE,
-            test_file.file_name().unwrap().to_str().unwrap()
+            file_name_str(test_file).expect("test path is valid UTF-8")
         );
         assert!(subtitle_filename.starts_with(constants::PREFIX_SUBTITLE));
         assert!(subtitle_filename.contains("test.mp4"));
@@ -1916,7 +1917,7 @@ mod tests {
         let danmu_filename = format!(
             "{}{}",
             constants::PREFIX_DANMAKU,
-            test_file.file_name().unwrap().to_str().unwrap()
+            file_name_str(test_file).expect("test path is valid UTF-8")
         );
         assert!(danmu_filename.starts_with(constants::PREFIX_DANMAKU));
         assert!(danmu_filename.contains("test.mp4"));

--- a/src-tauri/src/handlers/account.rs
+++ b/src-tauri/src/handlers/account.rs
@@ -74,7 +74,7 @@ pub async fn add_account(
                 uid,
                 name: String::new(),
                 avatar: String::new(),
-                csrf: csrf.clone().unwrap(),
+                csrf: csrf.clone().unwrap_or_default(),
                 cookies: cookies.into(),
                 created_at: Utc::now().to_rfc3339(),
             };
@@ -212,7 +212,7 @@ pub async fn add_account(
         uid: user_info.user_id,
         name: user_info.user_name,
         avatar: user_info.user_avatar,
-        csrf: csrf.unwrap(),
+        csrf: csrf.unwrap_or_default(),
         cookies: cookies.into(),
         created_at: Utc::now().to_rfc3339(),
     };

--- a/src-tauri/src/handlers/recorder.rs
+++ b/src-tauri/src/handlers/recorder.rs
@@ -39,7 +39,7 @@ pub async fn add_recorder(
     mut extra: String,
 ) -> Result<RecorderRow, String> {
     log::info!("Add recorder: {platform} {room_id}");
-    let platform = PlatformType::from_str(&platform).unwrap();
+    let platform = PlatformType::from_str(&platform).map_err(|e| e.to_string())?;
     let account = match platform {
         PlatformType::BiliBili => {
             if let Ok(account) = state.db.get_account_by_platform("bilibili").await {
@@ -142,7 +142,7 @@ pub async fn remove_recorder(
     room_id: String,
 ) -> Result<(), String> {
     log::info!("Remove recorder: {platform} {room_id}");
-    let platform = PlatformType::from_str(&platform).unwrap();
+    let platform = PlatformType::from_str(&platform).map_err(|e| e.to_string())?;
     match state
         .recorder_manager
         .remove_recorder(platform, &room_id)
@@ -177,7 +177,7 @@ pub async fn get_room_info(
     platform: String,
     room_id: String,
 ) -> Result<RecorderInfo, String> {
-    let platform = PlatformType::from_str(&platform).unwrap();
+    let platform = PlatformType::from_str(&platform).map_err(|e| e.to_string())?;
     if let Some(info) = state
         .recorder_manager
         .get_recorder_info(platform, &room_id)

--- a/src-tauri/src/handlers/utils.rs
+++ b/src-tauri/src/handlers/utils.rs
@@ -37,10 +37,10 @@ pub fn copy_dir_all(
 pub fn show_in_folder(path: String) {
     #[cfg(target_os = "windows")]
     {
-        Command::new("explorer")
-            .args(["/select,", &path]) // The comma after select is not a typo
-            .spawn()
-            .unwrap();
+        // The comma after select is not a typo
+        if let Err(e) = Command::new("explorer").args(["/select,", &path]).spawn() {
+            log::error!("Failed to open folder {path}: {e}");
+        }
     }
 
     #[cfg(target_os = "linux")]
@@ -49,44 +49,38 @@ pub fn show_in_folder(path: String) {
         use std::path::PathBuf;
         if path.contains(",") {
             // see https://gitlab.freedesktop.org/dbus/dbus/-/issues/76
-            let new_path = match metadata(&path).unwrap().is_dir() {
-                true => path,
-                false => {
-                    let mut path2 = PathBuf::from(path);
-                    path2.pop();
-                    path2.into_os_string().into_string().unwrap()
-                }
+            let is_dir = metadata(&path).map(|m| m.is_dir()).unwrap_or(false);
+            let new_path = if is_dir {
+                path
+            } else {
+                let mut path2 = PathBuf::from(path);
+                path2.pop();
+                path2.to_string_lossy().into_owned()
             };
-            let _ = Command::new("xdg-open")
-                .arg(&new_path)
-                .spawn()
-                .unwrap()
-                .wait();
-        } else {
-            let _ = Command::new("dbus-send")
-                .args([
-                    "--session",
-                    "--dest=org.freedesktop.FileManager1",
-                    "--type=method_call",
-                    "/org/freedesktop/FileManager1",
-                    "org.freedesktop.FileManager1.ShowItems",
-                    format!("array:string:\"file://{path}\"").as_str(),
-                    "string:\"\"",
-                ])
-                .spawn()
-                .unwrap()
-                .wait();
+            if let Err(e) = Command::new("xdg-open").arg(&new_path).spawn() {
+                log::error!("Failed to open folder {new_path}: {e}");
+            }
+        } else if let Err(e) = Command::new("dbus-send")
+            .args([
+                "--session",
+                "--dest=org.freedesktop.FileManager1",
+                "--type=method_call",
+                "/org/freedesktop/FileManager1",
+                "org.freedesktop.FileManager1.ShowItems",
+                format!("array:string:\"file://{path}\"").as_str(),
+                "string:\"\"",
+            ])
+            .spawn()
+        {
+            log::error!("Failed to reveal {path}: {e}");
         }
     }
 
     #[cfg(target_os = "macos")]
     {
-        Command::new("open")
-            .args(["-R", &path])
-            .spawn()
-            .unwrap()
-            .wait()
-            .unwrap();
+        if let Err(e) = Command::new("open").args(["-R", &path]).spawn() {
+            log::error!("Failed to reveal {path}: {e}");
+        }
     }
 }
 
@@ -104,7 +98,8 @@ pub async fn get_disk_info(state: state_type!()) -> Result<DiskInfo, ()> {
     let mut cache = PathBuf::from(&cache);
     if cache.is_relative() {
         // get current working directory
-        let cwd = std::env::current_dir().unwrap();
+        let cwd = std::env::current_dir()
+            .map_err(|e| log::error!("Failed to get current directory: {e}"))?;
         cache = cwd.join(cache);
     }
 
@@ -130,8 +125,9 @@ pub async fn get_disk_info_inner(target: PathBuf) -> Result<DiskInfo, ()> {
             .arg(target)
             .output()
             .await
-            .unwrap();
-        let output_str = String::from_utf8(output.stdout).unwrap();
+            .map_err(|e| log::error!("Failed to run df: {e}"))?;
+        let output_str =
+            String::from_utf8(output.stdout).map_err(|e| log::error!("Invalid df output: {e}"))?;
         // Filesystem     1K-blocks     Used Available Use% Mounted on
         // /dev/nvme0n1p2 959218776 43826092 866593352   5% /app/cache
         let lines = output_str.lines().collect::<Vec<&str>>();
@@ -140,9 +136,19 @@ pub async fn get_disk_info_inner(target: PathBuf) -> Result<DiskInfo, ()> {
             return Err(());
         }
         let parts = lines[1].split_whitespace().collect::<Vec<&str>>();
+        if parts.len() < 4 {
+            log::error!("Unexpected df output: {}", lines[1]);
+            return Err(());
+        }
         let disk = parts[0].to_string();
-        let total = parts[1].parse::<u64>().unwrap() * 1024;
-        let free = parts[3].parse::<u64>().unwrap() * 1024;
+        let total = parts[1]
+            .parse::<u64>()
+            .map_err(|e| log::error!("Failed to parse total blocks: {e}"))?
+            * 1024;
+        let free = parts[3]
+            .parse::<u64>()
+            .map_err(|e| log::error!("Failed to parse free blocks: {e}"))?
+            * 1024;
 
         Ok(DiskInfo { disk, total, free })
     }
@@ -161,9 +167,9 @@ pub async fn get_disk_info_inner(target: PathBuf) -> Result<DiskInfo, ()> {
         // Find the disk with the longest matching mount point
         let mut longest_match = 0;
         for disk in disks.list() {
-            let mount_point = disk.mount_point().to_str().unwrap();
-            if target.starts_with(mount_point) && mount_point.split('/').count() > longest_match {
-                disk_info.disk = mount_point.into();
+            let mount_point = disk.mount_point().to_string_lossy();
+            if target.starts_with(&*mount_point) && mount_point.split('/').count() > longest_match {
+                disk_info.disk = mount_point.to_string();
                 disk_info.total = disk.total_space();
                 disk_info.free = disk.available_space();
                 longest_match = mount_point.split('/').count();
@@ -181,16 +187,13 @@ pub async fn export_to_file(
     file_name: &str,
     content: &str,
 ) -> Result<(), String> {
-    let file = OpenOptions::new()
+    let mut file = OpenOptions::new()
         .create(true)
         .write(true)
         .truncate(true)
         .open(file_name)
-        .await;
-    if file.is_err() {
-        return Err(format!("Open file failed: {}", file.err().unwrap()));
-    }
-    let mut file = file.unwrap();
+        .await
+        .map_err(|e| format!("Open file failed: {e}"))?;
     if let Err(e) = file.write_all(content.as_bytes()).await {
         return Err(format!("Write file failed: {e}"));
     }
@@ -205,8 +208,12 @@ pub async fn export_to_file(
 pub async fn open_log_folder(state: state_type!()) -> Result<(), String> {
     #[cfg(feature = "gui")]
     {
-        let log_dir = state.app_handle.path().app_log_dir().unwrap();
-        show_in_folder(log_dir.to_str().unwrap().to_string());
+        let log_dir = state
+            .app_handle
+            .path()
+            .app_log_dir()
+            .map_err(|e| format!("Failed to get log dir: {e}"))?;
+        show_in_folder(log_dir.to_string_lossy().into_owned());
     }
     Ok(())
 }
@@ -321,13 +328,10 @@ pub async fn open_clip(state: state_type!(), video_id: i64) -> Result<(), String
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn list_folder(_state: state_type!(), path: String) -> Result<Vec<String>, String> {
     let path = PathBuf::from(path);
-    let entries = std::fs::read_dir(path);
-    if entries.is_err() {
-        return Err(format!("Read directory failed: {}", entries.err().unwrap()));
-    }
+    let entries = std::fs::read_dir(path).map_err(|e| format!("Read directory failed: {e}"))?;
     let mut files = Vec::new();
-    for entry in entries.unwrap().flatten() {
-        files.push(entry.path().to_str().unwrap().to_string());
+    for entry in entries.flatten() {
+        files.push(entry.path().to_string_lossy().into_owned());
     }
     Ok(files)
 }

--- a/src-tauri/src/handlers/video.rs
+++ b/src-tauri/src/handlers/video.rs
@@ -307,7 +307,8 @@ pub async fn clip_range(
     let mut output = PathBuf::from(&output);
     if output.is_relative() {
         // get current working directory
-        let cwd = std::env::current_dir().unwrap();
+        let cwd =
+            std::env::current_dir().map_err(|e| format!("Failed to get current directory: {e}"))?;
         output = cwd.join(output);
     }
 
@@ -370,18 +371,19 @@ pub async fn clip_range(
                                 video.id,
                             )
                             .await;
-                            if let Ok(subtitle) = result {
-                                let result =
-                                    update_video_subtitle_inner(&state_clone, video.id, subtitle)
-                                        .await;
-                                if let Err(e) = result {
-                                    log::error!("Update video subtitle error: {e}");
+                            match result {
+                                Ok(subtitle) => {
+                                    let result = update_video_subtitle_inner(
+                                        &state_clone,
+                                        video.id,
+                                        subtitle,
+                                    )
+                                    .await;
+                                    if let Err(e) = result {
+                                        log::error!("Update video subtitle error: {e}");
+                                    }
                                 }
-                            } else {
-                                log::error!(
-                                    "Generate video subtitle error: {}",
-                                    result.err().unwrap()
-                                );
+                                Err(e) => log::error!("Generate video subtitle error: {e}"),
                             }
                         }
 
@@ -481,6 +483,11 @@ async fn clip_range_inner(
         return Err("Failed to convert metadata length to i64".to_string());
     };
     let duration = params.ranges.iter().map(|r| r.duration()).sum::<f64>();
+    let cover_name = cover_file
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid cover path: {}", cover_file.display()))?
+        .to_string();
     let video = state
         .db
         .add_video(&VideoRow {
@@ -488,12 +495,7 @@ async fn clip_range_inner(
             status: 0,
             room_id: params.room_id.clone(),
             created_at: Local::now().to_rfc3339(),
-            cover: cover_file
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .to_string(),
+            cover: cover_name,
             file: filename.into(),
             note: params.note.clone(),
             length: duration as i64,
@@ -528,7 +530,7 @@ async fn clip_range_inner(
                 params.room_id, filename
             ))
             .show()
-            .unwrap();
+            .unwrap_or_else(|e| log::warn!("Failed to show clip notification: {e}"));
     }
 
     reporter.finish(true, "切片完成").await;
@@ -648,7 +650,7 @@ async fn upload_procedure_inner(
                         .title("BiliShadowReplay - 投稿成功")
                         .body(format!("投稿了房间 {} 的切片: {}", room_id, ret.bvid))
                         .show()
-                        .unwrap();
+                        .unwrap_or_else(|e| log::warn!("Failed to show post notification: {e}"));
                 }
                 reporter.finish(true, "投稿成功").await;
                 Ok(ret.bvid)
@@ -798,14 +800,20 @@ pub async fn update_video_cover(
     let output_path = Path::new(state.config.read().await.output.as_str()).join(&video.file);
     let cover_path = output_path.with_extension("jpg");
     // decode cover and write into file
-    let base64 = cover.split("base64,").nth(1).unwrap();
+    let base64 = cover
+        .split("base64,")
+        .nth(1)
+        .ok_or_else(|| "Cover is not a base64 data URL".to_string())?;
     let bytes = base64::engine::general_purpose::STANDARD
         .decode(base64)
-        .unwrap();
+        .map_err(|e| format!("Failed to decode cover: {e}"))?;
     tokio::fs::write(&cover_path, bytes)
         .await
         .map_err(|e| e.to_string())?;
-    let cover_file_name = cover_path.file_name().unwrap().to_str().unwrap();
+    let cover_file_name = cover_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| format!("Invalid cover path: {}", cover_path.display()))?;
     log::debug!("Update video cover: {id} {cover_file_name}");
     Ok(state.db.update_video_cover(id, cover_file_name).await?)
 }
@@ -1125,9 +1133,8 @@ pub async fn import_external_video(
         // 更新最终文件名和路径
         target_filename = mp4_target_full_path
             .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| format!("Invalid target path: {}", mp4_target_full_path.display()))?
             .to_string();
         mp4_target_full_path
     } else {
@@ -1143,7 +1150,11 @@ pub async fn import_external_video(
     let thumbnail_timestamp = get_optimal_thumbnail_timestamp(metadata.duration);
     let cover_path =
         match ffmpeg::generate_thumbnail(&final_target_full_path, thumbnail_timestamp).await {
-            Ok(path) => path.file_name().unwrap().to_str().unwrap().to_string(),
+            Ok(path) => path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| format!("Invalid thumbnail path: {}", path.display()))?
+                .to_string(),
             Err(e) => {
                 log::warn!("生成缩略图失败: {e}");
                 String::new() // 使用空字符串，前端会显示默认图标
@@ -1334,9 +1345,10 @@ async fn clip_video_inner(
         match ffmpeg::generate_thumbnail(&output_full_path, clip_thumbnail_timestamp).await {
             Ok(_) => thumbnail_full_path
                 .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| {
+                    format!("Invalid thumbnail path: {}", thumbnail_full_path.display())
+                })?
                 .to_string(),
             Err(e) => {
                 log::warn!("生成切片缩略图失败: {e}");

--- a/src-tauri/src/handlers/video_editing.rs
+++ b/src-tauri/src/handlers/video_editing.rs
@@ -72,6 +72,12 @@ fn resolve_video_path(output_dir: &Path, file: &str) -> PathBuf {
     }
 }
 
+/// Render a path as a UTF-8 string for an ffmpeg argument.
+fn path_str(path: &Path) -> Result<&str, String> {
+    path.to_str()
+        .ok_or_else(|| format!("Path is not valid UTF-8: {}", path.display()))
+}
+
 /// Extract frames from a video at specific timestamps or evenly distributed
 #[cfg_attr(feature = "gui", tauri::command)]
 pub async fn extract_video_frames(
@@ -143,13 +149,13 @@ async fn extract_frame_at_timestamp(video_path: &Path, timestamp: f64) -> Result
         "-ss",
         &timestamp.to_string(),
         "-i",
-        video_path.to_str().unwrap(),
+        path_str(video_path)?,
         "-vframes",
         "1",
         "-q:v",
         "2",
         "-y",
-        output_path.to_str().unwrap(),
+        path_str(&output_path)?,
     ]);
 
     let output = cmd
@@ -217,7 +223,7 @@ async fn get_video_metadata_internal(video_path: &Path) -> Result<VideoMetadata,
         "json",
         "-show_format",
         "-show_streams",
-        video_path.to_str().unwrap(),
+        path_str(video_path)?,
     ]);
 
     let output = cmd
@@ -503,11 +509,11 @@ pub async fn merge_videos(
             "-safe",
             "0",
             "-i",
-            concat_file.to_str().unwrap(),
+            path_str(&concat_file)?,
             "-c",
             "copy",
             "-y",
-            output_path.to_str().unwrap(),
+            path_str(&output_path)?,
         ]);
 
         let output = cmd
@@ -622,7 +628,7 @@ pub async fn merge_videos(
             "-c:a",
             "aac",
             "-y",
-            output_path.to_str().unwrap(),
+            path_str(&output_path)?,
         ]);
 
         let output = cmd
@@ -712,14 +718,14 @@ pub async fn extract_video_audio(state: state_type!(), video_id: i64) -> Result<
 
     cmd.args([
         "-i",
-        video_path.to_str().unwrap(),
+        path_str(&video_path)?,
         "-vn",
         "-acodec",
         "libmp3lame",
         "-q:a",
         "2",
         "-y",
-        output_path.to_str().unwrap(),
+        path_str(&output_path)?,
     ]);
 
     let output = cmd

--- a/src-tauri/src/http_server/api_server.rs
+++ b/src-tauri/src/http_server/api_server.rs
@@ -1005,11 +1005,11 @@ async fn handler_image_base64(
                 let headers = response.headers_mut();
                 headers.insert(
                     axum::http::header::CONTENT_TYPE,
-                    content_type.parse().unwrap(),
+                    axum::http::HeaderValue::from_static(content_type),
                 );
                 headers.insert(
                     axum::http::header::CACHE_CONTROL,
-                    "public, max-age=3600".parse().unwrap(),
+                    axum::http::HeaderValue::from_static("public, max-age=3600"),
                 );
 
                 return Ok(response);
@@ -1716,11 +1716,13 @@ async fn handler_upload_file(
         }
     }
 
-    if file_name.is_empty() || uploaded_file_path.is_none() {
+    if file_name.is_empty() {
         return Err(ApiError("No file uploaded".to_string()));
     }
 
-    let file_path = uploaded_file_path.unwrap();
+    let Some(file_path) = uploaded_file_path else {
+        return Err(ApiError("No file uploaded".to_string()));
+    };
     let file_path_str = file_path.to_string_lossy().to_string();
 
     log::info!("File uploaded: {} ({} bytes)", file_path_str, file_size);
@@ -1778,17 +1780,23 @@ async fn handler_hls(
     // Set content type
     headers.insert(
         axum::http::header::CONTENT_TYPE,
-        content_type.parse().unwrap(),
+        axum::http::HeaderValue::from_static(content_type),
     );
 
     // Only set cache control for m3u8 files
     if filename.ends_with(".m3u8") {
         headers.insert(
             axum::http::header::CACHE_CONTROL,
-            "no-cache, no-store, must-revalidate".parse().unwrap(),
+            axum::http::HeaderValue::from_static("no-cache, no-store, must-revalidate"),
         );
-        headers.insert(axum::http::header::PRAGMA, "no-cache".parse().unwrap());
-        headers.insert(axum::http::header::EXPIRES, "0".parse().unwrap());
+        headers.insert(
+            axum::http::header::PRAGMA,
+            axum::http::HeaderValue::from_static("no-cache"),
+        );
+        headers.insert(
+            axum::http::header::EXPIRES,
+            axum::http::HeaderValue::from_static("0"),
+        );
     }
 
     Ok(response)

--- a/src-tauri/src/jianying/mod.rs
+++ b/src-tauri/src/jianying/mod.rs
@@ -75,7 +75,7 @@ pub async fn generate_premiere_xml(
         xml.push_str("\">\n");
         xml.push_str(&format!(
             "            <name>{}</name>\n",
-            escape_xml(&clip.file_path.file_name().unwrap().to_string_lossy())
+            escape_xml(&clip.file_path.file_name().map(|n| n.to_string_lossy()).unwrap_or_default())
         ));
         xml.push_str(&format!(
             "            <start>{}</start>\n",
@@ -97,7 +97,7 @@ pub async fn generate_premiere_xml(
         xml.push_str("\">\n");
         xml.push_str(&format!(
             "              <name>{}</name>\n",
-            escape_xml(&clip.file_path.file_name().unwrap().to_string_lossy())
+            escape_xml(&clip.file_path.file_name().map(|n| n.to_string_lossy()).unwrap_or_default())
         ));
         xml.push_str(&format!(
             "              <pathurl>{}</pathurl>\n",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -562,13 +562,8 @@ async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Err
     let db_pool: Pool<Sqlite> = Pool::connect(&conn_url).await?;
     let migrations = get_migrations();
 
-    let migrator = Migrator::new(MigrationList(migrations))
-        .await
-        .expect("Failed to create migrator");
-    migrator
-        .run(&db_pool)
-        .await
-        .expect("Failed to run migrations");
+    let migrator = Migrator::new(MigrationList(migrations)).await?;
+    migrator.run(&db_pool).await?;
 
     db.set(db_pool).await;
     db.finish_pending_tasks().await?;
@@ -577,7 +572,8 @@ async fn setup_server_state(args: Args) -> Result<State, Box<dyn std::error::Err
     let progress_manager = Arc::new(ProgressManager::new());
     let emitter = EventEmitter::new(progress_manager.get_event_sender());
     let webhook_poster =
-        webhook::poster::create_webhook_poster(&config.read().await.webhook_url, None).unwrap();
+        webhook::poster::create_webhook_poster(&config.read().await.webhook_url, None)
+            .map_err(|e| e.to_string())?;
     let mut task_manager = TaskManager::new();
     task_manager.start();
     let task_manager = Arc::new(task_manager);
@@ -619,7 +615,8 @@ async fn setup_app_state(app: &tauri::App) -> Result<State, Box<dyn std::error::
     setup_logging(&log_dir).await?;
 
     log::info!("Setting up app state...");
-    let app_dirs = AppDirs::new(Some("cn.vjoi.bili-shadowreplay"), false).unwrap();
+    let app_dirs =
+        AppDirs::new(Some("cn.vjoi.bili-shadowreplay"), false).ok_or("系统未提供应用配置目录")?;
     let config_path = app_dirs.config_dir.join("Conf.toml");
     let cache_path = app_dirs.cache_dir.join("cache");
     let output_path = app_dirs.data_dir.join("output");
@@ -644,15 +641,16 @@ async fn setup_app_state(app: &tauri::App) -> Result<State, Box<dyn std::error::
     let db_clone = db.clone();
     let emitter = EventEmitter::new(app.handle().clone());
     let binding = dbs.0.read().await;
-    let dbpool = binding.get("sqlite:data_v2.db").unwrap();
-    let sqlite_pool = match dbpool {
-        tauri_plugin_sql::DbPool::Sqlite(pool) => Some(pool),
-    };
-    db_clone.set(sqlite_pool.unwrap().clone()).await;
+    let dbpool = binding
+        .get("sqlite:data_v2.db")
+        .ok_or("sqlite:data_v2.db is not registered")?;
+    let tauri_plugin_sql::DbPool::Sqlite(sqlite_pool) = dbpool;
+    db_clone.set(sqlite_pool.clone()).await;
     db_clone.finish_pending_tasks().await?;
     db_clone.finish_pending_record_summaries().await?;
     let webhook_poster =
-        webhook::poster::create_webhook_poster(&config.read().await.webhook_url, None).unwrap();
+        webhook::poster::create_webhook_poster(&config.read().await.webhook_url, None)
+            .map_err(|e| e.to_string())?;
     let mut task_manager = TaskManager::new();
     task_manager.start();
 
@@ -698,10 +696,9 @@ fn setup_plugins(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<tauri::W
     let migrations = get_migrations();
     let builder = builder
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            let _ = app
-                .get_webview_window("main")
-                .expect("no main window")
-                .set_focus();
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.set_focus();
+            }
         }))
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_os::init())
@@ -727,7 +724,9 @@ fn setup_event_handlers(builder: tauri::Builder<tauri::Wry>) -> tauri::Builder<t
         if let WindowEvent::CloseRequested { api, .. } = event {
             // main window is not closable
             if window.label() == "main" {
-                window.hide().unwrap();
+                if let Err(e) = window.hide() {
+                    log::error!("Failed to hide main window: {e}");
+                }
                 api.prevent_close();
             }
         }
@@ -958,15 +957,23 @@ async fn shutdown_signal() {
     {
         use tokio::signal::unix::{signal, SignalKind};
 
-        let mut terminate =
-            signal(SignalKind::terminate()).expect("Failed to install SIGTERM handler");
-        tokio::select! {
-            result = tokio::signal::ctrl_c() => {
-                if let Err(error) = result {
+        match signal(SignalKind::terminate()) {
+            Ok(mut terminate) => {
+                tokio::select! {
+                    result = tokio::signal::ctrl_c() => {
+                        if let Err(error) = result {
+                            log::error!("Failed to listen for Ctrl+C: {error}");
+                        }
+                    }
+                    _ = terminate.recv() => {}
+                }
+            }
+            Err(error) => {
+                log::error!("Failed to install SIGTERM handler: {error}");
+                if let Err(error) = tokio::signal::ctrl_c().await {
                     log::error!("Failed to listen for Ctrl+C: {error}");
                 }
             }
-            _ = terminate.recv() => {}
         }
     }
 
@@ -982,9 +989,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _guard = init_sentry_from_env();
     // get params from command line
     let args = Args::parse();
-    let state = setup_server_state(args)
-        .await
-        .expect("Failed to setup server state");
+    let state = setup_server_state(args).await?;
 
     // check ffmpeg status
     match ffmpeg::check_ffmpeg().await {

--- a/src-tauri/src/migration/migration_methods.rs
+++ b/src-tauri/src/migration/migration_methods.rs
@@ -21,8 +21,11 @@ pub async fn try_rebuild_archives(
         while let Some(file) = files.next_entry().await? {
             if file.file_type().await?.is_dir() {
                 // use folder name as live_id
-                let live_id = file.file_name();
-                let live_id = live_id.to_str().unwrap();
+                let file_name = file.file_name();
+                let Some(live_id) = file_name.to_str() else {
+                    log::warn!("Skipping archive with non-UTF-8 name: {:?}", file.path());
+                    continue;
+                };
                 let record_path = file.path();
                 let entry_store = EntryStore::new(record_path.to_string_lossy().as_ref()).await;
                 let existing_record = db.get_record(&room_id, live_id).await;
@@ -103,17 +106,21 @@ pub async fn try_convert_live_covers(
         let records = db.get_records(&room_id, 0, 999_999_999).await?;
         for record in &records {
             let record_path = room_cache_path.join(record.live_id.clone());
-            let cover = record.cover.clone();
-            if cover.is_none() {
+            let Some(cover) = record.cover.clone() else {
                 continue;
-            }
-
-            let cover = cover.unwrap();
+            };
             if cover.starts_with("data:") {
-                let base64 = cover.split("base64,").nth(1).unwrap();
-                let bytes = base64::engine::general_purpose::STANDARD
-                    .decode(base64)
-                    .unwrap();
+                let Some(base64) = cover.split("base64,").nth(1) else {
+                    log::warn!("Skipping cover with invalid data URL: {}", record.live_id);
+                    continue;
+                };
+                let bytes = match base64::engine::general_purpose::STANDARD.decode(base64) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        log::warn!("Skipping invalid cover for {}: {e}", record.live_id);
+                        continue;
+                    }
+                };
                 let path = record_path.join("cover.jpg");
                 tokio::fs::write(&path, bytes).await?;
 
@@ -142,10 +149,17 @@ pub async fn try_convert_clip_covers(
     for video in &videos {
         let cover = video.cover.clone();
         if cover.starts_with("data:") {
-            let base64 = cover.split("base64,").nth(1).unwrap();
-            let bytes = base64::engine::general_purpose::STANDARD
-                .decode(base64)
-                .unwrap();
+            let Some(base64) = cover.split("base64,").nth(1) else {
+                log::warn!("Skipping cover with invalid data URL: {}", video.file);
+                continue;
+            };
+            let bytes = match base64::engine::general_purpose::STANDARD.decode(base64) {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    log::warn!("Skipping invalid cover for {}: {e}", video.file);
+                    continue;
+                }
+            };
 
             let video_file_path = output_path.join(video.file.clone());
             let cover_file_path = video_file_path.with_extension("jpg");
@@ -153,12 +167,12 @@ pub async fn try_convert_clip_covers(
             tokio::fs::write(&cover_file_path, bytes).await?;
 
             log::info!("convert clip cover: {}", cover_file_path.display());
+            let cover_name = cover_file_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| format!("Invalid cover path: {}", cover_file_path.display()))?;
             // update record
-            db.update_video_cover(
-                video.id,
-                cover_file_path.file_name().unwrap().to_str().unwrap(),
-            )
-            .await?;
+            db.update_video_cover(video.id, cover_name).await?;
         }
     }
     Ok(())
@@ -197,7 +211,7 @@ pub async fn try_convert_entry_to_m3u8(
             if !entry_file.exists() || m3u8_file_path.exists() {
                 continue;
             }
-            let entry_store = EntryStore::new(record_path.to_str().unwrap()).await;
+            let entry_store = EntryStore::new(record_path.to_string_lossy().as_ref()).await;
             if entry_store.is_empty() {
                 continue;
             }

--- a/src-tauri/src/progress/progress_reporter.rs
+++ b/src-tauri/src/progress/progress_reporter.rs
@@ -74,7 +74,7 @@ impl EventEmitter {
                             &format!("progress-update:{}", id),
                             UpdateEvent { id, content },
                         )
-                        .unwrap();
+                        .unwrap_or_else(|e| log::error!("Failed to emit progress update: {e}"));
                 }
                 RecorderEvent::ProgressFinished {
                     id,
@@ -90,7 +90,7 @@ impl EventEmitter {
                                 message,
                             },
                         )
-                        .unwrap();
+                        .unwrap_or_else(|e| log::error!("Failed to emit progress finish: {e}"));
                 }
                 RecorderEvent::DanmuReceived { room, ts, content } => {
                     self.app_handle
@@ -102,7 +102,7 @@ impl EventEmitter {
                                 user_name: None,
                             },
                         )
-                        .unwrap();
+                        .unwrap_or_else(|e| log::error!("Failed to emit danmu event: {e}"));
                 }
                 _ => {}
             }

--- a/src-tauri/src/recorder_manager.rs
+++ b/src-tauri/src/recorder_manager.rs
@@ -190,6 +190,8 @@ pub enum RecorderManagerError {
     SubtitleGenerationFailed { error: String },
     #[error("Invalid live id, not timestamp str")]
     InvalidLiveID,
+    #[error("Invalid program date time: {value}")]
+    InvalidProgramDateTime { value: String },
     #[error("Archive danmu ass generation failed: {error}")]
     ArchiveDanmuAssGenerationFailed { error: String },
 }
@@ -296,7 +298,9 @@ impl RecorderManager {
                                 recorder.user_info.user_name, recorder.room_info.room_title
                             ))
                             .show()
-                            .unwrap();
+                            .unwrap_or_else(|e| {
+                                log::warn!("Failed to show live start notification: {e}")
+                            });
                     }
                 }
                 RecorderEvent::LiveEnd {
@@ -321,12 +325,20 @@ impl RecorderManager {
                                 recorder.user_info.user_name, recorder.room_info.room_title
                             ))
                             .show()
-                            .unwrap();
+                            .unwrap_or_else(|e| {
+                                log::warn!("Failed to show live end notification: {e}")
+                            });
                     }
                 }
                 RecorderEvent::RecordStart { recorder } => {
                     // add record entry into db
-                    let platform = PlatformType::from_str(&recorder.room_info.platform).unwrap();
+                    let platform = match PlatformType::from_str(&recorder.room_info.platform) {
+                        Ok(platform) => platform,
+                        Err(e) => {
+                            log::error!("Invalid platform in RecordStart event: {e}");
+                            continue;
+                        }
+                    };
                     let room_id = recorder.room_info.room_id.clone();
                     log::info!("Record start: {recorder:?}");
                     if let Err(e) = self
@@ -548,18 +560,23 @@ impl RecorderManager {
                 continue;
             }
             // get a list of recorders in db, if not created yet, create them
-            let recorders = self.db.get_recorders().await;
-            if recorders.is_err() {
-                log::error!(
-                    "Failed to get recorders from db: {}",
-                    recorders.err().unwrap()
-                );
-                return;
-            }
-            let recorders = recorders.unwrap();
+            let recorders = match self.db.get_recorders().await {
+                Ok(recorders) => recorders,
+                Err(e) => {
+                    log::error!("Failed to get recorders from db: {e}");
+                    interval.tick().await;
+                    continue;
+                }
+            };
             let mut recorder_map = HashMap::new();
             for recorder in recorders {
-                let platform = PlatformType::from_str(&recorder.platform).unwrap();
+                let platform = match PlatformType::from_str(&recorder.platform) {
+                    Ok(platform) => platform,
+                    Err(e) => {
+                        log::warn!("Skipping recorder with invalid platform: {e}");
+                        continue;
+                    }
+                };
                 let room_id = recorder.room_id;
                 let auto_start = recorder.auto_start;
                 let extra = recorder.extra;
@@ -578,7 +595,10 @@ impl RecorderManager {
                 if self.is_migrating.load(std::sync::atomic::Ordering::Relaxed) {
                     break;
                 }
-                let (auto_start, extra) = recorder_map.get(&(platform, room_id.clone())).unwrap();
+                let Some((auto_start, extra)) = recorder_map.get(&(platform, room_id.clone()))
+                else {
+                    continue;
+                };
                 let account = self
                     .db
                     .get_account_by_platform(platform.clone().as_str())
@@ -789,11 +809,9 @@ impl RecorderManager {
         }
         let mut bytes: Vec<u8> = Vec::new();
         tokio::fs::File::open(playlist_path)
-            .await
-            .unwrap()
+            .await?
             .read_to_end(&mut bytes)
-            .await
-            .unwrap();
+            .await?;
         Ok(bytes)
     }
 
@@ -871,11 +889,11 @@ impl RecorderManager {
         live_id: &str,
     ) -> Result<i64, RecorderManagerError> {
         let playlist = self.load_playlist(platform, room_id, live_id).await?;
-        if playlist.segments.is_empty() {
-            return Err(RecorderManagerError::EmptyPlaylist);
-        }
 
-        let first_segment = playlist.segments.first().unwrap();
+        let first_segment = playlist
+            .segments
+            .first()
+            .ok_or(RecorderManagerError::EmptyPlaylist)?;
         if let Some(program_date_time) = first_segment.program_date_time {
             return Ok(program_date_time.timestamp_millis());
         }
@@ -901,7 +919,9 @@ impl RecorderManager {
         // example: "2025-10-18T17:18:17.004+0800"
         // convert to timestamp
         let timestamp = DateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.3f%z")
-            .unwrap()
+            .map_err(|_| RecorderManagerError::InvalidProgramDateTime {
+                value: value.clone(),
+            })?
             .timestamp_millis();
         Ok(timestamp)
     }
@@ -947,19 +967,20 @@ impl RecorderManager {
     ) -> Vec<RelatedPlaylist> {
         let cache_path = self.config.read().await.cache.clone();
         let cache_path = Path::new(&cache_path);
-        let archives = self.db.get_archives_by_parent_id(room_id, parent_id).await;
-        if let Err(e) = archives {
-            log::error!(
-                "[{}] Failed to get all related playlists: {} {}",
-                room_id,
-                parent_id,
-                e
-            );
-            return Vec::new();
-        }
+        let archives = match self.db.get_archives_by_parent_id(room_id, parent_id).await {
+            Ok(archives) => archives,
+            Err(e) => {
+                log::error!(
+                    "[{}] Failed to get all related playlists: {} {}",
+                    room_id,
+                    parent_id,
+                    e
+                );
+                return Vec::new();
+            }
+        };
 
         let archives: Vec<(String, String)> = archives
-            .unwrap()
             .iter()
             .map(|a| (a.title.clone(), a.live_id.clone()))
             .collect();
@@ -1049,18 +1070,16 @@ impl RecorderManager {
             .first_segment_timestamp(platform, &params.room_id, &params.live_id)
             .await?;
 
-        let danmus = self
+        let mut danmus = match self
             .load_danmus(platform, &params.room_id, &params.live_id)
-            .await;
-        if danmus.is_err() {
-            log::error!(
-                "Failed to get danmus, skip danmu encoding: {}",
-                danmus.err().unwrap()
-            );
-            return Ok(clip_file);
-        }
-
-        let mut danmus = danmus.unwrap();
+            .await
+        {
+            Ok(danmus) => danmus,
+            Err(e) => {
+                log::error!("Failed to get danmus, skip danmu encoding: {e}");
+                return Ok(clip_file);
+            }
+        };
         log::debug!("First danmu entry: {:?}", danmus.first());
         log::debug!("Last danmu entry: {:?}", danmus.last());
         log::debug!("Stream start timestamp: {}", stream_start_timestamp_milis);
@@ -1185,15 +1204,13 @@ impl RecorderManager {
         }
 
         // get recorders from db
-        let recorders = self.db.get_recorders().await;
-        if recorders.is_err() {
-            log::error!(
-                "Failed to get recorders from db: {}",
-                recorders.err().unwrap()
-            );
-            return summary;
-        }
-        let recorders = recorders.unwrap();
+        let recorders = match self.db.get_recorders().await {
+            Ok(recorders) => recorders,
+            Err(e) => {
+                log::error!("Failed to get recorders from db: {e}");
+                return summary;
+            }
+        };
         summary.count = recorders.len();
         for recorder in recorders {
             // check if recorder is in recorder_set
@@ -1274,13 +1291,11 @@ impl RecorderManager {
             live_id,
         );
         let subtitle_file_path = work_dir.with_filename("subtitle.srt");
-        let subtitle_file = File::open(subtitle_file_path.full_path()).await;
-        if subtitle_file.is_err() {
-            return Err(RecorderManagerError::SubtitleNotFound {
+        let subtitle_file = File::open(subtitle_file_path.full_path())
+            .await
+            .map_err(|_| RecorderManagerError::SubtitleNotFound {
                 live_id: live_id.to_string(),
-            });
-        }
-        let subtitle_file = subtitle_file.unwrap();
+            })?;
         let mut subtitle_file = BufReader::new(subtitle_file);
         let mut subtitle_content = String::new();
         subtitle_file.read_to_string(&mut subtitle_content).await?;
@@ -1310,8 +1325,10 @@ impl RecorderManager {
         playlist.playlist_type = Some(MediaPlaylistType::Vod);
 
         let mut v: Vec<u8> = Vec::new();
-        playlist.write_to(&mut v).unwrap();
-        let m3u8_content: &str = std::str::from_utf8(&v).unwrap();
+        playlist.write_to(&mut v)?;
+        let m3u8_content = std::str::from_utf8(&v).map_err(|e| RecorderManagerError::HLSError {
+            err: format!("Failed to encode playlist: {e}"),
+        })?;
         tokio::fs::write(&m3u8_index_file_path.full_path(), m3u8_content).await?;
         log::info!(
             "[{}]M3U8 index file generated: {}",
@@ -1347,17 +1364,13 @@ impl RecorderManager {
             // Extract opus audio using FFmpeg
             let ffmpeg_path = crate::ffmpeg::ffmpeg_path();
             let mut cmd = tokio::process::Command::new(ffmpeg_path);
-            cmd.args([
-                "-i",
-                clip_file_path.full_path().to_str().unwrap(),
-                "-vn", // no video
-                "-acodec",
-                "libopus",
-                "-b:a",
-                "128k",
-                "-y",
-                opus_file_path.full_path().to_str().unwrap(),
-            ]);
+            cmd.arg("-i")
+                .arg(clip_file_path.full_path())
+                .args([
+                    "-vn", // no video
+                    "-acodec", "libopus", "-b:a", "128k", "-y",
+                ])
+                .arg(opus_file_path.full_path());
 
             let output =
                 cmd.output()
@@ -1395,13 +1408,15 @@ impl RecorderManager {
         )
         .await;
         // write subtitle file
-        if let Err(e) = result {
-            return Err(RecorderManagerError::SubtitleGenerationFailed {
-                error: e.to_string(),
-            });
-        }
+        let result = match result {
+            Ok(result) => result,
+            Err(e) => {
+                return Err(RecorderManagerError::SubtitleGenerationFailed {
+                    error: e.to_string(),
+                });
+            }
+        };
         log::info!("[{room_id}]Subtitle generated");
-        let result = result.unwrap();
         let subtitle_content = result
             .subtitle_content
             .iter()
@@ -1488,22 +1503,25 @@ impl RecorderManager {
             None
         };
 
-        let start = if let Some(params) = &params {
-            params
-                .iter()
-                .find(|param| param[0] == "start")
-                .map_or(0, |param| param[1].parse::<i64>().unwrap())
-        } else {
-            0
+        // Parse `start` / `end` query params defensively: a segment URI may
+        // carry arbitrary or malformed query strings.
+        let parse_param = |name: &str| -> i64 {
+            let value = params.as_ref().and_then(|params| {
+                params.iter().find_map(|param| match param.as_slice() {
+                    [key, value] if *key == name => Some(*value),
+                    _ => None,
+                })
+            });
+            match value {
+                Some(value) => value.parse::<i64>().unwrap_or_else(|e| {
+                    log::warn!("Invalid {name} parameter value {value:?}: {e}");
+                    0
+                }),
+                None => 0,
+            }
         };
-        let end = if let Some(params) = &params {
-            params
-                .iter()
-                .find(|param| param[0] == "end")
-                .map_or(0, |param| param[1].parse::<i64>().unwrap())
-        } else {
-            0
-        };
+        let start = parse_param("start");
+        let end = parse_param("end");
 
         let platform = PlatformType::from_str(platform).map_err(|_| {
             RecorderManagerError::InvalidPlatformType {
@@ -1532,7 +1550,7 @@ impl RecorderManager {
             let playlist = self.load_playlist(platform, room_id, live_id).await?;
             let playlist = self.playlist_range(&playlist, range).await?;
             let mut bytes: Vec<u8> = Vec::new();
-            playlist.write_to(&mut bytes).unwrap();
+            playlist.write_to(&mut bytes)?;
             Ok(bytes)
         } else {
             // try to find requested ts file in recorder's cache
@@ -1540,15 +1558,14 @@ impl RecorderManager {
             // remove path params
             let path = path.split('?').next().unwrap_or(path);
             let ts_file = format!("{}/{}", cache_path, path.replace("%7C", "|"));
-            let ts_file_content = tokio::fs::read(&ts_file).await;
-            if ts_file_content.is_err() {
-                log::warn!("Segment file not found: {ts_file}");
-                return Err(RecorderManagerError::HLSError {
+            let ts_file_content = tokio::fs::read(&ts_file).await.map_err(|e| {
+                log::warn!("Failed to read segment file {ts_file}: {e}");
+                RecorderManagerError::HLSError {
                     err: "Segment file not found".into(),
-                });
-            }
+                }
+            })?;
 
-            Ok(ts_file_content.unwrap())
+            Ok(ts_file_content)
         }
     }
 
@@ -1610,12 +1627,12 @@ impl RecorderManager {
             playlists = ordered;
         }
 
-        if playlists.is_empty() {
+        let Some(first_playlist) = playlists.first() else {
             log::error!("No selected playlists found: {parent_id}");
             return Ok(());
-        }
+        };
 
-        let title = playlists.first().unwrap().title.clone();
+        let title = first_playlist.title.clone();
 
         // generate archive danmu ass file for all playlists
         let danmu_ass_files = if encode_danmu {
@@ -1683,23 +1700,16 @@ impl RecorderManager {
             });
         }
 
-        let metadata = std::fs::metadata(&output_path);
-        if metadata.is_err() {
-            return Err(RecorderManagerError::HLSError {
+        let size = std::fs::metadata(&output_path)
+            .map_err(|_| RecorderManagerError::HLSError {
                 err: "Failed to get file metadata".into(),
-            });
-        }
-        let size = metadata.unwrap().len() as i64;
+            })?
+            .len() as i64;
 
-        let video_metadata = crate::ffmpeg::extract_video_metadata(Path::new(&output_path)).await;
         let mut length = 0;
-        if let Ok(video_metadata) = video_metadata {
-            length = video_metadata.duration as i64;
-        } else {
-            log::error!(
-                "Failed to get video metadata: {}",
-                video_metadata.err().unwrap()
-            );
+        match crate::ffmpeg::extract_video_metadata(Path::new(&output_path)).await {
+            Ok(video_metadata) => length = video_metadata.duration as i64,
+            Err(e) => log::error!("Failed to get video metadata: {e}"),
         }
 
         let _ = crate::ffmpeg::generate_thumbnail(Path::new(&output_path), 0.0).await;

--- a/src-tauri/src/static_server/mod.rs
+++ b/src-tauri/src/static_server/mod.rs
@@ -33,7 +33,7 @@ pub async fn start_static_server(
         }
     };
 
-    let port = listener.local_addr().unwrap().port();
+    let port = listener.local_addr()?.port();
 
     let output_path = config.read().await.output.clone();
     let cache_path = config.read().await.cache.clone();

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -9,14 +9,16 @@ pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
     let quit_i = MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
     let menu = Menu::with_items(app, &[&hide_i, &quit_i])?;
 
-    let _ = TrayIconBuilder::with_id("tray")
-        .icon(app.default_window_icon().unwrap().clone())
+    let mut builder = TrayIconBuilder::with_id("tray")
         .menu(&menu)
         .show_menu_on_left_click(false)
         .on_menu_event(move |app, event| match event.id.as_ref() {
             "hide" => {
-                let window = app.get_webview_window("main").unwrap();
-                window.hide().unwrap();
+                if let Some(window) = app.get_webview_window("main") {
+                    if let Err(e) = window.hide() {
+                        log::error!("Failed to hide main window: {e}");
+                    }
+                }
             }
             "quit" => {
                 app.exit(0);
@@ -36,8 +38,13 @@ pub fn create_tray<R: Runtime>(app: &tauri::AppHandle<R>) -> tauri::Result<()> {
                     let _ = window.set_focus();
                 }
             }
-        })
-        .build(app);
+        });
+
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+
+    let _ = builder.build(app);
 
     Ok(())
 }

--- a/src-tauri/src/webhook/poster.rs
+++ b/src-tauri/src/webhook/poster.rs
@@ -153,7 +153,9 @@ impl WebhookPoster {
         }
 
         error!("All webhook post attempts failed");
-        Err(last_error.unwrap())
+        Err(last_error.unwrap_or_else(|| {
+            WebhookPostError::Network("no webhook post attempt was made".to_string())
+        }))
     }
 
     /// Send the actual HTTP request


### PR DESCRIPTION
## What

Production code no longer calls `.unwrap()` on values that can fail at runtime. All 364 panic sites in non-test code (`src-tauri/src`: 232, `crates/`: 132) are gone; 17 `.expect()` calls remain, each on a compile-time invariant (literal regex/selector, generated user agent, cargo-provided env var) with a message explaining why it cannot fail.

**Rule applied:** values from user input, network responses, the database or the filesystem propagate a typed error or degrade gracefully; `.expect()` is reserved for provable invariants.

Test code keeps `unwrap()` for brevity.

## How

Grouped fixes rather than one-off patches:

- **database** — added `Database::pool()` and `DatabaseError::NotInitialized`; all 51 `self.db.read().await.clone().unwrap()` sites now use `self.pool().await?`.
- **ffmpeg** — added `path_str` / `file_name_str` helpers; spawn/stderr/stdout handling uses `.map_err(...)?` / `.ok_or(...)?`.
- **platform adapters** — added `utils::header_value` + `RecorderError::InvalidHeaderValue`; cookies/user agents are validated instead of `parse().unwrap()`; static literal headers use `HeaderValue::from_static`.

## Behaviour changes worth reviewing

- A failed desktop notification no longer panics and tears down the recorder event loop; same for progress `emit()`.
- `monitor_recorders` survives a transient DB error instead of stopping forever.
- Invalid platform rows / `start`/`end` HLS query params no longer panic the event loop or request handler.
- Bilibili WBI signing and Douyin JS results report typed errors when a provider response changes shape.
- `all_variants()` returns an empty list when the primary variant cannot be built.
- `Config::load` returns an error on a non-UTF-8 config path.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy` and `cargo clippy --no-default-features --features headless` — 0 warnings
- `cargo check` (GUI) and `cargo check --no-default-features --features headless` — pass
- `cargo test` (GUI: 137, headless: 136), `cargo test -p recorder` (83), `cargo test -p danmu_stream` (10) — 0 failures

## Notes

- Network parsing paths are covered by compile-time + unit tests only; the graceful-degradation branches are a suggestion worth a real-recording regression pass.
- `crates/` tests are not run by the repo's `cargo test` (root package only). Worth considering `--workspace` in CI, or a `clippy::unwrap_used` lint, to prevent regressions — happy to follow up if you want it.
