### PR TITLE
fix: restore Svelte 5 reactivity for list selections

### DIFF
--- a/src/AppLive.svelte
+++ b/src/AppLive.svelte
@@ -544,12 +544,14 @@
           {live_id}
           {markers}
           onMarkerAdd={(marker) => {
-            markers.push({
-              offset: marker.offset,
-              realtime: marker.realtime,
-              content: "[空标记点]",
-            });
-            markers = markers.sort((a, b) => a.offset - b.offset);
+            markers = [
+              ...markers,
+              {
+                offset: marker.offset,
+                realtime: marker.realtime,
+                content: "[空标记点]",
+              },
+            ].sort((a, b) => a.offset - b.offset);
           }}
         />
       </div>

--- a/src/page/Archive.svelte
+++ b/src/page/Archive.svelte
@@ -24,6 +24,7 @@
   import KuaishouIcon from "../lib/components/KuaishouIcon.svelte";
   import HuyaIcon from "../lib/components/HuyaIcon.svelte";
   import TikTokIcon from "../lib/components/TikTokIcon.svelte";
+  import { SvelteSet } from "svelte/reactivity";
   import GenerateWholeClipModal from "../lib/components/GenerateWholeClipModal.svelte";
   import ArchiveSummaryModal from "../lib/components/ArchiveSummaryModal.svelte";
   import type { RecorderInfo, RecorderList } from "src/lib/interface";
@@ -41,7 +42,7 @@
   let selectedRoomId: string | null = $state(null);
   let roomOptions: RoomOption[] = $state([]);
 
-  let selectedArchives: Set<string> = $state(new Set());
+  let selectedArchives = new SvelteSet<string>();
   let showDeleteConfirm = $state(false);
   let archiveToDelete: RecordItem | null = $state(null);
 
@@ -50,7 +51,7 @@
   let wholeClipArchive: RecordItem | null = $state(null);
   let showSummaryModal = $state(false);
   let summaryArchive: RecordItem | null = $state(null);
-  let summaryStatuses: Record<string, RecordSummaryStatus> = {};
+  let summaryStatuses: Record<string, RecordSummaryStatus> = $state({});
 
   // 分页相关状态
   let currentPage = $state(1);
@@ -439,7 +440,6 @@
     } else {
       selectedArchives.add(liveId);
     }
-    selectedArchives = selectedArchives; // Trigger reactivity
   }
 
   function selectAllArchives() {
@@ -451,7 +451,6 @@
         selectedArchives.add(archive.live_id)
       );
     }
-    selectedArchives = selectedArchives; // Trigger reactivity
   }
 
   async function deleteArchive(archive: RecordItem) {

--- a/src/page/Clip.svelte
+++ b/src/page/Clip.svelte
@@ -22,6 +22,7 @@
     RotateCw,
     Edit,
   } from "lucide-svelte";
+  import { SvelteSet } from "svelte/reactivity";
   import { AnnotationOutline } from "flowbite-svelte-icons";
   import BilibiliIcon from "../lib/components/BilibiliIcon.svelte";
   import DouyinIcon from "../lib/components/DouyinIcon.svelte";
@@ -37,7 +38,7 @@
   let selectedRoomId = $state(null);
   let roomIds: string[] = $state([]);
 
-  let selectedVideos: Set<number> = $state(new Set());
+  let selectedVideos = new SvelteSet<number>();
   let showDeleteConfirm = $state(false);
   let videoToDelete: VideoItem | null = $state(null);
   let showImportDialog = $state(false);
@@ -344,7 +345,6 @@
     } else {
       selectedVideos.add(id);
     }
-    selectedVideos = selectedVideos; // Trigger reactivity
   }
 
   function selectAllVideos() {
@@ -354,7 +354,6 @@
     } else {
       currentVideos.forEach((video) => selectedVideos.add(video.id));
     }
-    selectedVideos = selectedVideos; // Trigger reactivity
   }
 
   async function deleteVideo(video: VideoItem) {

--- a/src/page/Task.svelte
+++ b/src/page/Task.svelte
@@ -13,12 +13,13 @@
   } from "lucide-svelte";
   import type { TaskRow } from "../lib/db";
   import { onMount, onDestroy } from "svelte";
+  import { SvelteSet } from "svelte/reactivity";
 
   let tasks: TaskRow[] = $state([]);
   let loading = $state(true);
   let actionTaskId: string | null = $state(null);
   let refreshInterval = null;
-  let expandedTasks = $state(new Set<string>());
+  let expandedTasks = new SvelteSet<string>();
 
   async function update_tasks() {
     try {
@@ -284,7 +285,6 @@
     } else {
       expandedTasks.add(taskId);
     }
-    expandedTasks = expandedTasks; // 触发响应式更新
   }
 
   // 设置自动刷新


### PR DESCRIPTION
## Summary
- Replace native `Set` self-assignment with `SvelteSet` so archive/clip multi-select and task metadata expansion update the UI after the Svelte 5 runes migration.
- Make archive summary statuses `$state` so processing/success/failed icons refresh when summaries finish.
- Assign live preview markers to a new sorted array so adding a marker still triggers updates.

## Test plan
- [ ] On the archive page, select one or more recordings and confirm the bulk delete bar appears.
- [ ] On the clip page, select one or more videos and confirm the bulk delete bar appears.
- [ ] On the task page, expand/collapse a task’s details.
- [ ] Trigger or wait for an archive summary status change and confirm the row icon updates.
- [ ] In live preview, add a marker and confirm it shows on the timeline.


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Bug Fixes:
- Restore Svelte 5 UI reactivity for archive and clip multi-selection, task detail expansion, archive summary status changes, and live preview marker additions.