### PR TITLE
refactor: consolidate workspace dependencies and drop unused crates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,10 +35,23 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache Rust dependencies
+        id: rust-cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri -> target
           save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # On a partial cache hit Swatinem/rust-cache deletes every file under
+      # non-profile `target/` subdirectories, which strips the prebuilt native
+      # libs from `target/sherpa-onnx-prebuilt` but keeps the extracted `lib`
+      # directory. `sherpa-onnx-sys`'s build script only checks that the
+      # directory exists, so it never re-downloads and linking fails. Drop the
+      # whole directory and force the crate to rebuild so it fetches them again.
+      - name: Repair sherpa-onnx prebuilt libs
+        if: steps.rust-cache.outputs.cache-hit != 'true'
+        run: |
+          rm -rf src-tauri/target/sherpa-onnx-prebuilt
+          cargo clean -p sherpa-onnx-sys --manifest-path src-tauri/Cargo.toml
 
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -308,21 +308,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
 ]
 
 [[package]]
@@ -372,24 +361,6 @@ dependencies = [
 
 [[package]]
 name = "async-ffmpeg-sidecar"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e969d504ae9e2dfc900029d3eb70a730998f640b90e5c8ad4b94700481755ac5"
-dependencies = [
- "anyhow",
- "async-compression",
- "async_zip",
- "futures",
- "futures-util",
- "krata-tokio-tar",
- "reqwest 0.12.24",
- "sanitize-filename",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "async-ffmpeg-sidecar"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c4068752552d0d1b6f98d3209700a3e64d379d141af5698669badde04ecdf3"
@@ -404,21 +375,6 @@ dependencies = [
  "sanitize-filename",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
 ]
 
 [[package]]
@@ -445,7 +401,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -456,14 +412,14 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.0",
+ "event-listener",
  "futures-lite",
  "rustix 1.0.8",
 ]
@@ -495,32 +451,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers 0.3.0",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -668,9 +598,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -684,7 +614,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -702,12 +632,12 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -777,34 +707,25 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 name = "bili-shadowreplay"
 version = "2.22.3"
 dependencies = [
- "async-ffmpeg-sidecar 0.0.1",
- "async-std",
+ "async-ffmpeg-sidecar",
  "async-trait",
  "axum",
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "danmu_stream",
- "dashmap",
- "deno_core",
  "fix-path-env",
  "futures",
  "futures-core",
  "hound",
- "hyper 0.14.32",
  "log",
- "m3u8-rs 5.0.5",
- "md5 0.7.0",
- "mime_guess",
- "pct-str 1.2.0",
+ "m3u8-rs",
  "platform-dirs",
- "rand 0.8.5",
+ "rand 0.9.2",
  "recorder",
- "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "rig-core",
  "sanitize-filename",
- "scraper",
  "sentry",
  "serde",
  "serde_derive",
@@ -830,12 +751,9 @@ dependencies = [
  "tauri-utils",
  "thiserror 2.0.19",
  "tokio",
- "tokio-stream",
- "tokio-util",
- "toml 0.7.8",
- "tower-http 0.5.2",
+ "toml 0.9.2",
+ "tower-http",
  "url",
- "urlencoding",
  "uuid",
  "whisper-cpp-rs",
 ]
@@ -944,7 +862,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1591,8 +1509,8 @@ dependencies = [
  "hex",
  "http 1.3.1",
  "log",
- "md5 0.8.0",
- "pct-str 2.0.0",
+ "md5",
+ "pct-str",
  "prost",
  "rand 0.9.2",
  "regex",
@@ -1643,20 +1561,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -2137,9 +2041,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "serde",
@@ -2267,12 +2171,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
@@ -2288,7 +2186,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.0",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -2585,7 +2483,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
- "gloo-timers 0.4.0",
+ "gloo-timers",
  "send_wrapper",
 ]
 
@@ -2885,18 +2783,6 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-timers"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
@@ -2990,25 +2876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
 dependencies = [
  "crc32fast",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -3183,17 +3050,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -3211,7 +3067,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3241,30 +3097,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -3272,9 +3104,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.11",
+ "h2",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -3291,7 +3123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -3304,26 +3136,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3343,14 +3162,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.5",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -3804,15 +3623,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,25 +3786,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
-name = "m3u8-rs"
-version = "5.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1d7ba86f7ea62f17f4310c55e93244619ddc7dadfc7e565de1967e4e41e6e7"
-dependencies = [
- "chrono",
- "nom",
-]
 
 [[package]]
 name = "m3u8-rs"
@@ -4098,12 +3895,6 @@ dependencies = [
  "cfg-if",
  "digest",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "md5"
@@ -4830,15 +4621,6 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pct-str"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d207ec8d182c2fef45f028b9b9507770df19e89b3e14827ccd95d4a23f6003"
-dependencies = [
- "utf8-decode",
-]
-
-[[package]]
-name = "pct-str"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf1bdcc492c285a50bed60860dfa00b50baf1f60c73c7d6b435b01a2a11fd6ff"
@@ -5021,12 +4803,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -5540,7 +5316,7 @@ dependencies = [
 name = "recorder"
 version = "0.1.0"
 dependencies = [
- "async-ffmpeg-sidecar 0.0.3",
+ "async-ffmpeg-sidecar",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -5549,12 +5325,12 @@ dependencies = [
  "env_logger",
  "fastrand",
  "log",
- "m3u8-rs 6.0.0",
- "md5 0.8.0",
- "pct-str 2.0.0",
+ "m3u8-rs",
+ "md5",
+ "pct-str",
  "rand 0.9.2",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.24",
  "sanitize-filename",
  "scraper",
  "serde",
@@ -5664,53 +5440,11 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "async-compression",
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg 0.50.0",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "cookie",
@@ -5719,17 +5453,18 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.11",
+ "h2",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -5740,13 +5475,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http 0.6.11",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5767,9 +5502,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -5783,12 +5518,12 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http 0.6.11",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5988,15 +5723,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -6818,8 +6544,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http-body",
+ "hyper",
  "matchit 0.8.6",
  "pin-project-lite",
  "serde",
@@ -6968,7 +6694,7 @@ dependencies = [
  "crc 3.3.0",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.0",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -7284,12 +7010,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -7353,34 +7073,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.13.1",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -8170,18 +7869,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.19.15",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -8241,8 +7928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -8326,33 +8011,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.13.1",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8366,10 +8026,19 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
- "http-body 1.0.1",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -8793,12 +8462,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
 
 [[package]]
 name = "vcpkg"
@@ -9789,16 +9452,6 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -9952,7 +9605,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2 0.7.12",
- "event-listener 5.4.0",
+ "event-listener",
  "futures-core",
  "futures-lite",
  "hex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,43 +31,31 @@ reqwest = { workspace = true}
 serde_derive = "1.0.158"
 serde = "1.0.158"
 sysinfo = "0.32.0"
-m3u8-rs = "5.0.3"
-async-std = "1.12.0"
-async-ffmpeg-sidecar = "0.0.1"
+m3u8-rs = { workspace = true }
+async-ffmpeg-sidecar = { workspace = true }
 chrono = { version = "0.4.24", features = ["serde"] }
-toml = "0.7.3"
-regex = "1.7.3"
-tokio = { version = "1.27.0", features = ["process"] }
+toml = "0.9"
+tokio = { version = "1.27.0", features = ["process", "fs", "sync"] }
 platform-dirs = "0.3.0"
-pct-str = "1.2.0"
-md5 = "0.7.0"
-hyper = { version = "0.14", features = ["full"] }
-dashmap = "6.1.0"
-urlencoding = "2.1.3"
 log = "0.4.22"
 simplelog = "0.12.2"
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
-rand = "0.8.5"
-base64 = "0.21"
-mime_guess = "2.0"
+rand = { workspace = true }
+base64 = { workspace = true }
 async-trait = "0.1.87"
 whisper-cpp-rs = { path = "crates/whisper-cpp-rs" }
 hound = "3.5.1"
 uuid = { workspace = true }
 axum = { version = "0.7", features = ["macros", "multipart"] }
-tower-http = { version = "0.5", features = ["cors", "fs"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
 futures-core = "0.3"
 futures = "0.3"
-tokio-util = { version = "0.7", features = ["io"] }
-tokio-stream = "0.1"
 clap = { version = "4.5.37", features = ["derive"] }
 url = "2.5.4"
 srtparse = "0.2.0"
 thiserror = "2"
-deno_core = "0.355"
 sanitize-filename = "0.6.0"
 socketioxide = "0.17.2"
-scraper = "0.24.0"
 sentry = { version = "0.46.0", features = ["log", "logs"] }
 # Use Rig's core crate directly. The facade crate enables every provider and
 # vector-store integration by default, which would add unnecessary native
@@ -166,8 +154,16 @@ optional = true
 
 
 [workspace.dependencies]
-reqwest = { version = "0.11", features = ["blocking", "json", "multipart", "gzip"] }
+# Crates shared by the app and the workspace members. Declared once here so a
+# single version is resolved and compiled instead of one copy per crate.
+reqwest = { version = "0.12", features = ["json", "multipart", "gzip"] }
 uuid = { version = "1.4", features = ["v4"] }
+base64 = "0.22"
+md5 = "0.8"
+pct-str = "2.0"
+rand = "0.9"
+m3u8-rs = "6.0"
+async-ffmpeg-sidecar = "0.0.3"
 
 [profile.release]
 debug = 1

--- a/src-tauri/crates/danmu_stream/Cargo.toml
+++ b/src-tauri/crates/danmu_stream/Cargo.toml
@@ -25,19 +25,19 @@ log = "0.4"
 env_logger = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 url = "2.4"
-md5 = "0.8"
+md5 = { workspace = true }
 regex = "1.9"
 deno_core = "0.355"
-pct-str = "2.0"
+pct-str = { workspace = true }
 thiserror = "2.0"
 flate2 = "1.0"
 scroll = "0.13"
 scroll_derive = "0.13"
 brotli = "8.0"
 http = "1.0"
-rand = "0.9"
+rand = { workspace = true }
 urlencoding = "2.1"
 gzip = "0.1.2"
 hex = "0.4.3"

--- a/src-tauri/crates/danmu_stream/src/provider/bilibili/pack.rs
+++ b/src-tauri/crates/danmu_stream/src/provider/bilibili/pack.rs
@@ -196,7 +196,7 @@ mod tests {
     #[test]
     fn test_encode_unicode() {
         let packet = encode("你好", 7);
-        let data_len = "你好".as_bytes().len(); // 6 bytes for UTF-8
+        let data_len = "你好".len(); // 6 bytes for UTF-8
         assert_eq!(packet.len(), 16 + data_len);
         assert_eq!(&packet[16..], "你好".as_bytes());
     }

--- a/src-tauri/crates/recorder/Cargo.toml
+++ b/src-tauri/crates/recorder/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/lib.rs"
 [dependencies]
 danmu_stream = { path = "../danmu_stream" }
 async-trait = "0.1.89"
-rand = "0.9.2"
+rand = { workspace = true }
 chrono = "0.4.42"
 tokio = "1.48.0"
 reqwest = { workspace = true}
-pct-str = "2.0.0"
+pct-str = { workspace = true }
 serde_json = "1.0.145"
 serde = "1.0.228"
 regex = "1.12.2"
@@ -24,11 +24,11 @@ serde_derive = "1.0.228"
 thiserror = "2.0.17"
 log = "0.4.28"
 sanitize-filename = "0.6.0"
-m3u8-rs = "6.0.0"
-async-ffmpeg-sidecar = "0.0.3"
-md5 = "0.8.0"
+m3u8-rs = { workspace = true }
+async-ffmpeg-sidecar = { workspace = true }
+md5 = { workspace = true }
 scraper = "0.24.0"
-base64 = "0.22.1"
+base64 = { workspace = true }
 url = "2.5.0"
 urlencoding = "2.1.3"
 fastrand = "2.0.1"

--- a/src-tauri/crates/recorder/src/platforms/huya/extractor.rs
+++ b/src-tauri/crates/recorder/src/platforms/huya/extractor.rs
@@ -395,6 +395,40 @@ impl LiveStreamExtractor {
     }
 }
 
+// 实现 PlatformStreamInfo trait
+impl PlatformStreamInfo for StreamInfo {
+    fn primary_variant(&self) -> Result<StreamVariant, RecorderError> {
+        Ok(StreamVariant {
+            url: self.hls_url.clone(),
+            format: Format::HLS,
+            codec: Codec::AVC,
+            quality: Quality::Origin,
+            bitrate: None,
+        })
+    }
+
+    fn all_variants(&self) -> Vec<StreamVariant> {
+        match self.primary_variant() {
+            Ok(variant) => vec![variant],
+            Err(e) => {
+                log::warn!("Failed to build primary stream variant: {e}");
+                Vec::new()
+            }
+        }
+    }
+
+    fn expires_at(&self) -> Option<i64> {
+        None // Huya 流不过期
+    }
+
+    fn cdn_nodes(&self) -> Vec<CdnNode> {
+        Vec::new() // Huya 单 CDN
+    }
+
+    fn platform(&self) -> PlatformType {
+        PlatformType::Huya
+    }
+}
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose, Engine as _};
@@ -1691,40 +1725,5 @@ mod tests {
         assert_eq!(user_info.user_avatar, "https://huyaimg.msstatic.com/avatar/1003/23/3be5ff7cff0f6d08fee796ac537ef0_180_135.jpg?1525686175");
         assert_eq!(room_info.room_id, "857824");
         assert!(stream_info.hls_url.starts_with("https://"));
-    }
-}
-
-// 实现 PlatformStreamInfo trait
-impl PlatformStreamInfo for StreamInfo {
-    fn primary_variant(&self) -> Result<StreamVariant, RecorderError> {
-        Ok(StreamVariant {
-            url: self.hls_url.clone(),
-            format: Format::HLS,
-            codec: Codec::AVC,
-            quality: Quality::Origin,
-            bitrate: None,
-        })
-    }
-
-    fn all_variants(&self) -> Vec<StreamVariant> {
-        match self.primary_variant() {
-            Ok(variant) => vec![variant],
-            Err(e) => {
-                log::warn!("Failed to build primary stream variant: {e}");
-                Vec::new()
-            }
-        }
-    }
-
-    fn expires_at(&self) -> Option<i64> {
-        None // Huya 流不过期
-    }
-
-    fn cdn_nodes(&self) -> Vec<CdnNode> {
-        Vec::new() // Huya 单 CDN
-    }
-
-    fn platform(&self) -> PlatformType {
-        PlatformType::Huya
     }
 }

--- a/src-tauri/src/database/account.rs
+++ b/src-tauri/src/database/account.rs
@@ -2,7 +2,7 @@ use recorder::account::Account;
 
 use super::Database;
 use super::DatabaseError;
-use rand::seq::SliceRandom;
+use rand::seq::IndexedRandom;
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, sqlx::FromRow)]
 pub struct AccountRow {
@@ -88,7 +88,7 @@ impl Database {
         }
         // randomly select one account
         let account = accounts
-            .choose(&mut rand::thread_rng())
+            .choose(&mut rand::rng())
             .ok_or(DatabaseError::NotFound)?;
         Ok(account.clone())
     }

--- a/src-tauri/src/ffmpeg/playlist.rs
+++ b/src-tauri/src/ffmpeg/playlist.rs
@@ -191,6 +191,38 @@ fn parse_map_uri(rest: &str) -> Option<String> {
     })
 }
 
+pub async fn concat_playlists_to_video(
+    reporter: Option<&impl ProgressReporterTrait>,
+    playlists: &[&Path],
+    danmu_ass_files: Vec<Option<PathBuf>>,
+    output_path: &Path,
+) -> Result<(), String> {
+    let mut to_remove = Vec::new();
+    let mut segments = Vec::new();
+    for (i, playlist) in playlists.iter().enumerate() {
+        let mut video_path = output_path.with_extension(format!("{}.mp4", i));
+        if let Err(e) = clip_from_playlist(reporter, playlist, &video_path, None).await {
+            log::error!("Failed to generate playlist video: {e}");
+            continue;
+        }
+        to_remove.push(video_path.clone());
+        if let Some(danmu_ass_file) = &danmu_ass_files[i] {
+            video_path = super::encode_video_danmu(reporter, &video_path, danmu_ass_file).await?;
+            to_remove.push(video_path.clone());
+        }
+        segments.push(video_path);
+    }
+
+    super::general::concat_videos(reporter, &segments, output_path).await?;
+
+    // clean up segments
+    for segment in to_remove {
+        let _ = tokio::fs::remove_file(segment).await;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -239,36 +271,4 @@ mod tests {
         );
         assert_eq!(parse_map_uri("malformed"), None);
     }
-}
-
-pub async fn concat_playlists_to_video(
-    reporter: Option<&impl ProgressReporterTrait>,
-    playlists: &[&Path],
-    danmu_ass_files: Vec<Option<PathBuf>>,
-    output_path: &Path,
-) -> Result<(), String> {
-    let mut to_remove = Vec::new();
-    let mut segments = Vec::new();
-    for (i, playlist) in playlists.iter().enumerate() {
-        let mut video_path = output_path.with_extension(format!("{}.mp4", i));
-        if let Err(e) = clip_from_playlist(reporter, playlist, &video_path, None).await {
-            log::error!("Failed to generate playlist video: {e}");
-            continue;
-        }
-        to_remove.push(video_path.clone());
-        if let Some(danmu_ass_file) = &danmu_ass_files[i] {
-            video_path = super::encode_video_danmu(reporter, &video_path, danmu_ass_file).await?;
-            to_remove.push(video_path.clone());
-        }
-        segments.push(video_path);
-    }
-
-    super::general::concat_videos(reporter, &segments, output_path).await?;
-
-    // clean up segments
-    for segment in to_remove {
-        let _ = tokio::fs::remove_file(segment).await;
-    }
-
-    Ok(())
 }

--- a/src-tauri/src/handlers/account.rs
+++ b/src-tauri/src/handlers/account.rs
@@ -9,7 +9,7 @@ use recorder::platforms::bilibili::api::{QrInfo, QrStatus};
 use recorder::platforms::{bilibili, douyin, huya, kuaishou, tiktok, PlatformType};
 use recorder::UserInfo;
 
-use hyper::header::HeaderValue;
+use axum::http::HeaderValue;
 #[cfg(feature = "gui")]
 use tauri::State as TauriState;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -23,7 +23,6 @@ mod task;
 mod tray;
 mod webhook;
 
-use async_std::fs;
 use chrono::Utc;
 use config::Config;
 use database::Database;
@@ -44,6 +43,7 @@ use std::path::Path;
 #[cfg(feature = "gui")]
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::fs;
 use tokio::sync::RwLock;
 
 #[cfg(not(target_os = "windows"))]

--- a/src-tauri/src/subtitle_generator/whisper_cpp.rs
+++ b/src-tauri/src/subtitle_generator/whisper_cpp.rs
@@ -4,8 +4,10 @@ use crate::{
     progress::progress_reporter::ProgressReporterTrait,
     subtitle_generator::{GenerateResult, SubtitleGeneratorType},
 };
-use async_std::sync::{Arc, RwLock};
 use std::path::Path;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
 use whisper_cpp_rs::{FullParams, SamplingStrategy, WhisperContext};
 
 use super::SubtitleGenerator;


### PR DESCRIPTION
## Summary

Dependency cleanup and modernisation. No behavioural change intended.

- **Single source of truth for shared deps.** Crates now take `{ workspace = true }` instead of re-declaring versions, so one version is resolved and compiled per dep.
  Bumped in the process: `reqwest` 0.11 → 0.12, `base64` 0.21 → 0.22, `md5` 0.7 → 0.8, `pct-str` 1.2 → 2.0, `rand` 0.8 → 0.9, `m3u8-rs` 5.0 → 6.0, `toml` 0.7 → 0.9, `tower-http` 0.5 → 0.6, `async-ffmpeg-sidecar` 0.0.1 → 0.0.3.
- **Removed unused root dependencies:** `async-std`, `deno_core`, `dashmap`, `hyper` 0.14, `mime_guess`, `scraper`, `regex`, `tokio-util`, `tokio-stream`, `urlencoding`.
- **`async-std` → `tokio`:** `async_std::fs` and `async_std::sync::{Arc, RwLock}` replaced with their tokio/`std` equivalents, so the runtime is tokio-only.
- **`rand` 0.9 API migration:** `thread_rng()` → `rng()`, `SliceRandom` → `IndexedRandom`.
- **Clippy:** test modules moved to the end of their files, needless `as_bytes().len()` → `len()`.

`Cargo.lock` drops from 916 to 891 packages.

## Verification

- `cargo clippy --workspace --all-targets` — clean
- `cargo check -p bili-shadowreplay --no-default-features --features headless` — clean
- `cargo test --workspace` — 239 passed, 3 ignored, 0 failed
- pre-commit hooks (fmt / clippy / clippy headless / test / test headless) pass

## Risk

The major version bumps are the only real risk surface; all of them compile and pass tests on macOS. Windows/Linux CI will confirm the rest.

## Summary by Sourcery

Consolidate workspace dependencies, remove unused crates, and standardize the runtime on Tokio while preserving existing behavior.

Bug Fixes:
- Repair Sherpa-ONNX native-library caches during partial Rust cache hits to prevent CI linking failures.

Enhancements:
- Centralize shared Rust dependency versions in workspace configuration and update major dependency versions.
- Remove unused dependencies and migrate remaining asynchronous filesystem and synchronization usage from async-std to Tokio.
- Update code for the rand 0.9 API and apply related Clippy-driven cleanup.

Build:
- Reduce the locked dependency graph from 916 to 891 packages through dependency consolidation and removal.

CI:
- Improve lint workflow cache handling by rebuilding invalidated Sherpa-ONNX prebuilt libraries.

Tests:
- Validate the workspace with formatting, Clippy, headless checks, and the full test suite.